### PR TITLE
added path explicitly on publish

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -108,6 +108,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}
+          path: dist
 
       - name: Check files
         run: |


### PR DESCRIPTION
The job currently fails as (I believe) the dist path needs to be set similar to how it is done on the test server upload