### PR TITLE
Allow ticks for geoaxes

### DIFF
--- a/docs/projections.py
+++ b/docs/projections.py
@@ -344,7 +344,7 @@ for globe in (False, True):
 # borders using :ref:`settings <rc_UltraPlot>` like `land`, `landcolor`, `coast`,
 # `coastcolor`, and `coastlinewidth`. Finally, since `ultraplot.axes.GeoAxes.format`
 # calls `ultraplot.axes.Axes.format`, it can be used to add axes titles, a-b-c labels,
-# and figure titles, just like :func:`ultraplot.axes.CartesianAxes.format`.
+# and figure titles, just like :func:`ultraplot.axes.CartesianAxes.format`. UltraPlot also adds the ability to add tick marks for longitude and latitude using the keywords `lontick` and `lattick` for rectilinear projections only. This can enhance contrast and readability under some conditions, e.g. when overlaying contours.
 #
 # For details, see the `ultraplot.axes.GeoAxes.format` documentation.
 

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -1,4 +1,4 @@
-import ultraplot as plt, numpy as np
+import ultraplot as plt, numpy as np, warnings
 import pytest
 
 
@@ -114,3 +114,63 @@ def test_drawing_in_projection_with_globe():
         abcborder=False,
     )
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_geoticks():
+
+    lonlim = (-140, 60)
+    latlim = (-10, 50)
+    basemap_projection = plt.Proj(
+        "cyl",
+        lonlim=lonlim,
+        latlim=latlim,
+        backend="basemap",
+    )
+    fig, ax = plt.subplots(
+        ncols=3,
+        proj=(
+            "cyl",  # cartopy
+            "cyl",  # cartopy
+            basemap_projection,  # basemap
+        ),
+        share=0,
+    )
+    settings = dict(land=True, labels=True, lonlines=20, latlines=20)
+    # Shows sensible "default"; uses cartopy backend to show the grid lines with ticks
+    ax[0].format(
+        lonlim=lonlim,
+        latlim=latlim,
+        **settings,
+    )
+
+    # Add lateral ticks only
+    ax[1].format(
+        latticklen=True,
+        gridminor=True,
+        lonlim=lonlim,
+        latlim=latlim,
+        **settings,
+    )
+
+    ax[2].format(
+        latticklen=5.0,
+        lonticklen=2.0,
+        grid=False,
+        gridminor=False,
+        **settings,
+    )
+    return fig
+
+
+def test_geoticks_input_handling(recwarn):
+    fig, ax = plt.subplots(proj="aeqd")
+    # Should warn that about non-rectilinear projection.
+    with pytest.warns(plt.warnings.UltraplotWarning):
+        ax.format(lonticklen=True)
+    # When set to None the latticks are not added.
+    # No warnings should be raised.
+    ax.format(lonticklen=None)
+    assert len(recwarn) == 0
+    # Can parse a string
+    ax.format(lonticklen="1em")


### PR DESCRIPTION
This PR addresses #125. It introduces a test that tests specifically three use cases.
It modifies the code to allow for showing ticks in geoaxis. Currently, the tickers are completely controlled through the backend with small modifications to ensure high quality plots. This PR makes it to add ticks. It does this by manually adding a ticker when new keywords `lontick` or `lattick` is given which can take a bool or numeric as an input. When set to `None` the option is effectively ignored.

The defaults should generate a sensible plot with lat and long lines, but without ticks. Then it specifically tests whether leaving the ticks on on one axis does not hamper the other axes.

![image](https://github.com/user-attachments/assets/76e78cf7-10fb-4904-8022-971b5d94a23c)

Edit the parameters added would create a 2^4 test plots in terms of the combinations; I opted for specific tests that are a bit more complex but are quicker to generate while still testing all the properties.
