### PR TITLE
Prepare the pytest results in the workflow

### DIFF
--- a/.github/workflows/archive-pytest-results.yml
+++ b/.github/workflows/archive-pytest-results.yml
@@ -12,11 +12,12 @@ jobs:
     steps:
       - name: Print event data
         run: echo '${{ toJson(github.event) }}'
-  
+
   archive-test-results:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    permissions: {}
+    permissions:
+      contents: write # Need write permission to commit files
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +25,8 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          # Use a token with sufficient permissions
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-ultraplot.yml
+++ b/.github/workflows/build-ultraplot.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
-      run: 
+      run:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
@@ -50,13 +50,13 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Ultraplot/ultraplot
-  
+
   compare-baseline:
     needs: build-ultraplot
     runs-on: ubuntu-latest
     defaults:
-      run: 
-        shell: bash -el {0}    
+      run:
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
 
@@ -86,10 +86,18 @@ jobs:
           python -c "import ultraplot as plt; plt.config.Configurator()._save_yaml('ultraplot.yml')"
           pytest --mpl --mpl-baseline-path=baseline --mpl-generate-summary=html --mpl-results-path=./results/ --mpl-default-style="./ultraplot.yml" --store-failed-only ultraplot/tests
 
-      # Return the html output of the comparison even if failed
-      - name: Upload comparison failures
-        if: always()
+      - name: Prepare comparison results for archiving
+        if: failure()
+        run: |
+          # Create a directory structure using Python and Matplotlib versions
+          ARCHIVE_DIR="${inputs.python-version}-${inputs.matplotlib-version}"
+
+          # Add a simple config file for the archive workflow to use
+          echo "${inputs.python-version}|${inputs.matplotlib-version}" > results/config.txt
+
+      - name: Upload prepared archive
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failed-comparisons-${{ inputs.python-version }}-${{ inputs.matplotlib-version }}-${{ github.sha }}
-          path: results/*
+          name: failed-comparisons-${{ inputs.python-version }}-${{ inputs.matplotlib-version }}
+          path: results/


### PR DESCRIPTION
This PR adds a new workflow that automatically archives and displays matplotlib test comparison failures from CI runs. We discussed some options in #89 

## What does this PR do?

1. Adds a new GitHub workflow (`archive-pytest-results.yml`) that runs when the Matrix Test workflow fails
2. The workflow:
   - Downloads artifacts with failed plot comparisons from the test run
   - Organizes them into a structured archive in the docs directory
   - Creates an index page listing all archived test failures
   - Commits these changes to the repository

## Security considerations

- The workflow uses explicitly scoped permissions (`contents: write`)
- Processing is done on pre-rendered comparison results with no execution of untrusted code
- The workflow maintains a proper audit trail of who triggered the original workflow

