### PR TITLE
prod: only build ultraplot when ultraplot src changes

### DIFF
--- a/.github/workflows/main-no-changes.yml
+++ b/.github/workflows/main-no-changes.yml
@@ -17,4 +17,4 @@ jobs:
   build-success:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All tests passed successfully!"
+      - run: echo "No tests were run since no ultraplot Python code changes were detected! Marking the test suite as passed!"

--- a/.github/workflows/main-no-changes.yml
+++ b/.github/workflows/main-no-changes.yml
@@ -1,0 +1,20 @@
+name: Matrix Test
+on:
+  push:
+    branches: [main, devel]
+    paths-ignore:
+      - "ultraplot/**"
+  pull_request:
+    branches: [main, devel]
+    paths-ignore:
+      - "ultraplot/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-success:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All tests passed successfully!"

--- a/.github/workflows/main-no-changes.yml
+++ b/.github/workflows/main-no-changes.yml
@@ -1,4 +1,4 @@
-name: Matrix Test
+name: Matrix Test No Changes
 on:
   push:
     branches: [main, devel]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,12 @@ name: Matrix Test
 on:
   push:
     branches: [main, devel]
+    paths:
+      - "ultraplot/**"
   pull_request:
     branches: [main, devel]
+    paths:
+      - "ultraplot/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR will streamline the runs. When updating the docs, the src does not have to be built unless the src was changed.