### PR TITLE
Compatiblity update for mpl 3.10

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2914,7 +2914,6 @@ class Axes(maxes.Axes):
 
             from matplotlib.inset import InsetIndicator
 
-            kwargs.setdefault("facecolor", "none")
             indicator = InsetIndicator(
                 bounds=bounds, inset_ax=self, **kwargs)
 

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2914,10 +2914,9 @@ class Axes(maxes.Axes):
 
             from matplotlib.inset import InsetIndicator
 
-            # NOTE: Explicitly set facecolor here to none, as it seems to be ignore -- not sure why as it is the default
+            kwargs.setdefault("facecolor", "none")
             indicator = InsetIndicator(
-                bounds=bounds, inset_ax=self, facecolor="none", **kwargs
-            )
+                bounds=bounds, inset_ax=self, **kwargs)
 
             if self._inset_zoom_artists:
                 indicator = self._inset_zoom_artists

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2904,9 +2904,9 @@ class Axes(maxes.Axes):
             # TODO: Remove this block when support for matplotlib < 3.10 is dropped
             if version.parse(mpl.__version__) >= version.parse("3.12"):
                 warnings._warn_ultraplot(
-                "Support for matplotlib < 3.10 will be removed in a future version. "
-                "Please upgrade to matplotlib >= 3.10.",
-            )
+                    "Support for matplotlib < 3.10 will be removed in a future version. "
+                    "Please upgrade to matplotlib >= 3.10.",
+                )
             self.apply_aspect()
             kwargs.setdefault("label", "_indicate_inset")
             if kwargs.get("transform") is None:
@@ -2914,8 +2914,7 @@ class Axes(maxes.Axes):
 
             from matplotlib.inset import InsetIndicator
 
-            indicator = InsetIndicator(
-                bounds=bounds, inset_ax=self, **kwargs)
+            indicator = InsetIndicator(bounds=bounds, inset_ax=self, **kwargs)
 
             if self._inset_zoom_artists:
                 indicator = self._inset_zoom_artists

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2881,35 +2881,71 @@ class Axes(maxes.Axes):
         """
         %(axes.indicate_inset)s
         """
+        import matplotlib as mpl
+        from packaging import version
+
         # Add the inset indicators
         parent = self._inset_parent
         if not parent:
             raise ValueError("This command can only be called from an inset axes.")
+
         kwargs.update(_pop_props(kwargs, "patch"))  # impose alternative defaults
+
         if not self._inset_zoom_artists:
             kwargs.setdefault("zorder", 3.5)
             kwargs.setdefault("linewidth", rc["axes.linewidth"])
             kwargs.setdefault("edgecolor", rc["axes.edgecolor"])
-        xlim, ylim = self.get_xlim(), self.get_ylim()
-        rect = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
-        rectpatch, connects = parent.indicate_inset(rect, self)
 
-        # Update indicator properties
-        # NOTE: Unlike matplotlib we sync zoom box properties with connection lines.
-        if self._inset_zoom_artists:
-            rectpatch_prev, connects_prev = self._inset_zoom_artists
-            rectpatch.update_from(rectpatch_prev)
-            rectpatch.set_zorder(rectpatch_prev.get_zorder())
-            rectpatch_prev.remove()
-            for line, line_prev in zip(connects, connects_prev):
-                line.update_from(line_prev)
-                line.set_zorder(line_prev.get_zorder())  # not included in update_from
-                line_prev.remove()
-        rectpatch.update(kwargs)
-        for line in connects:
-            line.update(kwargs)
-        self._inset_zoom_artists = (rectpatch, connects)
-        return rectpatch, connects
+        xlim, ylim = self.get_xlim(), self.get_ylim()
+        bounds = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
+
+        if version.parse(mpl.__version__) >= version.parse("3.10"):
+            # Implementation for matplotlib >= 3.10
+            self.apply_aspect()
+            kwargs.setdefault("label", "_indicate_inset")
+            if kwargs.get("transform") is None:
+                kwargs["transform"] = self.transData
+
+            from matplotlib.inset import InsetIndicator
+
+            indicator = InsetIndicator(
+                bounds=bounds, inset_ax=self, facecolor="none", **kwargs
+            )
+
+            if self._inset_zoom_artists:
+                indicator = self._inset_zoom_artists
+                indicator.update(kwargs)
+                indicator.rectangle.update(kwargs)
+                [c.update(kwargs) for c in indicator.connectors]
+            else:
+                self._inset_zoom_artists = indicator
+                self.add_artist(indicator)
+
+            return (indicator.rectangle, indicator.connectors)
+
+        else:
+            # Implementation for matplotlib < 3.10
+            rectpatch, connects = parent.indicate_inset(bounds, self)
+
+            # Update indicator properties
+            if self._inset_zoom_artists:
+                rectpatch_prev, connects_prev = self._inset_zoom_artists
+                rectpatch.update_from(rectpatch_prev)
+                rectpatch.set_zorder(rectpatch_prev.get_zorder())
+                rectpatch_prev.remove()
+                for line, line_prev in zip(connects, connects_prev):
+                    line.update_from(line_prev)
+                    line.set_zorder(
+                        line_prev.get_zorder()
+                    )  # not included in update_from
+                    line_prev.remove()
+
+            rectpatch.update(kwargs)
+            for line in connects:
+                line.update(kwargs)
+
+            self._inset_zoom_artists = (rectpatch, connects)
+            return rectpatch, connects
 
     @docstring._snippet_manager
     def panel(self, side=None, **kwargs):

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2914,6 +2914,7 @@ class Axes(maxes.Axes):
 
             from matplotlib.inset import InsetIndicator
 
+            # NOTE: Explicitly set facecolor here to none, as it seems to be ignore -- not sure why as it is the default
             indicator = InsetIndicator(
                 bounds=bounds, inset_ax=self, facecolor="none", **kwargs
             )

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2901,12 +2901,7 @@ class Axes(maxes.Axes):
 
         if version.parse(mpl.__version__) >= version.parse("3.10"):
             # Implementation for matplotlib >= 3.10
-            # TODO: Remove this block when support for matplotlib < 3.10 is dropped
-            if version.parse(mpl.__version__) >= version.parse("3.12"):
-                warnings._warn_ultraplot(
-                    "Support for matplotlib < 3.10 will be removed in a future version. "
-                    "Please upgrade to matplotlib >= 3.10.",
-                )
+            # NOTE: if the api changes we need to deprecate the old one. At the time of writing the IndicateInset is experimental and may change in the future. This would require us to change potentially the return signature of this function.
             self.apply_aspect()
             kwargs.setdefault("label", "_indicate_inset")
             if kwargs.get("transform") is None:

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2901,6 +2901,12 @@ class Axes(maxes.Axes):
 
         if version.parse(mpl.__version__) >= version.parse("3.10"):
             # Implementation for matplotlib >= 3.10
+            # TODO: Remove this block when support for matplotlib < 3.10 is dropped
+            if version.parse(mpl.__version__) >= version.parse("3.12"):
+                warnings._warn_ultraplot(
+                "Support for matplotlib < 3.10 will be removed in a future version. "
+                "Please upgrade to matplotlib >= 3.10.",
+            )
             self.apply_aspect()
             kwargs.setdefault("label", "_indicate_inset")
             if kwargs.get("transform") is None:


### PR DESCRIPTION
Addresses #27

# Reason
Updates `indicate_inset_zoom` to support matplotlib 3.10+ while maintaining backwards compatibility.

## Changes
- Adds version-specific implementation for matplotlib ≥3.10 using the new `InsetIndicator` class
- Maintains existing implementation for matplotlib <3.10 using rectangle and patches
- Both implementations share the same interface and return format

## Technical Details
- For mpl ≥3.10: Uses `InsetIndicator` class which manages both rectangle and connectors in a single object
- For mpl <3.10: Continues to use separate rectangle patch and connector lines
- Implements version checking to automatically select the appropriate implementation