### PR TITLE
bugfix for Axes.legend when certain keywords are set to str

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1319,7 +1319,7 @@ class Axes(maxes.Axes):
             _, key = pair
             value = kwargs.pop(key, None)
             if isinstance(value, str):
-                value = units(kwargs[key], "em", fontsize=fontsize)
+                value = units(value, "em", fontsize=fontsize)
             if value is not None:
                 kwargs[key] = value
 

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -192,4 +192,7 @@ def test_legend_col_spacing():
     ax.plot(state.rand(10), label="even longer label")
     for idx in range(3):
         ax.legend(loc="bottom", ncol=3, columnspacing=f"{idx}em")
+
+    with pytest.raises(ValueError):
+        ax.legend(loc="bottom", ncol=3, columnspacing="15x")
     return fig

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -179,3 +179,18 @@ def test_tuple_handles():
             handler_map={tuple: legend_handler.HandlerTuple(pad=0, ndivide=3)},
         )
     return fig
+
+
+@pytest.mark.image_compare
+def test_legend_col_spacing():
+    """
+    Test legend column spacing.
+    """
+    fig, ax = uplt.subplots()
+    ax.plot(state.rand(10), label="short")
+    ax.plot(state.rand(10), label="longer label")
+    ax.plot(state.rand(10), label="even longer label")
+    for idx in range(3):
+        ax.legend(loc="bottom", ncol=3, columnspacing=f"{idx}em")
+    uplt.show(block=1)
+    return fig

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -191,7 +191,10 @@ def test_legend_col_spacing():
     ax.plot(state.rand(10), label="longer label")
     ax.plot(state.rand(10), label="even longer label")
     for idx in range(3):
-        ax.legend(loc="bottom", ncol=3, columnspacing=f"{idx}em")
+        spacing = f"{idx}em"
+        if idx == 2:
+            spacing = 3
+        ax.legend(loc="bottom", ncol=3, columnspacing=spacing)
 
     with pytest.raises(ValueError):
         ax.legend(loc="bottom", ncol=3, columnspacing="15x")

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -181,7 +181,7 @@ def test_tuple_handles():
     return fig
 
 
-@pytest.mark.image_compare
+@pytest.mark.mpl_image_compare
 def test_legend_col_spacing():
     """
     Test legend column spacing.

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -192,5 +192,4 @@ def test_legend_col_spacing():
     ax.plot(state.rand(10), label="even longer label")
     for idx in range(3):
         ax.legend(loc="bottom", ncol=3, columnspacing=f"{idx}em")
-    uplt.show(block=1)
     return fig


### PR DESCRIPTION
Bug: `kwargs` just has popped out key, and thus, `kwargs[key]` won't work.  It raises KeyError when the value is a string (e.g.,`columnspacing='1em'`)