### PR TITLE
Update compatibility for Inset Indicator

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2881,35 +2881,68 @@ class Axes(maxes.Axes):
         """
         %(axes.indicate_inset)s
         """
+        import matplotlib as mpl
+        from packaging import version
+
         # Add the inset indicators
         parent = self._inset_parent
         if not parent:
             raise ValueError("This command can only be called from an inset axes.")
+
         kwargs.update(_pop_props(kwargs, "patch"))  # impose alternative defaults
+
         if not self._inset_zoom_artists:
             kwargs.setdefault("zorder", 3.5)
             kwargs.setdefault("linewidth", rc["axes.linewidth"])
             kwargs.setdefault("edgecolor", rc["axes.edgecolor"])
-        xlim, ylim = self.get_xlim(), self.get_ylim()
-        rect = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
-        rectpatch, connects = parent.indicate_inset(rect, self)
 
-        # Update indicator properties
-        # NOTE: Unlike matplotlib we sync zoom box properties with connection lines.
-        if self._inset_zoom_artists:
-            rectpatch_prev, connects_prev = self._inset_zoom_artists
-            rectpatch.update_from(rectpatch_prev)
-            rectpatch.set_zorder(rectpatch_prev.get_zorder())
-            rectpatch_prev.remove()
-            for line, line_prev in zip(connects, connects_prev):
-                line.update_from(line_prev)
-                line.set_zorder(line_prev.get_zorder())  # not included in update_from
-                line_prev.remove()
-        rectpatch.update(kwargs)
-        for line in connects:
-            line.update(kwargs)
-        self._inset_zoom_artists = (rectpatch, connects)
-        return rectpatch, connects
+        xlim, ylim = self.get_xlim(), self.get_ylim()
+        bounds = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
+
+        if version.parse(mpl.__version__) >= version.parse('3.10'):
+            # Implementation for matplotlib >= 3.10
+            self.apply_aspect()
+            kwargs.setdefault('label', '_indicate_inset')
+            if kwargs.get("transform") is None:
+                kwargs["transform"] = self.transData
+
+            from matplotlib.inset import InsetIndicator
+            indicator = InsetIndicator(bounds=bounds, inset_ax=self, facecolor='none', **kwargs)
+
+            if self._inset_zoom_artists:
+                indicator = self._inset_zoom_artists
+                indicator.update(kwargs)
+                indicator.rectangle.update(kwargs)
+                [c.update(kwargs) for c in indicator.connectors]
+            else:
+                self._inset_zoom_artists = indicator
+                self.add_artist(indicator)
+
+            return (indicator.rectangle, indicator.connectors)
+
+        else:
+            # Implementation for matplotlib < 3.10
+            rectpatch, connects = parent.indicate_inset(bounds, self)
+
+            # Update indicator properties
+            if self._inset_zoom_artists:
+                rectpatch_prev, connects_prev = self._inset_zoom_artists
+                rectpatch.update_from(rectpatch_prev)
+                rectpatch.set_zorder(rectpatch_prev.get_zorder())
+                rectpatch_prev.remove()
+                for line, line_prev in zip(connects, connects_prev):
+                    line.update_from(line_prev)
+                    line.set_zorder(line_prev.get_zorder())  # not included in update_from
+                    line_prev.remove()
+
+            rectpatch.update(kwargs)
+            for line in connects:
+                line.update(kwargs)
+
+            self._inset_zoom_artists = (rectpatch, connects)
+            return rectpatch, connects
+
+
 
     @docstring._snippet_manager
     def panel(self, side=None, **kwargs):

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2899,15 +2899,18 @@ class Axes(maxes.Axes):
         xlim, ylim = self.get_xlim(), self.get_ylim()
         bounds = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
 
-        if version.parse(mpl.__version__) >= version.parse('3.10'):
+        if version.parse(mpl.__version__) >= version.parse("3.10"):
             # Implementation for matplotlib >= 3.10
             self.apply_aspect()
-            kwargs.setdefault('label', '_indicate_inset')
+            kwargs.setdefault("label", "_indicate_inset")
             if kwargs.get("transform") is None:
                 kwargs["transform"] = self.transData
 
             from matplotlib.inset import InsetIndicator
-            indicator = InsetIndicator(bounds=bounds, inset_ax=self, facecolor='none', **kwargs)
+
+            indicator = InsetIndicator(
+                bounds=bounds, inset_ax=self, facecolor="none", **kwargs
+            )
 
             if self._inset_zoom_artists:
                 indicator = self._inset_zoom_artists
@@ -2932,7 +2935,9 @@ class Axes(maxes.Axes):
                 rectpatch_prev.remove()
                 for line, line_prev in zip(connects, connects_prev):
                     line.update_from(line_prev)
-                    line.set_zorder(line_prev.get_zorder())  # not included in update_from
+                    line.set_zorder(
+                        line_prev.get_zorder()
+                    )  # not included in update_from
                     line_prev.remove()
 
             rectpatch.update(kwargs)
@@ -2941,8 +2946,6 @@ class Axes(maxes.Axes):
 
             self._inset_zoom_artists = (rectpatch, connects)
             return rectpatch, connects
-
-
 
     @docstring._snippet_manager
     def panel(self, side=None, **kwargs):

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2491,10 +2491,6 @@ class PlotAxes(base.Axes):
         # Ignore cycle for single-column plotting
         resolved_cycle = None if ncycle == 1 else resolved_cycle
 
-        # Return or apply cycle
-        if return_cycle:
-            return resolved_cycle, kwargs
-
         if resolved_cycle and resolved_cycle != self._active_cycle:
             self.set_prop_cycle(resolved_cycle)
 
@@ -2506,7 +2502,9 @@ class PlotAxes(base.Axes):
                 if kwargs.get(key) is None and prop in current_prop:
                     value = current_prop[prop]
                     kwargs[key] = pcolors.to_rgba(value) if key == "c" else value
-
+       # Return or apply cycle
+        if return_cycle:
+            return resolved_cycle, kwargs
         return kwargs
 
     def _parse_level_lim(

--- a/ultraplot/constructor.py
+++ b/ultraplot/constructor.py
@@ -852,7 +852,6 @@ markeredgecolors, markerfacecolors
     """
 
     def __init__(self, *args, N=None, samples=None, name=None, **kwargs):
-        self.name = "_no_name"  # default value
         cycler_props = self._parse_basic_properties(kwargs)
         samples = _not_none(samples=samples, N=N)  # trigger Colormap default
         if not args:
@@ -863,6 +862,7 @@ markeredgecolors, markerfacecolors
             self._handle_colormap_args(args, cycler_props, kwargs, samples, name)
 
         self._iterator = None  # internal reference for cycle
+        self.name = _not_none(name, "_no_name")
 
     def _parse_basic_properties(self, kwargs):
         """Parse and validate basic properties from kwargs."""


### PR DESCRIPTION
Fixes #27 

# Explanation
Matplotlib 3.10 introduced a new class for indicating inset. This classes effectively holds rectangles and connection patches. I streamlined the api to merely modify the existing class while remaining backwards compatibility.