### PR TITLE
fix: get pypi publish working

### DIFF
--- a/.github/workflows/build-ultraplot.yml
+++ b/.github/workflows/build-ultraplot.yml
@@ -20,6 +20,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: mamba-org/setup-micromamba@v2.0.4
         with:
           environment-file: ./environment.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
       matplotlib-versions: ${{ steps.set-versions.outputs.matplotlib-versions }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,6 +5,10 @@ on:
   push:
     tags: ["v*"]
 
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
 jobs:
   publish-pypi-test:
     name: Publish to TestPyPI
@@ -17,15 +21,33 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Get tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        shell: bash
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
       - name: Build package
         run: |
-          python -m pip install build
-          python -m build
+          python -m pip install --upgrade pip wheel setuptools setuptools_scm build twine
+          python -m build --sdist --wheel . --outdir dist
+
+      - name: CheckFiles
+        run: |
+          ls dist
+        shell: bash
+
+      - name: Test wheels
+        run: |
+          pushd dist
+          python -m pip install ultraplot*.whl
+          python -m twine check *
+          popd
+        shell: bash
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -45,15 +67,33 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+
+      - name: Get tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        shell: bash
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
       - name: Build package
         run: |
-          python -m pip install build
-          python -m build
+          python -m pip install --upgrade pip wheel setuptools setuptools_scm build twine
+          python -m build --sdist --wheel . --outdir dist
+
+      - name: CheckFiles
+        run: |
+          ls dist
+        shell: bash
+
+      - name: Test wheels
+        run: |
+          pushd dist
+          python -m pip install ultraplot*.whl
+          python -m twine check *
+          popd
+        shell: bash
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
+          # releases generate both release and tag events so
+          # we get a race condition if we don't skip existing
+          skip-existing: true
 
   publish-prod:
     name: Publish to PyPI

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -79,6 +79,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Get tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -102,6 +104,14 @@ jobs:
         run: |
           pushd dist
           python -m pip install ultraplot*.whl
+
+          version=$(python -c "import ultraplot; print(ultraplot.__version__)")
+          echo "Version: $version"
+          if [[ "$version" == "0."* ]]; then
+            echo "Version is not set correctly!"
+            exit 1
+          fi
+
           python -m twine check *
           popd
         shell: bash

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -67,7 +67,7 @@ jobs:
           verbose: true
           # releases generate both release and tag events so
           # we get a race condition if we don't skip existing
-          skip-existing: true
+          skip-existing: ${{ github.event_name == 'release' && 'true' || 'false' }}
 
   publish-prod:
     name: Publish to PyPI

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,6 +22,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Get tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -29,7 +31,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Build package
         run: |
@@ -45,6 +47,14 @@ jobs:
         run: |
           pushd dist
           python -m pip install ultraplot*.whl
+
+          version=$(python -c "import ultraplot; print(ultraplot.__version__)")
+          echo "Version: $version"
+          if [[ "$version" == "0."* ]]; then
+            echo "Version is not set correctly!"
+            exit 1
+          fi
+
           python -m twine check *
           popd
         shell: bash
@@ -76,7 +86,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Build package
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,5 +1,6 @@
 name: Publish to PyPI
 on:
+  pull_request:
   release:
     types: [published]
   push:
@@ -49,6 +50,7 @@ jobs:
         shell: bash
 
       - name: Publish to TestPyPI
+        if: github.event_name != 'pull_request'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ __pycache__
 tmp
 trash
 garbage
+
+# version file
+ultraplot/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools>=64",
-            "setuptools_scm[toml]>=8",
-            "wheel",
-            "numpy>=1.26.0",
-            "matplotlib>=3.9",
-            ]
+requires = [
+    "setuptools>=64",
+    "setuptools_scm[toml]>=8",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,7 +12,6 @@ authors = [
     {name = "Casper van Elteren", email = "caspervanelteren@gmail.com"},
     {name = "Luke Davis", email = "lukelbd@gmail.com"},
 ]
-
 maintainers = [
     {name = "Casper van Elteren", email = "caspervanelteren@gmail.com"},
 ]
@@ -38,21 +36,15 @@ dependencies= [
 ]
 dynamic = ["version"]
 
-
 [project.urls]
 "Documentation" = "https://ultraplot.readthedocs.io"
 "Issue Tracker" = "https://github.com/ultraplot/ultraplot/issues"
 "Source Code" = "https://github.com/ultraplot/ultraplot"
 
-[project.entry-points."setuptools.finalize_distribution_options"]
-setuptools_scm = "setuptools_scm._integration.setuptools:infer_version"
-
-
-
 [tool.setuptools]
-packages = ["ultraplot"]
+packages = {find = {exclude=["docs*", "baseline*", "logo*"]}}
 include-package-data = true
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
-local_scheme = "dirty-tag"
+write_to = "ultraplot/_version.py"
+write_to_template = "__version__ = '{version}'\n"

--- a/ultraplot/__init__.py
+++ b/ultraplot/__init__.py
@@ -6,13 +6,11 @@ A succinct matplotlib wrapper for making beautiful, publication-quality graphics
 name = "ultraplot"
 
 try:
-    from importlib.metadata import version as get_version
-except ImportError:  # for Python < 3.8
-    from importlib_metadata import version as get_version
-try:
-    version = __version__ = get_version(name)
-except Exception:
-    version = __version__ = "unknown"
+    from ._version import __version__
+except ImportError:
+    __version__ = "unknown"
+
+version = __version__
 
 # Import dependencies early to isolate import times
 from . import internals, externals, tests  # noqa: F401


### PR DESCRIPTION
I am copying over the configs from conda-forge-metadata which has a working publish action: https://github.com/conda-forge/conda-forge-metadata/blob/main/.github/workflows/pypi.yml

Hopefully this finally fixes things. 

Right now, setuptools scm is not computing the version from the tag correctly.