### PR TITLE
prod: add dependabot to update github action workflow versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
This PR adds github's dependabot to update the versions of actions used in the github actions CI workflows. It will make a PR on the repo once a month to update things.