### PR TITLE
filter out property if not set

### DIFF
--- a/ultraplot/constructor.py
+++ b/ultraplot/constructor.py
@@ -881,10 +881,10 @@ markeredgecolors, markerfacecolors
 
     def _handle_empty_args(self, props, kwargs):
         """Handle case when no positional arguments are provided."""
-        props.setdefault("color", "black")
+        props.setdefault("color", ["black"])
         if kwargs:
             warnings._warn_ultraplot(f"Ignoring Cycle() keyword arg(s) {kwargs}.")
-        self._build_cycler(())
+        self._build_cycler((props,))
 
     def _handle_cycler_args(self, args, props, kwargs):
         """Handle case when arguments are cycler objects."""
@@ -928,13 +928,17 @@ markeredgecolors, markerfacecolors
                 props.setdefault(key, []).extend(value)
         # Build cycler with matching property lengths
         # Ensure at least a default color property exists
-        if not props:
-            props = {"color": ["black"]}
-
         # Build cycler with matching property lengths
         lengths = [len(value) for value in props.values()]
         maxlen = np.lcm.reduce(lengths)
-        props = {key: value * (maxlen // len(value)) for key, value in props.items()}
+        props = {
+            key: value * (maxlen // len(value))
+            for key, value in props.items()
+            if len(value)
+        }
+        # Set default color property if not present
+        if "color" not in props or not props:
+            props = {"color": ["black"]}
         mcycler = cycler.cycler(**props)
         super().__init__(mcycler)
 

--- a/ultraplot/tests/test_constructor.py
+++ b/ultraplot/tests/test_constructor.py
@@ -113,3 +113,12 @@ def test_pass_on_cycle():
     for color in colors:
         assert color == active_cycle.get_next()["color"]
         assert color == cycle.get_next()["color"]
+
+    colors = ["red", "green", "black"]
+    cycle = uplt.Cycle(color=colors)
+    fig, ax = uplt.subplots()
+    ax.set_prop_cycle(cycle)
+    active_cycle = ax.axes._active_cycle
+    for color in colors:
+        assert color == active_cycle.get_next()["color"]
+        assert color == cycle.get_next()["color"]

--- a/ultraplot/tests/test_constructor.py
+++ b/ultraplot/tests/test_constructor.py
@@ -78,6 +78,7 @@ def test_cycler_edge_cases():
     props1 = cycle.get_next()
     props2 = cycle.get_next()
     assert props1["marker"] == props2["marker"]  # marker should stay same
+    assert props1["color"] == "red"
     assert props1["color"] != props2["color"]  # color should cycle
 
 

--- a/ultraplot/tests/test_constructor.py
+++ b/ultraplot/tests/test_constructor.py
@@ -77,7 +77,9 @@ def test_cycler_edge_cases():
     assert props1["color"] != props2["color"]  # color should cycle
 
     cycle = uplt.Cycle(color=[])
+    assert cycle.get_next() == dict(color="black")  # default fallback
     cycle = uplt.Cycle(colors=[])
+    assert cycle.get_next() == dict(color="black")  # default fallback
 
 
 # see https://github.com/matplotlib/matplotlib/pull/29469

--- a/ultraplot/tests/test_constructor.py
+++ b/ultraplot/tests/test_constructor.py
@@ -65,7 +65,7 @@ def test_not_allowed_keyword():
 def test_cycler_edge_cases():
     """Test edge cases and error conditions"""
     # Test with empty lists
-    cycle = uplt.Cycle(colors=[])
+    cycle = uplt.Cycle()
     assert cycle.get_next() == dict(color="black")  # default fallback
 
     # Test with mismatched lengths
@@ -75,6 +75,9 @@ def test_cycler_edge_cases():
     props2 = cycle.get_next()
     assert props1["marker"] == props2["marker"]  # marker should stay same
     assert props1["color"] != props2["color"]  # color should cycle
+
+    cycle = uplt.Cycle(color=[])
+    cycle = uplt.Cycle(colors=[])
 
 
 # see https://github.com/matplotlib/matplotlib/pull/29469

--- a/ultraplot/tests/test_constructor.py
+++ b/ultraplot/tests/test_constructor.py
@@ -67,6 +67,10 @@ def test_cycler_edge_cases():
     # Test with empty lists
     cycle = uplt.Cycle()
     assert cycle.get_next() == dict(color="black")  # default fallback
+    cycle = uplt.Cycle(color=[])
+    assert cycle.get_next() == dict(color="black")  # default fallback
+    cycle = uplt.Cycle(colors=[])
+    assert cycle.get_next() == dict(color="black")  # default fallback
 
     # Test with mismatched lengths
     cycle = uplt.Cycle(["red", "blue"], marker=["o"])
@@ -75,11 +79,6 @@ def test_cycler_edge_cases():
     props2 = cycle.get_next()
     assert props1["marker"] == props2["marker"]  # marker should stay same
     assert props1["color"] != props2["color"]  # color should cycle
-
-    cycle = uplt.Cycle(color=[])
-    assert cycle.get_next() == dict(color="black")  # default fallback
-    cycle = uplt.Cycle(colors=[])
-    assert cycle.get_next() == dict(color="black")  # default fallback
 
 
 # see https://github.com/matplotlib/matplotlib/pull/29469


### PR DESCRIPTION
#98 Addresses an issue where explicit key word is given or not. By default the first argument is assumed to be the color spec but that does not have to be the case.