### PR TITLE
fix: checkout from correct fork

### DIFF
--- a/.github/workflows/archive-pytest-results.yml
+++ b/.github/workflows/archive-pytest-results.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   debug:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Print event data
         run: echo '${{ toJson(github.event) }}'
@@ -15,6 +16,7 @@ jobs:
   archive-test-results:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    permissions: {}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/archive-pytest-results.yml
+++ b/.github/workflows/archive-pytest-results.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
@@ -41,7 +42,7 @@ jobs:
         run: |
           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
           SHA_SHORT=$(echo ${{ github.event.workflow_run.head_sha }} | cut -c1-7)
-          PR_NUMBER=$(echo "${{ github.event.workflow_run.head_branch }}" | grep -oP 'pull/\K\d+' || echo "main")
+          PR_NUMBER=$(echo "${{ github.event.workflow_run.head_branch }}" | grep -oP 'pull/\K\d+' || echo "-1")
 
           if [[ "$PR_NUMBER" == "main" ]]; then
             BRANCH_INFO="main"


### PR DESCRIPTION
@cvanelteren this should fix the latest error. A few other comments

1. The `head_branch` is not the merge branch and so it won't have the PR number in it. It appears that for this event the `pull_request` attribute is empty so we'll need to parse the PR by searching the API if we want the number.

2. We need to set the permissions for tokens to null for security reasons. We are checking out untrusted code in the context of the upstream repo.