### PR TITLE
Axis sharing fix

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3225,7 +3225,6 @@ class Axes(maxes.Axes):
             raise ValueError(f"Invalid number {num!r}. Must be integer >=1.")
 
 
-
 # Apply signature obfuscation after storing previous signature
 # NOTE: This is needed for __init__
 Axes._format_signatures = {Axes: inspect.signature(Axes.format)}

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3224,42 +3224,6 @@ class Axes(maxes.Axes):
         else:
             raise ValueError(f"Invalid number {num!r}. Must be integer >=1.")
 
-    # Override matplotlib defaults ot handle multiple axis sharing
-    def sharex(self, other):
-        return self.share_axis(which="x", other=other)
-
-    def sharey(self, other):
-        self.share_axis(which="y", other=other)
-
-    # Internal function to share axes
-    def share_axis(self, which, other):
-        if not isinstance(other, Axes):
-            return TypeError(
-                f"Cannot share axes with {type(other).__name__}.\n"
-                f"Expected: matplotlib.axes.Axes instance\n"
-                f"Received: {type(other).__name__}\n"
-                "Please provide a valid Axes instance to share with."
-            )
-
-        self._shared_axes[which].join(self, other)
-
-        # Get axis objects
-        this_axis = getattr(self, f"{which}axis")
-        other_axis = getattr(other, f"{which}axis")
-
-        # Set minor ticker
-        this_axis.minor = other_axis.minor
-
-        # Get and set limits
-        limits = getattr(other, f"get_{which}lim")()
-        set_lim = getattr(self, f"set_{which}lim")
-        get_autoscale = getattr(other, f"get_autoscale{which}_on")
-
-        lim0, lim1 = limits
-        set_lim(lim0, lim1, emit=False, auto=get_autoscale())
-
-        # Set scale
-        this_axis._scale = other_axis._scale
 
 
 # Apply signature obfuscation after storing previous signature

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3224,6 +3224,43 @@ class Axes(maxes.Axes):
         else:
             raise ValueError(f"Invalid number {num!r}. Must be integer >=1.")
 
+    # Override matplotlib defaults ot handle multiple axis sharing
+    def sharex(self, other):
+        return self.share_axis(which="x", other=other)
+
+    def sharey(self, other):
+        self.share_axis(which="y", other=other)
+
+    # Internal function to share axes
+    def share_axis(self, which, other):
+        if not isinstance(other, Axes):
+            return TypeError(
+                f"Cannot share axes with {type(other).__name__}.\n"
+                f"Expected: matplotlib.axes.Axes instance\n"
+                f"Received: {type(other).__name__}\n"
+                "Please provide a valid Axes instance to share with."
+            )
+
+        self._shared_axes[which].join(self, other)
+
+        # Get axis objects
+        this_axis = getattr(self, f"{which}axis")
+        other_axis = getattr(other, f"{which}axis")
+
+        # Set minor ticker
+        this_axis.minor = other_axis.minor
+
+        # Get and set limits
+        limits = getattr(other, f"get_{which}lim")()
+        set_lim = getattr(self, f"set_{which}lim")
+        get_autoscale = getattr(other, f"get_autoscale{which}_on")
+
+        lim0, lim1 = limits
+        set_lim(lim0, lim1, emit=False, auto=get_autoscale())
+
+        # Set scale
+        this_axis._scale = other_axis._scale
+
 
 # Apply signature obfuscation after storing previous signature
 # NOTE: This is needed for __init__

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -576,7 +576,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             if ax1.get_autoscalex_on() and not ax2.get_autoscalex_on():
                 ax1.set_xlim(ax2.get_xlim())  # non-default limits
         # Copy non-default locators and formatters
-        self.get_shared_x_axes().joined(self, sharex)  # share limit/scale changes
+        self.sharex(sharex) # get_shared_x_axes now returns an immutable object
         if sharex.xaxis.isDefault_majloc and not self.xaxis.isDefault_majloc:
             sharex.xaxis.set_major_locator(self.xaxis.get_major_locator())
         if sharex.xaxis.isDefault_minloc and not self.xaxis.isDefault_minloc:
@@ -598,7 +598,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
                 ax1.set_yscale(ax2.get_yscale())
             if ax1.get_autoscaley_on() and not ax2.get_autoscaley_on():
                 ax1.set_ylim(ax2.get_ylim())
-        self.get_shared_y_axes().joined(self, sharey)  # share limit/scale changes
+        self.sharey(sharey) # get_shared_y_axes now returns an immutable object
         if sharey.yaxis.isDefault_majloc and not self.yaxis.isDefault_majloc:
             sharey.yaxis.set_major_locator(self.yaxis.get_major_locator())
         if sharey.yaxis.isDefault_minloc and not self.yaxis.isDefault_minloc:

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -576,7 +576,10 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             if ax1.get_autoscalex_on() and not ax2.get_autoscalex_on():
                 ax1.set_xlim(ax2.get_xlim())  # non-default limits
         # Copy non-default locators and formatters
-        self.sharex(sharex) # get_shared_x_axes now returns an immutable object
+        # self.sharex(sharex)
+        self._shared_axes["x"].join(self, sharex)
+
+        # self.get_shared_x_axes().joined(self, sharex)  # share limit/scale changes
         if sharex.xaxis.isDefault_majloc and not self.xaxis.isDefault_majloc:
             sharex.xaxis.set_major_locator(self.xaxis.get_major_locator())
         if sharex.xaxis.isDefault_minloc and not self.xaxis.isDefault_minloc:
@@ -598,7 +601,8 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
                 ax1.set_yscale(ax2.get_yscale())
             if ax1.get_autoscaley_on() and not ax2.get_autoscaley_on():
                 ax1.set_ylim(ax2.get_ylim())
-        self.sharey(sharey) # get_shared_y_axes now returns an immutable object
+        # self.sharey(sharey) # get_shared_y_axes now returns an immutable object
+        self._shared_axes["y"].join(self, sharey)
         if sharey.yaxis.isDefault_majloc and not self.yaxis.isDefault_majloc:
             sharey.yaxis.set_major_locator(self.yaxis.get_major_locator())
         if sharey.yaxis.isDefault_minloc and not self.yaxis.isDefault_minloc:

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -576,10 +576,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             if ax1.get_autoscalex_on() and not ax2.get_autoscalex_on():
                 ax1.set_xlim(ax2.get_xlim())  # non-default limits
         # Copy non-default locators and formatters
-        # self.sharex(sharex)
         self._shared_axes["x"].join(self, sharex)
-
-        # self.get_shared_x_axes().joined(self, sharex)  # share limit/scale changes
         if sharex.xaxis.isDefault_majloc and not self.xaxis.isDefault_majloc:
             sharex.xaxis.set_major_locator(self.xaxis.get_major_locator())
         if sharex.xaxis.isDefault_minloc and not self.xaxis.isDefault_minloc:
@@ -601,7 +598,6 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
                 ax1.set_yscale(ax2.get_yscale())
             if ax1.get_autoscaley_on() and not ax2.get_autoscaley_on():
                 ax1.set_ylim(ax2.get_ylim())
-        # self.sharey(sharey) # get_shared_y_axes now returns an immutable object
         self._shared_axes["y"].join(self, sharey)
         if sharey.yaxis.isDefault_majloc and not self.yaxis.isDefault_majloc:
             sharey.yaxis.set_major_locator(self.yaxis.get_major_locator())

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -563,6 +563,17 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             and other._panel_parent is self._panel_parent  # other is sibling panel
         )
 
+    def _safe_share(self, axis_name, other_axis):
+        if hasattr(self, f"_share{axis_name}"):
+            setattr(self, f"_share{axis_name}", None)
+        getattr(self, f"share{axis_name}")(other_axis)
+
+    def share_axis(self, which, other):
+        if not isinstance(other, plot.PlotAxes):
+            raise ValueError("other must be an Axes instance")
+        shared = getattr(self, f"get_shared_{which}_axes")()
+        self._shared_axes[which].join(self, other)
+
     def _sharex_limits(self, sharex):
         """
         Safely share limits and tickers without resetting things.
@@ -576,7 +587,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             if ax1.get_autoscalex_on() and not ax2.get_autoscalex_on():
                 ax1.set_xlim(ax2.get_xlim())  # non-default limits
         # Copy non-default locators and formatters
-        self._shared_axes["x"].join(self, sharex)
+        self.sharex(sharex)
         if sharex.xaxis.isDefault_majloc and not self.xaxis.isDefault_majloc:
             sharex.xaxis.set_major_locator(self.xaxis.get_major_locator())
         if sharex.xaxis.isDefault_minloc and not self.xaxis.isDefault_minloc:
@@ -598,7 +609,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
                 ax1.set_yscale(ax2.get_yscale())
             if ax1.get_autoscaley_on() and not ax2.get_autoscaley_on():
                 ax1.set_ylim(ax2.get_ylim())
-        self._shared_axes["y"].join(self, sharey)
+        self.sharey(sharey)
         if sharey.yaxis.isDefault_majloc and not self.yaxis.isDefault_majloc:
             sharey.yaxis.set_major_locator(self.yaxis.get_major_locator())
         if sharey.yaxis.isDefault_minloc and not self.yaxis.isDefault_minloc:

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -563,7 +563,6 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             and other._panel_parent is self._panel_parent  # other is sibling panel
         )
 
-
     def _sharex_limits(self, sharex):
         """
         Safely share limits and tickers without resetting things.

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -563,11 +563,6 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             and other._panel_parent is self._panel_parent  # other is sibling panel
         )
 
-    def _safe_share(self, axis_name, other_axis):
-        if hasattr(self, f"_share{axis_name}"):
-            setattr(self, f"_share{axis_name}", None)
-        getattr(self, f"share{axis_name}")(other_axis)
-
     def share_axis(self, which, other):
         if not isinstance(other, plot.PlotAxes):
             raise ValueError("other must be an Axes instance")

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -563,11 +563,6 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             and other._panel_parent is self._panel_parent  # other is sibling panel
         )
 
-    def share_axis(self, which, other):
-        if not isinstance(other, plot.PlotAxes):
-            raise ValueError("other must be an Axes instance")
-        shared = getattr(self, f"get_shared_{which}_axes")()
-        self._shared_axes[which].join(self, other)
 
     def _sharex_limits(self, sharex):
         """

--- a/ultraplot/axes/shared.py
+++ b/ultraplot/axes/shared.py
@@ -185,7 +185,7 @@ class _SharedAxes(object):
             for lab in obj.get_ticklabels():
                 lab.update(kwtext_extra)
 
-    # Override matplotlib defaults ot handle multiple axis sharing
+    # Override matplotlib defaults to handle multiple axis sharing
     def sharex(self, other):
         return self.share_axis(which="x", other=other)
 

--- a/ultraplot/axes/shared.py
+++ b/ultraplot/axes/shared.py
@@ -197,7 +197,7 @@ class _SharedAxes(object):
         if not isinstance(other, Axes):
             return TypeError(
                 f"Cannot share axes with {type(other).__name__}.\n"
-                f"Expected: matplotlib.axes.Axes instance\n"
+                f"Expected: ultraplot.base.Axes instance\n"
                 f"Received: {type(other).__name__}\n"
                 "Please provide a valid Axes instance to share with."
             )

--- a/ultraplot/axes/shared.py
+++ b/ultraplot/axes/shared.py
@@ -188,10 +188,10 @@ class _SharedAxes(object):
 
     # Override matplotlib defaults to handle multiple axis sharing
     def sharex(self, other):
-        return self.share_axis(which="x", other=other)
+        return self._share_axis(which="x", other=other)
 
     def sharey(self, other):
-        self.share_axis(which="y", other=other)
+        self._share_axis(which="y", other=other)
 
     # Ultraplot internal function to share axes
     def _share_axis(self, which, other):

--- a/ultraplot/axes/shared.py
+++ b/ultraplot/axes/shared.py
@@ -10,6 +10,7 @@ from ..config import rc
 from ..internals import ic  # noqa: F401
 from ..internals import _pop_kwargs
 from ..utils import _fontsize_to_pt, _not_none, units
+from ..axes import Axes
 
 
 class _SharedAxes(object):
@@ -192,8 +193,8 @@ class _SharedAxes(object):
     def sharey(self, other):
         self.share_axis(which="y", other=other)
 
-    # Internal function to share axes
-    def share_axis(self, which, other):
+    # Ultraplot internal function to share axes
+    def _share_axis(self, which, other):
         if not isinstance(other, Axes):
             return TypeError(
                 f"Cannot share axes with {type(other).__name__}.\n"

--- a/ultraplot/axes/shared.py
+++ b/ultraplot/axes/shared.py
@@ -185,7 +185,6 @@ class _SharedAxes(object):
             for lab in obj.get_ticklabels():
                 lab.update(kwtext_extra)
 
-
     # Override matplotlib defaults ot handle multiple axis sharing
     def sharex(self, other):
         return self.share_axis(which="x", other=other)

--- a/ultraplot/axes/shared.py
+++ b/ultraplot/axes/shared.py
@@ -184,3 +184,41 @@ class _SharedAxes(object):
         if kwtext_extra:
             for lab in obj.get_ticklabels():
                 lab.update(kwtext_extra)
+
+
+    # Override matplotlib defaults ot handle multiple axis sharing
+    def sharex(self, other):
+        return self.share_axis(which="x", other=other)
+
+    def sharey(self, other):
+        self.share_axis(which="y", other=other)
+
+    # Internal function to share axes
+    def share_axis(self, which, other):
+        if not isinstance(other, Axes):
+            return TypeError(
+                f"Cannot share axes with {type(other).__name__}.\n"
+                f"Expected: matplotlib.axes.Axes instance\n"
+                f"Received: {type(other).__name__}\n"
+                "Please provide a valid Axes instance to share with."
+            )
+
+        self._shared_axes[which].join(self, other)
+
+        # Get axis objects
+        this_axis = getattr(self, f"{which}axis")
+        other_axis = getattr(other, f"{which}axis")
+
+        # Set minor ticker
+        this_axis.minor = other_axis.minor
+
+        # Get and set limits
+        limits = getattr(other, f"get_{which}lim")()
+        set_lim = getattr(self, f"set_{which}lim")
+        get_autoscale = getattr(other, f"get_autoscale{which}_on")
+
+        lim0, lim1 = limits
+        set_lim(lim0, lim1, emit=False, auto=get_autoscale())
+
+        # Set scale
+        this_axis._scale = other_axis._scale

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -379,7 +379,6 @@ from matplotlib import tri
 
 
 @pytest.mark.mpl_image_compare
-@pytest.mark.mpl_image_compare
 @pytest.mark.parametrize(
     "x, y, z, triangles, use_triangulation, use_datadict",
     [
@@ -426,4 +425,33 @@ def test_triplot_variants(x, y, z, triangles, use_triangulation, use_datadict):
         else:
             ax.triplot(x, y, "ko-")  # Without specific triangles
 
+    return fig
+
+@pytest.mark.mpl_image_compare
+@pytest.mark.parametrize("share", ["limits", "labels"])
+def test_axis_sharing(share):
+    fig, ax = uplt.subplots(ncols = 2, nrows = 2, share = share)
+    labels = ["A", "B", "C", "D"]
+    for idx, axi  in enumerate(ax):
+        axi.scatter(idx, idx)
+        axi.set_xlabel(labels[idx])
+        axi.set_ylabel(labels[idx])
+
+    # TODO: the labels are handled in a funky way. The plot looks fine but the label are not "shared" that is the labels still exist but they are not visible and instead there are new labels created. Need to figure this out
+    # test left hand side
+    if share != "labels":
+        assert all([i == j for i, j in zip(ax[0].get_xlim(), ax[2].get_xlim())])
+        assert all([i == j for i, j in zip(ax[0].get_ylim(), ax[1].get_ylim())])
+        assert all([i == j for i, j in zip(ax[1].get_xlim(), ax[3].get_xlim())])
+    #elif share == "labels":
+    #    print("--" * 32)
+    #    print(repr(ax.get_xlabel()))
+    #    print(repr(ax.get_ylabel()))
+    #    print("--" * 32)
+    #    # columns shares x label
+    #    assert ax[0].get_xlabel() == ax[2].get_xlabel().strip()
+    #    assert ax[1].get_xlabel() == ax[3].get_xlabel().strip()
+    #    # rows share ylabel
+    #    assert ax[0].get_ylabel() == ax[1].get_ylabel().strip()
+    #    assert ax[2].get_ylabel().strip() == ax[3].get_ylabel().strip()
     return fig

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -426,32 +426,3 @@ def test_triplot_variants(x, y, z, triangles, use_triangulation, use_datadict):
             ax.triplot(x, y, "ko-")  # Without specific triangles
 
     return fig
-
-@pytest.mark.mpl_image_compare
-@pytest.mark.parametrize("share", ["limits", "labels"])
-def test_axis_sharing(share):
-    fig, ax = uplt.subplots(ncols = 2, nrows = 2, share = share)
-    labels = ["A", "B", "C", "D"]
-    for idx, axi  in enumerate(ax):
-        axi.scatter(idx, idx)
-        axi.set_xlabel(labels[idx])
-        axi.set_ylabel(labels[idx])
-
-    # TODO: the labels are handled in a funky way. The plot looks fine but the label are not "shared" that is the labels still exist but they are not visible and instead there are new labels created. Need to figure this out
-    # test left hand side
-    if share != "labels":
-        assert all([i == j for i, j in zip(ax[0].get_xlim(), ax[2].get_xlim())])
-        assert all([i == j for i, j in zip(ax[0].get_ylim(), ax[1].get_ylim())])
-        assert all([i == j for i, j in zip(ax[1].get_xlim(), ax[3].get_xlim())])
-    #elif share == "labels":
-    #    print("--" * 32)
-    #    print(repr(ax.get_xlabel()))
-    #    print(repr(ax.get_ylabel()))
-    #    print("--" * 32)
-    #    # columns shares x label
-    #    assert ax[0].get_xlabel() == ax[2].get_xlabel().strip()
-    #    assert ax[1].get_xlabel() == ax[3].get_xlabel().strip()
-    #    # rows share ylabel
-    #    assert ax[0].get_ylabel() == ax[1].get_ylabel().strip()
-    #    assert ax[2].get_ylabel().strip() == ax[3].get_ylabel().strip()
-    return fig

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -172,3 +172,33 @@ def test_reference_aspect():
     fig.auto_layout()
     assert np.isclose(refwidth, axs[fig._refnum - 1]._get_size_inches()[0])
     return fig
+
+
+@pytest.mark.mpl_image_compare
+@pytest.mark.parametrize("share", ["limits", "labels"])
+def test_axis_sharing(share):
+    fig, ax = uplt.subplots(ncols=2, nrows=2, share=share)
+    labels = ["A", "B", "C", "D"]
+    for idx, axi in enumerate(ax):
+        axi.scatter(idx, idx)
+        axi.set_xlabel(labels[idx])
+        axi.set_ylabel(labels[idx])
+
+    # TODO: the labels are handled in a funky way. The plot looks fine but the label are not "shared" that is the labels still exist but they are not visible and instead there are new labels created. Need to figure this out.
+    # test left hand side
+    if share != "labels":
+        assert all([i == j for i, j in zip(ax[0].get_xlim(), ax[2].get_xlim())])
+        assert all([i == j for i, j in zip(ax[0].get_ylim(), ax[1].get_ylim())])
+        assert all([i == j for i, j in zip(ax[1].get_xlim(), ax[3].get_xlim())])
+    # elif share == "labels":
+    #    print("--" * 32)
+    #    print(repr(ax.get_xlabel()))
+    #    print(repr(ax.get_ylabel()))
+    #    print("--" * 32)
+    #    # columns shares x label
+    #    assert ax[0].get_xlabel() == ax[2].get_xlabel().strip()
+    #    assert ax[1].get_xlabel() == ax[3].get_xlabel().strip()
+    #    # rows share ylabel
+    #    assert ax[0].get_ylabel() == ax[1].get_ylabel().strip()
+    #    assert ax[2].get_ylabel().strip() == ax[3].get_ylabel().strip()
+    return fig

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -177,7 +177,7 @@ def test_reference_aspect():
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("share", ["limits", "labels"])
 def test_axis_sharing(share):
-    fig, ax = uplt.subplots(ncols=2, nrows=2, share=share, span = False)
+    fig, ax = uplt.subplots(ncols=2, nrows=2, share=share, span=False)
     labels = ["A", "B", "C", "D"]
     for idx, axi in enumerate(ax):
         axi.scatter(idx, idx)
@@ -191,23 +191,25 @@ def test_axis_sharing(share):
         assert all([i == j for i, j in zip(ax[0].get_ylim(), ax[1].get_ylim())])
         assert all([i == j for i, j in zip(ax[1].get_xlim(), ax[3].get_xlim())])
     elif share == "labels":
-       ax.draw(fig.canvas.get_renderer()) # forcing a draw to ensure the labels are shared
-       # columns shares x label; top row should be empty
-       assert ax[0].xaxis.get_label().get_visible() == False
-       assert ax[1].xaxis.get_label().get_visible() == False
+        ax.draw(
+            fig.canvas.get_renderer()
+        )  # forcing a draw to ensure the labels are shared
+        # columns shares x label; top row should be empty
+        assert ax[0].xaxis.get_label().get_visible() == False
+        assert ax[1].xaxis.get_label().get_visible() == False
 
-       assert ax[2].xaxis.get_label().get_visible() == True
-       assert ax[2].get_xlabel() == 'A'
-       assert ax[3].xaxis.get_label().get_visible() == True
-       assert ax[3].get_xlabel() == 'B'
+        assert ax[2].xaxis.get_label().get_visible() == True
+        assert ax[2].get_xlabel() == "A"
+        assert ax[3].xaxis.get_label().get_visible() == True
+        assert ax[3].get_xlabel() == "B"
 
-       # rows share ylabel
-       assert ax[3].yaxis.get_label().get_visible() == False
-       assert ax[1].yaxis.get_label().get_visible() == False
+        # rows share ylabel
+        assert ax[3].yaxis.get_label().get_visible() == False
+        assert ax[1].yaxis.get_label().get_visible() == False
 
-       assert ax[0].yaxis.get_label().get_visible() == True
-       assert ax[2].yaxis.get_label().get_visible() == True
-       assert ax[0].get_ylabel() == 'B'
-       assert ax[2].get_ylabel() == 'D'
+        assert ax[0].yaxis.get_label().get_visible() == True
+        assert ax[2].yaxis.get_label().get_visible() == True
+        assert ax[0].get_ylabel() == "B"
+        assert ax[2].get_ylabel() == "D"
 
     return fig

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -184,7 +184,10 @@ def test_axis_sharing(share):
         axi.set_xlabel(labels[idx])
         axi.set_ylabel(labels[idx])
 
-    # TODO: the labels are handled in a funky way. The plot looks fine but the label are not "shared" that is the labels still exist but they are not visible and instead there are new labels created. Need to figure this out.
+    # TODO: the labels are handled in a funky way. The plot looks fine but
+    # the label are not "shared" that is the labels still exist but they
+    # are not visible and instead there are new labels created. Need to
+    # figure this out.
     # test left hand side
     if share != "labels":
         assert all([i == j for i, j in zip(ax[0].get_xlim(), ax[2].get_xlim())])

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -177,7 +177,7 @@ def test_reference_aspect():
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("share", ["limits", "labels"])
 def test_axis_sharing(share):
-    fig, ax = uplt.subplots(ncols=2, nrows=2, share=share)
+    fig, ax = uplt.subplots(ncols=2, nrows=2, share=share, span = False)
     labels = ["A", "B", "C", "D"]
     for idx, axi in enumerate(ax):
         axi.scatter(idx, idx)
@@ -190,15 +190,24 @@ def test_axis_sharing(share):
         assert all([i == j for i, j in zip(ax[0].get_xlim(), ax[2].get_xlim())])
         assert all([i == j for i, j in zip(ax[0].get_ylim(), ax[1].get_ylim())])
         assert all([i == j for i, j in zip(ax[1].get_xlim(), ax[3].get_xlim())])
-    # elif share == "labels":
-    #    print("--" * 32)
-    #    print(repr(ax.get_xlabel()))
-    #    print(repr(ax.get_ylabel()))
-    #    print("--" * 32)
-    #    # columns shares x label
-    #    assert ax[0].get_xlabel() == ax[2].get_xlabel().strip()
-    #    assert ax[1].get_xlabel() == ax[3].get_xlabel().strip()
-    #    # rows share ylabel
-    #    assert ax[0].get_ylabel() == ax[1].get_ylabel().strip()
-    #    assert ax[2].get_ylabel().strip() == ax[3].get_ylabel().strip()
+    elif share == "labels":
+       ax.draw(fig.canvas.get_renderer()) # forcing a draw to ensure the labels are shared
+       # columns shares x label; top row should be empty
+       assert ax[0].xaxis.get_label().get_visible() == False
+       assert ax[1].xaxis.get_label().get_visible() == False
+
+       assert ax[2].xaxis.get_label().get_visible() == True
+       assert ax[2].get_xlabel() == 'A'
+       assert ax[3].xaxis.get_label().get_visible() == True
+       assert ax[3].get_xlabel() == 'B'
+
+       # rows share ylabel
+       assert ax[3].yaxis.get_label().get_visible() == False
+       assert ax[1].yaxis.get_label().get_visible() == False
+
+       assert ax[0].yaxis.get_label().get_visible() == True
+       assert ax[2].yaxis.get_label().get_visible() == True
+       assert ax[0].get_ylabel() == 'B'
+       assert ax[2].get_ylabel() == 'D'
+
     return fig


### PR DESCRIPTION
Addresses https://github.com/Ultraplot/ultraplot/issues/11#issuecomment-2590028154

The MPL api changed in v3.6 where get_[x/y]_shared_axes returns an immutable object.

- [x] check remaining code base for use of this object
- [x] write unittests
   - [x]  to test for sharing limits
   - [x] to test for sharing labels (only)