### PR TITLE
Add baseline comparison to workflow

### DIFF
--- a/.github/workflows/build-ultraplot.yml
+++ b/.github/workflows/build-ultraplot.yml
@@ -35,27 +35,41 @@ jobs:
           micromamba activate ultraplot-dev
           pytest
 
-      # Skip pytest-mpl for now as it removes the RC file
-      # Future should include it though! See https://github.com/matplotlib/pytest-mpl/issues/236
-      # - name: Generate baseline from main
-      #   shell: bash -el {0}
-      #   run: |
-      #     mkdir -p baseline
-      #     micromamba activate ultraplot-dev
-      #     git fetch origin ${{ github.event.pull_request.base.sha }}
-      #     git checkout ${{ github.event.pull_request.base.sha }}
-      #     pytest --mpl-generate-path=baseline_images
-      #     git checkout ${{ github.sha }}  # Return to PR branch
-      # - name: Image Comparison Ultraplot
-      #   shell: bash -el {0}
-      #   run: |
-      #     micromamba activate ultraplot-dev
-      #     pytest --mpl --mpl-baseline-path=baseline_images
+  compare-baseline:
+    needs: build-ultraplot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mamba-org/setup-micromamba@v2.0.4
+        with:
+          environment-file: ./environment.yml
+          init-shell: bash
+          create-args: >-
+            --verbose
+            python=${{ inputs.python-version }}
+          cache-environment: true
+          cache-downloads: false
 
-      # # return the images that failed
-      # - name: Upload comparison failures
-      #   if: failure()
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: failed-comparisons
-      #     path: result_images
+      - name: Generate baseline from main
+        shell: bash -el {0}
+        run: |
+          mkdir -p baseline
+          micromamba activate ultraplot-dev
+          git fetch origin ${{ github.event.pull_request.base.sha }}
+          git checkout ${{ github.event.pull_request.base.sha }}
+          pytest --mpl-generate-path=baseline_images
+          git checkout ${{ github.sha }}  # Return to PR branch
+
+      - name: Image Comparison Ultraplot
+        shell: bash -el {0}
+        run: |
+          micromamba activate ultraplot-dev
+          pytest --mpl-generate-path=baseline_images --mpl-default-style $(python -c "import ultraplot as plt; print(plt.config.Configurator())")
+
+      # return the images that failed
+      - name: Upload comparison failures
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-comparisons
+          path: result_images

--- a/ultraplot/ticker.py
+++ b/ultraplot/ticker.py
@@ -241,9 +241,15 @@ class DiscreteLocator(mticker.Locator):
                     step = step // i
                     break
         diff = np.abs(np.diff(locs[: step + 1 : step]))
-        (offset,) = np.where(np.isclose(locs % diff if diff.size else 0.0, 0.0))
-        offset = offset[0] if offset.size else np.argmin(np.abs(locs))
-        return locs[offset % step :: step]  # even multiples from zero or zero-close
+
+        if diff.size:
+            matches = np.where(np.isclose(locs % diff, 0.0))[0]
+            offset = matches[0] if len(matches) else np.argmin(np.abs(locs))
+        else:
+            offset = np.argmin(np.abs(locs))
+        return locs[
+            int(offset) % step :: step
+        ]  # even multiples from zero or zero-close
 
 
 class DegreeLocator(mticker.MaxNLocator):


### PR DESCRIPTION
Adding the baseline tests back into ensure future fidelity and make the tests more robust. This would make it easier to track potentially hard to see errors. It would further document future changes in case we wish to deviate from a style in the future.