### PR TITLE
Second dep on build still being skipped

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -37,7 +37,7 @@ jobs:
       name: prod
       url: https://pypi.org/project/ultraplot/
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'push' && needs.publish-pypi-test.result == 'success')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Fix PyPI publishing workflow

Updated the workflow to properly handle both release and tag push events:
- For tag pushes: Publishes to TestPyPI first, then PyPI if successful
- For releases: Publishes directly to PyPI, skipping TestPyPI

Fixed conditional logic in the publish-prod job to ensure it runs in both scenarios while maintaining the correct dependency chain.