### PR TITLE
fixing publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,21 +62,7 @@ jobs:
           min_version = re.search(r">=(\d+\.\d+)", mpl_req)
           max_version = re.search(r"<(\d+\.\d+)", mpl_req)
 
-          mpl_versions = []
-          if min_version and max_version:
-              # Convert version strings to tuples
-              min_v = tuple(map(int, min_version.group(1).split(".")))
-              max_v = tuple(map(int, max_version.group(1).split(".")))
-
-              # Generate version list
-              current = min_v
-              while current < max_v:
-                  mpl_versions.append(".".join(map(str, current)))
-                  current = (current[0], current[1] + 1)
-
-          # If no versions found, default to 3.9
-          if not mpl_versions:
-              mpl_versions = ["3.9"]
+          mpl_versions = data.get("tool", {}).get("ultraplot", {}).get("supported-versions", {}).get("matplotlib", ["3.9"])
 
           # Create output dictionary
           output = {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,21 @@ jobs:
           min_version = re.search(r">=(\d+\.\d+)", mpl_req)
           max_version = re.search(r"<(\d+\.\d+)", mpl_req)
 
-          mpl_versions = data.get("tool", {}).get("ultraplot", {}).get("supported-versions", {}).get("matplotlib", ["3.9"])
+          mpl_versions = []
+          if min_version and max_version:
+              # Convert version strings to tuples
+              min_v = tuple(map(int, min_version.group(1).split(".")))
+              max_v = tuple(map(int, max_version.group(1).split(".")))
+
+              # Generate version list
+              current = min_v
+              while current < max_v:
+                  mpl_versions.append(".".join(map(str, current)))
+                  current = (current[0], current[1] + 1)
+
+          # If no versions found, default to 3.9
+          if not mpl_versions:
+              mpl_versions = ["3.9"]
 
           # Create output dictionary
           output = {

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -31,6 +31,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          verbose: true
 
   publish-prod:
     name: Publish to PyPI
@@ -56,3 +57,5 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,6 @@ dynamic = ["version"]
 setuptools_scm = "setuptools_scm._integration.setuptools:infer_version"
 
 
-[tool.ultraplot.supported-versions]
-matplotlib = ["3.9",
-            # "3.10" # add when basemap is updated
-            ]
-
 [tool.setuptools]
 packages = ["ultraplot"]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ dynamic = ["version"]
 setuptools_scm = "setuptools_scm._integration.setuptools:infer_version"
 
 
+[tool.ultraplot.supported-versions]
+matplotlib = ["3.9",
+            # "3.10" # add when basemap is updated
+            ]
 
 [tool.setuptools]
 packages = ["ultraplot"]


### PR DESCRIPTION
fixes #60

The workflow indicates that pypi does not allow for the custom classifier for matplotlib framework (https://pypi.org/classifiers/). I moved them to a custom header and updated the workflow appropriately.  
