### PR TITLE
Fixes heatmap not showing labels.

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1388,12 +1388,70 @@ class PlotAxes(base.Axes):
         formatter = constructor.Formatter(
             formatter, precision=precision, **formatter_kw
         )  # noqa: E501
-        if isinstance(obj, mcontour.ContourSet):
-            self._add_contour_labels(obj, cobj, formatter, **labels_kw)
-        elif isinstance(obj, mcollections.Collection):
-            self._add_collection_labels(obj, formatter, **labels_kw)
-        else:
-            raise RuntimeError(f"Not possible to add labels to object {obj!r}.")
+        match obj:
+            case mcontour.ContourSet():
+                self._add_contour_labels(obj, cobj, formatter, **labels_kw)
+            case mcollections.QuadMesh():
+                self._add_quadmesh_labels(obj, formatter, **labels_kw)
+            case mcollections.Collection():
+                self._add_collection_labels(obj, formatter, **labels_kw)
+            case _:
+                raise RuntimeError(f"Not possible to add labels to object {obj!r}.")
+
+
+    def _add_quadmesh_labels(
+        self,
+        obj,
+        fmt,
+        *,
+        c=None,
+        color=None,
+        colors=None,
+        size=None,
+        fontsize=None,
+        **kwargs,
+    ):
+        """
+        Add labels to QuadMesh cells with support for shade-dependent text colors.
+        Values are inferred from the unnormalized mesh cell color.
+        """
+        # Parse input args
+        obj.update_scalarmappable()
+        color = _not_none(c=c, color=color, colors=colors)
+        fontsize = _not_none(size=size, fontsize=fontsize, default=rc["font.smallsize"])
+        kwargs.setdefault("ha", "center")
+        kwargs.setdefault("va", "center")
+
+        # Get the mesh data
+        array = obj.get_array()
+        coords = obj.get_coordinates()  # This gives vertices (11x11x2)
+
+        # Calculate cell centers by averaging the four corners of each cell
+        x_centers = (coords[:-1, :-1, 0] + coords[1:, 1:, 0]) / 2
+        y_centers = (coords[:-1, :-1, 1] + coords[1:, 1:, 1]) / 2
+
+        # Apply colors and create labels
+        labs = []
+        for i, ((x, y), value) in enumerate(zip(zip(x_centers.flat, y_centers.flat), array.flat)):
+            # Skip masked or invalid values
+            if value is ma.masked or not np.isfinite(value):
+                continue
+
+            # Handle discrete normalization if present
+            if isinstance(obj.norm, pcolors.DiscreteNorm):
+                value = obj.norm._norm.inverse(obj.norm(value))
+
+            # Determine text color based on background
+            icolor = color
+            if color is None:
+                _, _, lum = utils.to_xyz(obj.cmap(obj.norm(value)), "hcl")
+                icolor = "w" if lum < 50 else "k"
+
+            # Create text label
+            lab = self.text(x, y, fmt(value), color=icolor, size=fontsize, **kwargs)
+            labs.append(lab)
+
+        return labs
 
     def _add_collection_labels(
         self,

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1398,7 +1398,6 @@ class PlotAxes(base.Axes):
             case _:
                 raise RuntimeError(f"Not possible to add labels to object {obj!r}.")
 
-
     def _add_quadmesh_labels(
         self,
         obj,
@@ -1432,7 +1431,9 @@ class PlotAxes(base.Axes):
 
         # Apply colors and create labels
         labs = []
-        for i, ((x, y), value) in enumerate(zip(zip(x_centers.flat, y_centers.flat), array.flat)):
+        for i, ((x, y), value) in enumerate(
+            zip(zip(x_centers.flat, y_centers.flat), array.flat)
+        ):
             # Skip masked or invalid values
             if value is ma.masked or not np.isfinite(value):
                 continue
@@ -1502,7 +1503,6 @@ class PlotAxes(base.Axes):
             y = (bbox.ymin + bbox.ymax) / 2
             lab = self.text(x, y, fmt(value), color=icolor, size=fontsize, **kwargs)
             labs.append(lab)
-
         obj.set_edgecolors(edgecolors)
         return labs
 

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -505,3 +505,14 @@ def test_line_plot_cyclers():
 
     fig.format(xlabel="xlabel", ylabel="ylabel", suptitle="On-the-fly property cycles")
     return fig
+
+
+@pytest.mpl_image_compare
+def test_heatmap_labels():
+    """
+    Heatmap function should show labels when asked
+    """
+    fig, ax = uplt.subplots()
+    x = state.rand(10, 10)
+    ax.heatmap(x, labels=True)
+    return fig

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -507,7 +507,7 @@ def test_line_plot_cyclers():
     return fig
 
 
-@pytest.mpl_image_compare
+@pytest.mark.mpl_image_compare
 def test_heatmap_labels():
     """
     Heatmap function should show labels when asked

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -512,7 +512,14 @@ def test_heatmap_labels():
     """
     Heatmap function should show labels when asked
     """
-    fig, ax = uplt.subplots()
     x = state.rand(10, 10)
+    # Nans should not be shown
+    x[0, 0] = np.nan
+    x[0, -1] = np.nan
+    x[-1, 0] = np.nan
+    x[-1, -1] = np.nan
+    x[4:6, 4:6] = np.nan
+
+    fig, ax = uplt.subplots()
     ax.heatmap(x, labels=True)
     return fig


### PR DESCRIPTION
This PR makes the logic for `pcolormesh` specific to `QuadMesh` which is the object returned by `pcolormesh` and is more specific than a `Collection`. 

This ensures that labels are added correctly again when using a heatmap

```python
import ultraplot as plt, numpy as np

x = np.random.rand(10, 10)
fig, ax = plt.subplots(figsize=(5, 5))
ax.heatmap(x, labels=True)
fig.show()

```
![image](https://github.com/user-attachments/assets/37877ced-1ec8-4649-9321-8e91baea6e11)

