### PR TITLE
fix: make sure PRs do not mess with releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,7 @@ on:
     tags: ["v*"]
 
 concurrency:
-  group: publish-pypi
+  group: publish-pypi-{{ github.sha }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
GHA only allows one workflow run to be queued behind a running one when it does not cancel in progress jobs. By add the SHA to the concurrency group, we allow for PRs to run the pypi build for testing while also allowing tags / releases on main to not be canceled.