### PR TITLE
Add texgyre to docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y texlive-fonts-extra
+          sudo fc-cache -fv
         # need tex-gyre-hero fonts to show text in geo plots
       - name: "Build docs"
         shell: bash -el {0}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: mamba-org/setup-micromamba@v2.0.4
         with:
           environment-file: ./environment.yml
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fonts-texgyre
       - name: "Build docs"
         shell: bash -el {0}
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y fonts-texgyre
+          sudo apt-get install -y texlive-fonts-extra
+        # need tex-gyre-hero fonts to show text in geo plots
       - name: "Build docs"
         shell: bash -el {0}
         run: |


### PR DESCRIPTION
Should address errors like:

>/home/docs/checkouts/readthedocs.org/user_builds/ultraplot/conda/latest/lib/python3.12/site-packages/cartopy/mpl/gridliner.py:751: UserWarning: Glyph 8242 (\N{PRIME}) missing from font(s) TeX Gyre Heros.
  artist.update_bbox_position_size(renderer)