### PR TITLE
Edgefix off by default

### DIFF
--- a/docs/2dplots.py
+++ b/docs/2dplots.py
@@ -34,13 +34,13 @@
 #
 # .. important::
 #
-#    By default, UltraPlot automatically adjusts the width of
-#    :func:`~ultraplot.axes.PlotAxes.contourf` and :func:`~ultraplot.axes.PlotAxes.pcolor` edges
-#    to eliminate the appearance of `"white lines" in saved vector graphic files
-#    <https://github.com/jklymak/contourfIssues>`__. However, this can significantly
-#    slow down the drawing time for large datasets. To disable this feature,
-#    pass ``edgefix=False`` to the relevant :class:`~ultraplot.axes.PlotAxes` command,
-#    or set :rcraw:`edgefix` to ``False`` to disable globally.
+#    UltraPlot includes functionality to fix the common issue of unwanted
+#    `"white lines" in saved vector graphic files
+#    <https://github.com/jklymak/contourfIssues>`__ by adjusting the width of
+#    :func:`~ultraplot.axes.PlotAxes.contourf` and :func:`~ultraplot.axes.PlotAxes.pcolor` edges.
+#    This feature is disabled by default to maintain optimal performance, especially for large datasets.
+#    To enable this edge-fixing capability, pass ``edgefix=True`` to the relevant
+#    :class:`~ultraplot.axes.PlotAxes` command, or set :rcraw:`edgefix` to ``True`` to enable globally.
 
 # %% [raw] raw_mimetype="text/restructuredtext"
 # .. _ug_2dstd:

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -21,6 +21,7 @@ import matplotlib.projections as mproj
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
+from matplotlib import get_backend
 import numpy as np
 from matplotlib import cbook
 

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1131,7 +1131,7 @@ _rc_ultraplot_table = {
     ),
     # Special setting
     "edgefix": (
-        True,
+        False,
         _validate_bool,
         'Whether to fix issues with "white lines" appearing between patches '
         "in saved vector graphics and with vector graphic backends. Applies "


### PR DESCRIPTION
## Description
`Pcolormesh` and `pcolor` now include functionality to mitigate visual artifacts (such as white lines between color cells) that are generated by some PDF readers when saving plots as vector graphics files. This issue has been a long-standing problem when creating publication-quality vector graphics of color mesh plots. This issue was raised in #136. 

## What this changes
Sets the `rc` param from `True` to false to mittiage annoyances in EDA. 
The functionality otherwise remains unchanged.

