### PR TITLE
Fix margin

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -1870,6 +1870,7 @@ class Figure(mfigure.Figure):
         # do not want to overwrite the matplotlib docstring.
         if isinstance(filename, str):
             filename = os.path.expanduser(filename)
+        # NOTE: this draw ensures that we are applying ultraplots layout adjustment. It is unclear what changed with ultraplot's history that makes this necessary, but it seems to cause no issues. Future devs, if unnecessary remove this line and test.
         self.canvas.draw()
         super().savefig(filename, **kwargs)
 

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -1870,6 +1870,7 @@ class Figure(mfigure.Figure):
         # do not want to overwrite the matplotlib docstring.
         if isinstance(filename, str):
             filename = os.path.expanduser(filename)
+        self.canvas.draw()
         super().savefig(filename, **kwargs)
 
     @docstring._concatenate_inherited


### PR DESCRIPTION
Addresses #43. An issue popped up where the margins are widened when saving a figure without showing the figure first. This can be remedied by forcing a draw prior to calling mpl's `savefig` but feels a bit hacky. Not sure how to do this more cleanly.