### PR TITLE
fix: correct chain of logic for publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,6 +30,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          verbose: true
 
   publish-prod:
     name: Publish to PyPI
@@ -55,3 +56,5 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -38,7 +38,7 @@ jobs:
       name: prod
       url: https://pypi.org/project/ultraplot/
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'push'
+    if: github.event_name == 'release'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,7 +12,6 @@ jobs:
       name: test
       url: https://test.pypi.org/project/ultraplot/
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     permissions:
       id-token: write
       contents: read
@@ -39,7 +38,7 @@ jobs:
       name: prod
       url: https://pypi.org/project/ultraplot/
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || (github.event_name == 'push' && needs.publish-pypi-test.result == 'success')
+    if: github.event_name == 'release' || github.event_name == 'push'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This PR fixes the logic in the publish workflow. It uses test pypi for releases and tag pushes, but only pushes releases to pypi.