### PR TITLE
Fix colorbar ticks

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1143,6 +1143,7 @@ class Axes(maxes.Axes):
         # DiscreteLocator or else get issues (see mpl #22233).
         norm = mappable.norm
         formatter = _not_none(formatter, getattr(norm, "_labels", None), "auto")
+        formatter_kw.setdefault("tickrange", (norm.vmin, norm.vmax))
         formatter = constructor.Formatter(formatter, **formatter_kw)
         categorical = isinstance(formatter, mticker.FixedFormatter)
         if locator is not None:

--- a/ultraplot/tests/test_2dplots.py
+++ b/ultraplot/tests/test_2dplots.py
@@ -353,3 +353,19 @@ def test_triangular_functions():
     da = xr.DataArray(state.rand(N), dims=("x",), coords={"x": x, "y": ("x", y)})
     ax.tricontour(da.x, da.y, da, labels=True)
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_colorbar_extends():
+    """
+    Test all the possible extends
+    """
+    # Ensure that the colorbars are not showing artifacts on the ticks. In the past extend != neither showed ghosting on the ticks. This occured after a manual draw after the colorbar was created.
+    fig, ax = uplt.subplots(nrows=2, ncols=2, share=False)
+    data = state.rand(20, 20)
+    levels = np.linspace(0, 1, 11)
+    extends = ["neither", "both", "min", "max"]
+    for extend, axi in zip(extends, ax):
+        m = axi.contourf(data, levels=levels, extend=extend)
+        axi.colorbar(m)
+    return fig


### PR DESCRIPTION
Addresses #105 

When `extend != 'neither'` the additional `update_ticks` is creating ghosting on the ticks. I am not sure why this happened but the `update_ticks` command is overridden by Ultraplot but deprecated by mpl. Removing the function outright breaks code elsewhere that I currently do not fully understand. I would be more in favor of removing this additional function but for now we can fix this by removing this additional call. Unittest is added to safe guard against future changes.