### PR TITLE
Set seed prior to test to ensure fidelity

### DIFF
--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -26,10 +26,6 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
-    config.seed = 51423
-
-
 class StoreFailedMplPlugin:
     def __init__(self, config):
         self.config = config

--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -1,4 +1,4 @@
-import os, shutil, pytest, re
+import os, shutil, pytest, re, numpy as np
 from pathlib import Path
 import warnings
 
@@ -8,6 +8,15 @@ warnings.filterwarnings(
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_numpy_seed():
+    """
+    Ensure all tests start with the same rng
+    """
+    seed = 51423
+    np.random.seed(seed)
+
+
 # Define command line option
 def pytest_addoption(parser):
     parser.addoption(
@@ -15,6 +24,10 @@ def pytest_addoption(parser):
         action="store_true",
         help="Store only failed matplotlib comparison images",
     )
+
+
+def pytest_configure(config):
+    config.seed = 51423
 
 
 class StoreFailedMplPlugin:

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -17,7 +17,7 @@ def test_auto_reverse():
     """
     x = np.arange(10)[::-1]
     y = np.arange(10)
-    z = state.rand(10, 10)
+    z = np.random.rand(10, 10)
     fig, axs = uplt.subplots(ncols=2, nrows=3, share=0)
     # axs[0].format(xreverse=False)  # should fail
     axs[0].plot(x, y)

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -9,8 +9,6 @@ import pandas as pd
 import ultraplot as uplt
 import pytest
 
-state = np.random.RandomState(51423)
-
 
 @pytest.mark.mpl_image_compare
 def test_auto_reverse():
@@ -51,7 +49,7 @@ def test_cmap_cycles():
         samples=[3, 4, 5, 2, 1],
     )
     fig, ax = uplt.subplots()
-    data = state.rand(10, len(cycle)).cumsum(axis=1)
+    data = np.random.rand(10, len(cycle)).cumsum(axis=1)
     data = pd.DataFrame(data, columns=list("abcdefghijklmno"))
     ax.plot(data, cycle=cycle, linewidth=2, legend="b")
     return fig
@@ -63,9 +61,12 @@ def test_column_iteration():
     Test scatter column iteration.
     """
     fig, axs = uplt.subplots(ncols=2)
-    axs[0].plot(state.rand(5, 5), state.rand(5, 5), lw=5)
+    axs[0].plot(np.random.rand(5, 5), np.random.rand(5, 5), lw=5)
     axs[1].scatter(
-        state.rand(5, 5), state.rand(5, 5), state.rand(5, 5), state.rand(5, 5)
+        np.random.rand(5, 5),
+        np.random.rand(5, 5),
+        np.random.rand(5, 5),
+        np.random.rand(5, 5),
     )
     return fig
 
@@ -86,7 +87,7 @@ def test_bar_width():
     """
     fig, axs = uplt.subplots(ncols=3)
     x = np.arange(10)
-    y = state.rand(10, 2)
+    y = np.random.rand(10, 2)
     for i, ax in enumerate(axs):
         ax.bar(x * (2 * i + 1), y, width=0.8, absolute_width=i == 1)
     return fig
@@ -117,8 +118,8 @@ def test_boxplot_colors():
     """
     fig = uplt.figure(share=False)
     ax = fig.subplot(221)
-    box_data = state.uniform(-3, 3, size=(1000, 5))
-    violin_data = state.normal(0, 1, size=(1000, 5))
+    box_data = np.random.uniform(-3, 3, size=(1000, 5))
+    violin_data = np.random.normal(0, 1, size=(1000, 5))
     ax.box(box_data, fillcolor=["red", "blue", "green", "orange", "yellow"])
     ax = fig.subplot(222)
     ax.violin(
@@ -145,7 +146,7 @@ def test_boxplot_vectors():
     labels = ["foo", "bar", "baz"]
     datas = []
     for count in counts:
-        data = state.rand(count)
+        data = np.random.rand(count)
         datas.append(data)
     datas = np.array(datas, dtype=object)
     assert len(datas) == len(coords)
@@ -171,7 +172,7 @@ def test_histogram_types():
     Test the different histogram types using basic keywords.
     """
     fig, axs = uplt.subplots(ncols=2, nrows=2, share=False)
-    data = state.normal(size=(100, 5))
+    data = np.random.normal(size=(100, 5))
     data += np.arange(5)
     kws = ({"stack": 0}, {"stack": 1}, {"fill": 0}, {"fill": 1, "alpha": 0.5})
     for ax, kw in zip(axs, kws):
@@ -185,7 +186,7 @@ def test_invalid_plot():
     Test lines with missing or invalid values.
     """
     fig, axs = uplt.subplots(ncols=2)
-    data = state.normal(size=(100, 5))
+    data = np.random.normal(size=(100, 5))
     for j in range(5):
         data[:, j] = np.sort(data[:, j])
         data[: 19 * (j + 1), j] = np.nan
@@ -202,7 +203,7 @@ def test_invalid_dist():
     Test distributions with missing or invalid data.
     """
     fig, axs = uplt.subplots(ncols=2, nrows=2)
-    data = state.normal(size=(100, 5))
+    data = np.random.normal(size=(100, 5))
     for i in range(5):  # test uneven numbers of invalid values
         data[: 10 * (i + 1), :] = np.nan
     data_masked = ma.masked_invalid(data)  # should be same result
@@ -237,7 +238,7 @@ def test_parametric_labels():
     uplt.rc.inlinefmt = "svg"
     fig, ax = uplt.subplots()
     ax.parametric(
-        state.rand(5),
+        np.random.rand(5),
         c=list("abcde"),
         lw=20,
         colorbar="b",
@@ -261,8 +262,8 @@ def test_parametric_colors():
     )
     for ax, color in zip(axs, colors):
         ax.parametric(
-            state.rand(5),
-            state.rand(5),
+            np.random.rand(5),
+            np.random.rand(5),
             linewidth=2,
             label="label",
             color=color,
@@ -277,8 +278,8 @@ def test_scatter_args():
     """
     Test diverse scatter keyword parsing and RGB scaling.
     """
-    x, y = state.randn(50), state.randn(50)
-    data = state.rand(50, 3)
+    x, y = np.random.randn(50), np.random.randn(50)
+    data = np.random.rand(50, 3)
     fig, axs = uplt.subplots(ncols=4, share=0)
     ax = axs[0]
     ax.scatter(x, y, s=80, fc="none", edgecolors="r")
@@ -314,7 +315,7 @@ def test_scatter_alpha():
     Test behavior with multiple alpha values.
     """
     fig, ax = uplt.subplots()
-    data = state.rand(10)
+    data = np.random.rand(10)
     alpha = np.linspace(0.1, 1, data.size)
     ax.scatter(data, alpha=alpha)
     ax.scatter(data + 1, c=np.arange(data.size), cmap="BuRd", alpha=alpha)
@@ -336,8 +337,8 @@ def test_scatter_cycle():
         edgecolors=["r", "k"],
     )
     ax.scatter(
-        state.rand(10, 4),
-        state.rand(10, 4),
+        np.random.rand(10, 4),
+        np.random.rand(10, 4),
         cycle=cycle,
         area_size=False,
     )
@@ -362,7 +363,7 @@ def test_scatter_sizes():
             ax.scatter(np.arange(5), [0.25 * (1 + i)] * 5, size**2, **kw)
     # Test various size arguments
     ax = fig.subplot(122, margin=0.15)
-    data = state.rand(5) * 500
+    data = np.random.rand(5) * 500
     ax.scatter(
         np.arange(5),
         [0.25] * 5,
@@ -449,7 +450,7 @@ def test_norm_not_modified():
     assert norm.vmin == 0
     assert norm.vmax == 10
 
-    arr = state.rand(20, 40) * 1000
+    arr = np.random.rand(20, 40) * 1000
     xe = np.linspace(0, 1, num=40, endpoint=True)
     ye = np.linspace(0, 1, num=20, endpoint=True)
 
@@ -464,11 +465,10 @@ def test_norm_not_modified():
 def test_line_plot_cyclers():
     # Sample data
     M, N = 50, 10
-    state = np.random.RandomState(51423)
-    data1 = (state.rand(M, N) - 0.48).cumsum(axis=1).cumsum(axis=0)
-    data2 = (state.rand(M, N) - 0.48).cumsum(axis=1).cumsum(axis=0) * 1.5
-    data1 += state.rand(M, N)
-    data2 += state.rand(M, N)
+    data1 = (np.random.rand(M, N) - 0.48).cumsum(axis=1).cumsum(axis=0)
+    data2 = (np.random.rand(M, N) - 0.48).cumsum(axis=1).cumsum(axis=0) * 1.5
+    data1 += np.random.rand(M, N)
+    data2 += np.random.rand(M, N)
     data1 *= 2
 
     cmaps = ("Blues", "Reds")
@@ -512,7 +512,7 @@ def test_heatmap_labels():
     """
     Heatmap function should show labels when asked
     """
-    x = state.rand(10, 10)
+    x = np.random.rand(10, 10)
     # Nans should not be shown
     x[0, 0] = np.nan
     x[0, -1] = np.nan

--- a/ultraplot/tests/test_2dplots.py
+++ b/ultraplot/tests/test_2dplots.py
@@ -8,8 +8,6 @@ import xarray as xr
 
 import ultraplot as uplt
 
-state = np.random.RandomState(51423)
-
 
 @pytest.mark.skip("not sure what this does")
 @pytest.mark.mpl_image_compare
@@ -18,7 +16,7 @@ def test_colormap_vcenter():
     Test colormap vcenter.
     """
     fig, axs = uplt.subplots(ncols=3)
-    data = 10 * state.rand(10, 10) - 3
+    data = 10 * np.random.rand(10, 10) - 3
     axs[0].pcolor(data, vcenter=0)
     axs[1].pcolor(data, vcenter=1)
     axs[2].pcolor(data, vcenter=2)
@@ -34,9 +32,9 @@ def test_auto_diverging1():
     fig = uplt.figure()
     # fig.format(collabels=('Auto sequential', 'Auto diverging'), suptitle='Default')
     ax = fig.subplot(121)
-    ax.pcolor(state.rand(10, 10) * 5, colorbar="b")
+    ax.pcolor(np.random.rand(10, 10) * 5, colorbar="b")
     ax = fig.subplot(122)
-    ax.pcolor(state.rand(10, 10) * 5 - 3.5, colorbar="b")
+    ax.pcolor(np.random.rand(10, 10) * 5 - 3.5, colorbar="b")
     fig.format(toplabels=("Sequential", "Diverging"))
     return fig
 
@@ -46,7 +44,7 @@ def test_auto_diverging1():
 def test_autodiverging2():
     # Test with explicit vcenter
     fig, axs = uplt.subplots(ncols=3)
-    data = 5 * state.rand(10, 10)
+    data = 5 * np.random.rand(10, 10)
     axs[0].pcolor(data, vcenter=0, colorbar="b")  # otherwise should be disabled
     axs[1].pcolor(data, vcenter=1.5, colorbar="b")
     axs[2].pcolor(data, vcenter=4, colorbar="b", symmetric=True)
@@ -60,7 +58,7 @@ def test_autodiverging3():
     cmap = uplt.Colormap(
         ("red7", "red3", "red1", "blue1", "blue3", "blue7"), listmode="discrete"
     )  # noqa: E501
-    data1 = 10 * state.rand(10, 10)
+    data1 = 10 * np.random.rand(10, 10)
     data2 = data1 - 2
     for i, cmap in enumerate(("RdBu_r", cmap)):
         for j, data in enumerate((data1, data2)):
@@ -72,7 +70,7 @@ def test_autodiverging3():
 @pytest.mark.mpl_image_compare
 def test_autodiverging4():
     fig, axs = uplt.subplots(ncols=3)
-    data = state.rand(5, 5) * 10 - 5
+    data = np.random.rand(5, 5) * 10 - 5
     for i, ax in enumerate(axs[:2]):
         ax.pcolor(data, sequential=bool(i), colorbar="b")
     axs[2].pcolor(data, diverging=False, colorbar="b")  # should have same effect
@@ -82,7 +80,7 @@ def test_autodiverging4():
 @pytest.mark.mpl_image_compare
 def test_autodiverging5():
     fig, axs = uplt.subplots(ncols=2)
-    data = state.rand(5, 5) * 10 + 2
+    data = np.random.rand(5, 5) * 10 + 2
     for ax, norm in zip(axs, (None, "div")):
         ax.pcolor(data, norm=norm, colorbar="b")
     return fig
@@ -94,11 +92,11 @@ def test_colormap_mode():
     Test auto extending, auto discrete. Should issue warnings.
     """
     fig, axs = uplt.subplots(ncols=2, nrows=2, share=False)
-    axs[0].pcolor(state.rand(5, 5) % 0.3, extend="both", cyclic=True, colorbar="b")
-    axs[1].pcolor(state.rand(5, 5), sequential=True, diverging=True, colorbar="b")
-    axs[2].pcolor(state.rand(5, 5), discrete=False, qualitative=True, colorbar="b")
+    axs[0].pcolor(np.random.rand(5, 5) % 0.3, extend="both", cyclic=True, colorbar="b")
+    axs[1].pcolor(np.random.rand(5, 5), sequential=True, diverging=True, colorbar="b")
+    axs[2].pcolor(np.random.rand(5, 5), discrete=False, qualitative=True, colorbar="b")
     uplt.rc["cmap.discrete"] = False  # should be ignored below
-    axs[3].contourf(state.rand(5, 5), colorbar="b")
+    axs[3].contourf(np.random.rand(5, 5), colorbar="b")
     return fig
 
 
@@ -110,7 +108,7 @@ def test_contour_labels():
     filled contour edges when not adding labels but that would be inconsistent with
     behavior when labels are active.
     """
-    data = state.rand(5, 5) * 10 - 5
+    data = np.random.rand(5, 5) * 10 - 5
     fig, axs = uplt.subplots(ncols=2)
     ax = axs[0]
     ax.contourf(
@@ -137,10 +135,10 @@ def test_contour_negative():
     """
     fig = uplt.figure(share=False)
     ax = fig.subplot(131)
-    data = state.rand(10, 10) * 10 - 5
+    data = np.random.rand(10, 10) * 10 - 5
     ax.contour(data, color="k")
     ax = fig.subplot(132)
-    ax.tricontour(*(state.rand(3, 20) * 10 - 5), color="k")
+    ax.tricontour(*(np.random.rand(3, 20) * 10 - 5), color="k")
     ax = fig.subplot(133)
     ax.contour(data, cmap=["black"])  # fails but that's ok
     return fig
@@ -170,7 +168,7 @@ def test_edge_fix():
     fig, axs = uplt.subplots(ncols=2, share=False)
     axs.format(grid=False)
     axs[0].bar(
-        state.rand(
+        np.random.rand(
             10,
         )
         * 10
@@ -178,10 +176,10 @@ def test_edge_fix():
         width=1,
         negpos=True,
     )
-    axs[1].area(state.rand(5, 3), stack=True)
+    axs[1].area(np.random.rand(5, 3), stack=True)
 
     # Test whether ignored for transparent colorbars
-    data = state.rand(10, 10)
+    data = np.random.rand(10, 10)
     cmap = "magma"
     fig, axs = uplt.subplots(nrows=3, ncols=2, refwidth=2.5, share=False)
     for i, iaxs in enumerate((axs[:2], axs[2:4])):
@@ -208,15 +206,18 @@ def test_flow_functions():
     """
     fig, ax = uplt.subplots()
     for _ in range(2):
-        ax.streamplot(state.rand(10, 10), 5 * state.rand(10, 10), label="label")
+        ax.streamplot(np.random.rand(10, 10), 5 * np.random.rand(10, 10), label="label")
 
     fig, axs = uplt.subplots(ncols=2)
     ax = axs[0]
     ax.quiver(
-        state.rand(10, 10), 5 * state.rand(10, 10), c=state.rand(10, 10), label="label"
+        np.random.rand(10, 10),
+        5 * np.random.rand(10, 10),
+        c=np.random.rand(10, 10),
+        label="label",
     )
     ax = axs[1]
-    ax.quiver(state.rand(10), state.rand(10), label="single")
+    ax.quiver(np.random.rand(10), np.random.rand(10), label="single")
     return fig
 
 
@@ -226,7 +227,7 @@ def test_gray_adjustment():
     Test gray adjustments when creating segmented colormaps.
     """
     fig, ax = uplt.subplots()
-    data = state.rand(5, 5) * 10 - 5
+    data = np.random.rand(5, 5) * 10 - 5
     cmap = uplt.Colormap(["blue", "grey3", "red"])
     ax.pcolor(data, cmap=cmap, colorbar="b")
     return fig
@@ -240,14 +241,19 @@ def test_ignore_message():
     warning = uplt.internals.UltraplotWarning
     fig, axs = uplt.subplots(ncols=2, nrows=2)
     with pytest.warns(warning):
-        axs[0].contour(state.rand(5, 5) * 10, levels=uplt.arange(10), symmetric=True)
+        axs[0].contour(
+            np.random.rand(5, 5) * 10, levels=uplt.arange(10), symmetric=True
+        )
     with pytest.warns(warning):
         axs[1].contourf(
-            state.rand(10, 10), levels=np.linspace(0, 1, 10), locator=5, locator_kw={}
+            np.random.rand(10, 10),
+            levels=np.linspace(0, 1, 10),
+            locator=5,
+            locator_kw={},
         )
     with pytest.warns(warning):
         axs[2].contourf(
-            state.rand(10, 10),
+            np.random.rand(10, 10),
             levels=uplt.arange(0, 1, 0.2),
             vmin=0,
             vmax=2,
@@ -256,8 +262,8 @@ def test_ignore_message():
         )
     with pytest.warns(warning):
         axs[3].hexbin(
-            state.rand(1000),
-            state.rand(1000),
+            np.random.rand(1000),
+            np.random.rand(1000),
             levels=uplt.arange(0, 20),
             gridsize=10,
             locator=2,
@@ -273,9 +279,8 @@ def test_levels_with_vmin_vmax():
     Make sure `vmin` and `vmax` go into level generation algorithm.
     """
     # Sample data
-    state = np.random.RandomState(51423)
     x = y = np.array([-10, -5, 0, 5, 10])
-    data = state.rand(y.size, x.size)
+    data = np.random.rand(y.size, x.size)
 
     # Figure
     fig = uplt.figure(refwidth=2.3, share=False)
@@ -291,7 +296,7 @@ def test_level_restriction():
     Test `negative`, `positive`, and `symmetric` with and without discrete.
     """
     fig, axs = uplt.subplots(ncols=3, nrows=2)
-    data = 20 * state.rand(10, 10) - 5
+    data = 20 * np.random.rand(10, 10) - 5
     keys = ("negative", "positive", "symmetric")
     for i, grp in enumerate((axs[:3], axs[3:])):
         for j, ax in enumerate(grp):
@@ -307,7 +312,7 @@ def test_qualitative_colormaps_1():
     extreme only if unset.
     """
     fig, axs = uplt.subplots(ncols=2)
-    data = state.rand(5, 5)
+    data = np.random.rand(5, 5)
     colors = uplt.get_colors("set3")
     for ax, extend in zip(axs, ("both", "neither")):
         ax.pcolor(data, extend=extend, colors=colors, colorbar="b")
@@ -317,7 +322,7 @@ def test_qualitative_colormaps_1():
 @pytest.mark.mpl_image_compare
 def test_qualitative_colormaps_2():
     fig, axs = uplt.subplots(ncols=2)
-    data = state.rand(5, 5)
+    data = np.random.rand(5, 5)
     cmap = uplt.Colormap("set3")
     cmap.set_under("black")  # does not overwrite
     for ax, extend in zip(axs, ("both", "neither")):
@@ -332,7 +337,7 @@ def test_segmented_norm():
     """
     fig, ax = uplt.subplots()
     ax.pcolor(
-        state.rand(5, 5) * 10,
+        np.random.rand(5, 5) * 10,
         discrete=False,
         norm="segmented",
         norm_kw={"levels": [0, 2, 10]},
@@ -348,9 +353,9 @@ def test_triangular_functions():
     """
     fig, ax = uplt.subplots()
     N = 30
-    y = state.rand(N) * 20
-    x = state.rand(N) * 50
-    da = xr.DataArray(state.rand(N), dims=("x",), coords={"x": x, "y": ("x", y)})
+    y = np.random.rand(N) * 20
+    x = np.random.rand(N) * 50
+    da = xr.DataArray(np.random.rand(N), dims=("x",), coords={"x": x, "y": ("x", y)})
     ax.tricontour(da.x, da.y, da, labels=True)
     return fig
 
@@ -362,7 +367,7 @@ def test_colorbar_extends():
     """
     # Ensure that the colorbars are not showing artifacts on the ticks. In the past extend != neither showed ghosting on the ticks. This occured after a manual draw after the colorbar was created.
     fig, ax = uplt.subplots(nrows=2, ncols=2, share=False)
-    data = state.rand(20, 20)
+    data = np.random.rand(20, 20)
     levels = np.linspace(0, 1, 11)
     extends = ["neither", "both", "min", "max"]
     for extend, axi in zip(extends, ax):

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -6,8 +6,6 @@ import numpy as np
 import pytest
 import ultraplot as uplt
 
-state = np.random.RandomState(51423)
-
 
 def test_axis_access():
     # attempt to access the ax object 2d and linearly
@@ -172,7 +170,7 @@ def test_twin_axes_3():
     axs[-1].spines["right"].set_position(("axes", 1.2))
     colors = ("Green", "Red", "Blue")
     for ax, color in zip(axs, colors):
-        data = state.random(1) * state.random(10)
+        data = np.random.random(1) * np.random.random(10)
         ax.plot(data, marker="o", linestyle="none", color=color)
         ax.format(ylabel="%s Thing" % color, ycolor=color)
     axs[0].format(xlabel="xlabel")

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -6,8 +6,6 @@ import numpy as np
 import pytest
 import ultraplot as uplt
 
-state = np.random.RandomState(51423)
-
 
 @pytest.mark.mpl_image_compare
 def test_outer_align():
@@ -57,7 +55,7 @@ def test_discrete_ticks():
     Test `DiscreteLocator`.
     """
     levels = uplt.arange(0, 2, 0.1)
-    data = state.rand(5, 5) * 2
+    data = np.random.rand(5, 5) * 2
     fig, axs = uplt.subplots(share=False, ncols=2, nrows=2, refwidth=2)
     for i, ax in enumerate(axs):
         cmd = ax.contourf if i // 2 == 0 else ax.pcolormesh
@@ -74,19 +72,19 @@ def test_discrete_vs_fixed():
     mappable ticks and `FixedLocator` otherwise.
     """
     fig, axs = uplt.subplots(ncols=2, nrows=3, refwidth=1.3, share=False)
-    axs[0].plot(state.rand(10, 5), labels=list("xyzpq"), colorbar="b")  # fixed
-    axs[1].plot(state.rand(10, 5), labels=np.arange(5), colorbar="b")  # discrete
+    axs[0].plot(np.random.rand(10, 5), labels=list("xyzpq"), colorbar="b")  # fixed
+    axs[1].plot(np.random.rand(10, 5), labels=np.arange(5), colorbar="b")  # discrete
     axs[2].contourf(
-        state.rand(10, 10),
+        np.random.rand(10, 10),
         colorbar="b",
         colorbar_kw={"ticklabels": list("xyzpq")},  # fixed
     )
-    axs[3].contourf(state.rand(10, 10), colorbar="b")  # discrete
+    axs[3].contourf(np.random.rand(10, 10), colorbar="b")  # discrete
     axs[4].pcolormesh(
-        state.rand(10, 10) * 20, colorbar="b", levels=[0, 2, 4, 6, 8, 10, 15, 20]
+        np.random.rand(10, 10) * 20, colorbar="b", levels=[0, 2, 4, 6, 8, 10, 15, 20]
     )  # fixed
     axs[5].pcolormesh(
-        state.rand(10, 10) * 20, colorbar="b", levels=uplt.arange(0, 20, 2)
+        np.random.rand(10, 10) * 20, colorbar="b", levels=uplt.arange(0, 20, 2)
     )  # discrete
     return fig
 
@@ -97,8 +95,7 @@ def test_uneven_levels():
     Test even and uneven levels with discrete cmap. Ensure minor ticks are disabled.
     """
     N = 20
-    state = np.random.RandomState(51423)
-    data = np.cumsum(state.rand(N, N), axis=1) * 12
+    data = np.cumsum(np.random.rand(N, N), axis=1) * 12
     colors = [
         "white",
         "indigo1",
@@ -140,11 +137,11 @@ def test_on_the_fly_mappable():
 
     # Passing labels to plot function.
     fig, ax = uplt.subplots()
-    ax.scatter(state.rand(10, 4), labels=["foo", "bar", "baz", "xyz"], colorbar="b")
+    ax.scatter(np.random.rand(10, 4), labels=["foo", "bar", "baz", "xyz"], colorbar="b")
 
     # Passing string value lists. This helps complete the analogy with legend 'labels'.
     fig, ax = uplt.subplots()
-    hs = ax.line(state.rand(20, 5))
+    hs = ax.line(np.random.rand(20, 5))
     ax.colorbar(hs, loc="b", values=["abc", "def", "ghi", "pqr", "xyz"])
     return fig
 
@@ -161,8 +158,7 @@ def test_inset_colorbars():
     # Colorbars from lines
     fig = uplt.figure(share=False, refwidth=2)
     ax = fig.subplot(121)
-    state = np.random.RandomState(51423)
-    data = 1 + (state.rand(12, 10) - 0.45).cumsum(axis=0)
+    data = 1 + (np.random.rand(12, 10) - 0.45).cumsum(axis=0)
     cycle = uplt.Cycle("algae")
     hs = ax.line(
         data,
@@ -208,7 +204,7 @@ def test_segmented_norm_center():
     """
     fig, ax = uplt.subplots()
     cmap = uplt.Colormap("NegPos", cut=0.1)
-    data = state.rand(10, 10) * 10 - 2
+    data = np.random.rand(10, 10) * 10 - 2
     levels = [-4, -3, -2, -1, 0, 1, 2, 4, 8, 16, 32, 64, 128]
     norm = uplt.SegmentedNorm(levels, vcenter=0, fair=1)
     ax.pcolormesh(data, levels=levels, norm=norm, cmap=cmap, colorbar="b")
@@ -221,7 +217,7 @@ def test_segmented_norm_ticks():
     Ensure segmented norm ticks show up in center when `values` are passed.
     """
     fig, ax = uplt.subplots()
-    data = state.rand(10, 10) * 10
+    data = np.random.rand(10, 10) * 10
     values = (1, 5, 5.5, 6, 10)
     ax.contourf(
         data,
@@ -238,7 +234,7 @@ def test_reversed_levels():
     Test negative levels with a discrete norm and segmented norm.
     """
     fig, axs = uplt.subplots(ncols=4, nrows=2, refwidth=1.8)
-    data = state.rand(20, 20).cumsum(axis=0)
+    data = np.random.rand(20, 20).cumsum(axis=0)
     i = 0
     for stride in (1, -1):
         for key in ("levels", "values"):
@@ -257,7 +253,7 @@ def test_reversed_levels():
 def test_minor_override():
     """Test minor ticks override."""
     # Setting a custom minor tick should override the settings. Here we set the ticks to 1 and the minorticks to half that. We then check that the minor ticks are set correctly
-    data = state.rand(10, 10)
+    data = np.random.rand(10, 10)
     left, right, minor, n = 0, 1, 0.05, 11
     levels = np.linspace(left, right, n)
     fig, ax = uplt.subplots()

--- a/ultraplot/tests/test_format.py
+++ b/ultraplot/tests/test_format.py
@@ -5,8 +5,6 @@ Test format and rc behavior.
 import locale, numpy as np, ultraplot as uplt, pytest
 import warnings
 
-state = np.random.RandomState(51423)
-
 
 # def test_colormap_assign():
 #     """
@@ -83,7 +81,7 @@ def test_multi_formatting():
     Support formatting in multiple projections.
     """
     fig, axs = uplt.subplots(ncols=2, proj=("cart", "cyl"))
-    axs[0].pcolormesh(state.rand(5, 5))
+    axs[0].pcolormesh(np.random.rand(5, 5))
     fig.format(
         land=1,
         labels=1,
@@ -247,7 +245,7 @@ def test_spine_side():
     Test automatic spine selection when passing `xspineloc` or `yspineloc`.
     """
     fig, ax = uplt.subplots()
-    ax.plot(uplt.arange(-5, 5), (10 * state.rand(11, 5) - 5).cumsum(axis=0))
+    ax.plot(uplt.arange(-5, 5), (10 * np.random.rand(11, 5) - 5).cumsum(axis=0))
     ax.format(xloc="bottom", yloc="zero")
     ax.alty(loc="right")
     return fig
@@ -316,7 +314,7 @@ def test_tick_labels():
     """
     import pandas as pd
 
-    data = state.rand(5, 3)
+    data = np.random.rand(5, 3)
     data = pd.DataFrame(data, index=["foo", "bar", "baz", "bat", "bot"])
     fig, axs = uplt.subplots(abc="A.", abcloc="ul", ncols=2, refwidth=3, span=False)
     for i, ax in enumerate(axs):

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -50,8 +50,7 @@ def test_drawing_in_projection_without_globe():
     offset = -40
     lon = plt.arange(offset, 360 + offset - 1, 60)
     lat = plt.arange(-60, 60 + 1, 30)
-    state = np.random.RandomState(51423)
-    data = state.rand(len(lat), len(lon))
+    data = np.random.rand(len(lat), len(lon))
 
     globe = False
     string = "with" if globe else "without"
@@ -86,8 +85,7 @@ def test_drawing_in_projection_with_globe():
     offset = -40
     lon = plt.arange(offset, 360 + offset - 1, 60)
     lat = plt.arange(-60, 60 + 1, 30)
-    state = np.random.RandomState(51423)
-    data = state.rand(len(lat), len(lon))
+    data = np.random.rand(len(lat), len(lon))
 
     globe = True
     string = "with" if globe else "without"

--- a/ultraplot/tests/test_imshow.py
+++ b/ultraplot/tests/test_imshow.py
@@ -13,11 +13,10 @@ def setup_mpl():
 @pytest.mark.mpl_image_compare
 def test_standardized_input():
     # Sample data
-    state = np.random.RandomState(51423)
     x = y = np.array([-10, -5, 0, 5, 10])
     xedges = plt.edges(x)
     yedges = plt.edges(y)
-    data = state.rand(y.size, x.size)  # "center" coordinates
+    data = np.random.rand(y.size, x.size)  # "center" coordinates
     lim = (np.min(xedges), np.max(xedges))
 
     with plt.rc.context({"cmap": "Grays", "cmap.levels": 21}):
@@ -48,10 +47,9 @@ def test_standardized_input():
 def test_inbounds_data():
     # Sample data
     cmap = "turku_r"
-    state = np.random.RandomState(51423)
     N = 80
     x = y = np.arange(N + 1)
-    data = 10 + (state.normal(0, 3, size=(N, N))).cumsum(axis=0).cumsum(axis=1)
+    data = 10 + (np.random.normal(0, 3, size=(N, N))).cumsum(axis=0).cumsum(axis=1)
     xlim = ylim = (0, 25)
 
     # Plot the data
@@ -90,8 +88,7 @@ def test_inbounds_data():
 @pytest.mark.mpl_image_compare
 def test_colorbar():
     # Sample data
-    state = np.random.RandomState(51423)
-    data = 10 + state.normal(0, 1, size=(33, 33)).cumsum(axis=0).cumsum(axis=1)
+    data = 10 + np.random.normal(0, 1, size=(33, 33)).cumsum(axis=0).cumsum(axis=1)
 
     # Figure
     fig, axs = plt.subplots([[1, 1, 2, 2], [0, 3, 3, 0]], ref=3, refwidth=2.3)

--- a/ultraplot/tests/test_integration.py
+++ b/ultraplot/tests/test_integration.py
@@ -7,8 +7,6 @@ import xarray as xr
 import ultraplot as uplt, pytest
 import pint
 
-state = np.random.RandomState(51423)
-
 
 @pytest.mark.mpl_image_compare
 def test_pint_quantities():
@@ -20,10 +18,10 @@ def test_pint_quantities():
     fig, ax = uplt.subplots()
     ax.plot(
         np.arange(10),
-        state.rand(10) * ureg.km,
+        np.random.rand(10) * ureg.km,
         "C0",
         np.arange(10),
-        state.rand(10) * ureg.m * 1e2,
+        np.random.rand(10) * ureg.m * 1e2,
         "C1",
     )
     return fig
@@ -37,7 +35,7 @@ def test_data_keyword():
     N = 10
     M = 20
     ds = xr.Dataset(
-        {"z": (("x", "y"), state.rand(N, M))},
+        {"z": (("x", "y"), np.random.rand(N, M))},
         coords={
             "x": ("x", np.arange(N) * 10, {"long_name": "longitude"}),
             "y": ("y", np.arange(M) * 5, {"long_name": "latitude"}),
@@ -57,14 +55,14 @@ def test_keep_guide_labels():
     legend subsequently.
     """
     fig, ax = uplt.subplots()
-    df = pd.DataFrame(state.rand(5, 5))
+    df = pd.DataFrame(np.random.rand(5, 5))
     df.name = "variable"
     m = ax.pcolor(df)
     ax.colorbar(m)
 
     fig, ax = uplt.subplots()
     for k in ("foo", "bar", "baz"):
-        s = pd.Series(state.rand(5), index=list("abcde"), name=k)
+        s = pd.Series(np.random.rand(5), index=list("abcde"), name=k)
         ax.plot(
             s,
             legend="ul",
@@ -89,7 +87,7 @@ def test_seaborn_swarmplot():
     ax = fig.subplot()
     sns.swarmplot(ax=ax, x="day", y="total_bill", data=tips, palette="cubehelix")
     # fig, ax = uplt.subplots()
-    # sns.swarmplot(y=state.normal(size=100), ax=ax)
+    # sns.swarmplot(y=np.random.normal(size=100), ax=ax)
     return fig
 
 
@@ -99,8 +97,8 @@ def test_seaborn_hist():
     Test seaborn histograms.
     """
     fig, axs = uplt.subplots(ncols=2, nrows=2)
-    sns.histplot(state.normal(size=100), ax=axs[0])
-    sns.kdeplot(x=state.rand(100), y=state.rand(100), ax=axs[1])
+    sns.histplot(np.random.normal(size=100), ax=axs[0])
+    sns.kdeplot(x=np.random.rand(100), y=np.random.rand(100), ax=axs[1])
     penguins = sns.load_dataset("penguins")
     sns.histplot(
         data=penguins, x="flipper_length_mm", hue="species", multiple="stack", ax=axs[2]
@@ -145,5 +143,5 @@ def test_seaborn_heatmap():
     Test seaborn heatmaps. This should work thanks to backwards compatibility support.
     """
     fig, ax = uplt.subplots()
-    sns.heatmap(state.normal(size=(50, 50)), ax=ax[0])
+    sns.heatmap(np.random.normal(size=(50, 50)), ax=ax[0])
     return fig

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -4,8 +4,6 @@ Test legends.
 """
 import numpy as np, pandas as pd, ultraplot as uplt, pytest
 
-state = np.random.RandomState(51423)
-
 
 @pytest.mark.mpl_image_compare
 def test_auto_legend():
@@ -13,12 +11,12 @@ def test_auto_legend():
     Test retrieval of legends from panels, insets, etc.
     """
     fig, ax = uplt.subplots()
-    ax.line(state.rand(5, 3), labels=list("abc"))
+    ax.line(np.random.rand(5, 3), labels=list("abc"))
     px = ax.panel_axes("right", share=False)
-    px.linex(state.rand(5, 3), labels=list("xyz"))
+    px.linex(np.random.rand(5, 3), labels=list("xyz"))
     # px.legend(loc='r')
     ix = ax.inset_axes((-0.2, 0.8, 0.5, 0.5), zoom=False)
-    ix.line(state.rand(5, 2), labels=list("pq"))
+    ix.line(np.random.rand(5, 2), labels=list("pq"))
     ax.legend(loc="b", order="F", edgecolor="red9", edgewidth=3)
     return fig
 
@@ -44,7 +42,7 @@ def test_centered_legends():
     """
     # Basic centered legends
     fig, axs = uplt.subplots(ncols=2, nrows=2, axwidth=2)
-    hs = axs[0].plot(state.rand(10, 6))
+    hs = axs[0].plot(np.random.rand(10, 6))
     locs = ["l", "t", "r", "uc", "ul", "ll"]
     locs = ["l", "t", "uc", "ll"]
     labels = ["a", "bb", "ccc", "ddddd", "eeeeeeee", "fffffffff"]
@@ -53,7 +51,7 @@ def test_centered_legends():
 
     # Pass centered legends with keywords or list-of-list input.
     fig, ax = uplt.subplots()
-    hs = ax.plot(state.rand(10, 5), labels=list("abcde"))
+    hs = ax.plot(np.random.rand(10, 5), labels=list("abcde"))
     ax.legend(hs, center=True, loc="b")
     ax.legend(hs + hs[:1], loc="r", ncol=1)
     ax.legend([hs[:2], hs[2:], hs[0]], loc="t")
@@ -92,9 +90,9 @@ def test_contour_legend_with_label():
 
     fig, axs = uplt.subplots(ncols=2)
     ax = axs[0]
-    ax.contour(state.rand(5, 5), color="k", label=label, legend="b")
+    ax.contour(np.random.rand(5, 5), color="k", label=label, legend="b")
     ax = axs[1]
-    ax.pcolor(state.rand(5, 5), label=label, legend="b")
+    ax.pcolor(np.random.rand(5, 5), label=label, legend="b")
     return fig
 
 
@@ -103,14 +101,12 @@ def test_contour_legend_without_label():
     """
     Support contour element labels. If has no label should trigger warning.
     """
-    figs = []
     label = None
-
     fig, axs = uplt.subplots(ncols=2)
     ax = axs[0]
-    ax.contour(state.rand(5, 5), color="k", label=label, legend="b")
+    ax.contour(np.random.rand(5, 5), color="k", label=label, legend="b")
     ax = axs[1]
-    ax.pcolor(state.rand(5, 5), label=label, legend="b")
+    ax.pcolor(np.random.rand(5, 5), label=label, legend="b")
     return fig
 
 
@@ -119,10 +115,10 @@ def test_histogram_legend():
     """
     Support complex histogram legends.
     """
-    uplt.rc.inlinefmt = "svg"
+    uplt.rc.inlineformat = "svg"
     fig, ax = uplt.subplots()
     res = ax.hist(
-        state.rand(500, 2), 4, labels=("label", "other"), edgefix=True, legend="b"
+        np.random.rand(500, 2), 4, labels=("label", "other"), edgefix=True, legend="b"
     )
     ax.legend(res, loc="r", ncol=1)  # should issue warning after ignoring numpy arrays
     df = pd.DataFrame(
@@ -145,12 +141,12 @@ def test_multiple_calls():
     Test successive plotting additions to guides.
     """
     fig, ax = uplt.subplots()
-    ax.pcolor(state.rand(10, 10), colorbar="b")
-    ax.pcolor(state.rand(10, 5), cmap="grays", colorbar="b")
-    ax.pcolor(state.rand(10, 5), cmap="grays", colorbar="b")
+    ax.pcolor(np.random.rand(10, 10), colorbar="b")
+    ax.pcolor(np.random.rand(10, 5), cmap="grays", colorbar="b")
+    ax.pcolor(np.random.rand(10, 5), cmap="grays", colorbar="b")
 
     fig, ax = uplt.subplots()
-    data = state.rand(10, 5)
+    data = np.random.rand(10, 5)
     for i in range(data.shape[1]):
         ax.plot(data[:, i], colorbar="b", label=f"x{i}", colorbar_kw={"label": "hello"})
     return fig
@@ -164,8 +160,8 @@ def test_tuple_handles():
     from matplotlib import legend_handler
 
     fig, ax = uplt.subplots(refwidth=3, abc="A.", abcloc="ul", span=False)
-    patches = ax.fill_between(state.rand(10, 3), stack=True)
-    lines = ax.line(1 + 0.5 * (state.rand(10, 3) - 0.5).cumsum(axis=0))
+    patches = ax.fill_between(np.random.rand(10, 3), stack=True)
+    lines = ax.line(1 + 0.5 * (np.random.rand(10, 3) - 0.5).cumsum(axis=0))
     # ax.legend([(handles[0], lines[1])], ['joint label'], loc='bottom', queue=True)
     for hs in (lines, patches):
         ax.legend(
@@ -187,9 +183,9 @@ def test_legend_col_spacing():
     Test legend column spacing.
     """
     fig, ax = uplt.subplots()
-    ax.plot(state.rand(10), label="short")
-    ax.plot(state.rand(10), label="longer label")
-    ax.plot(state.rand(10), label="even longer label")
+    ax.plot(np.random.rand(10), label="short")
+    ax.plot(np.random.rand(10), label="longer label")
+    ax.plot(np.random.rand(10), label="even longer label")
     for idx in range(3):
         spacing = f"{idx}em"
         if idx == 2:

--- a/ultraplot/tests/test_projections.py
+++ b/ultraplot/tests/test_projections.py
@@ -8,8 +8,6 @@ import numpy as np
 import ultraplot as uplt
 import pytest
 
-state = np.random.RandomState(51423)
-
 
 @pytest.mark.mpl_image_compare
 def test_aspect_ratios():
@@ -59,7 +57,7 @@ def test_cartopy_contours():
     ax.coastlines()
     x = np.linspace(-180, 180, N)
     y = np.linspace(-90, 90, N)
-    z = state.rand(N, N) * 10 - 5
+    z = np.random.rand(N, N) * 10 - 5
     m = ax.contourf(
         x,
         y,
@@ -77,7 +75,7 @@ def test_cartopy_contours():
     m = ax.contourf(
         np.linspace(0, 180, N),
         np.linspace(0, 90, N)[1::2],
-        state.rand(N // 2, N) * 10 + 5,
+        np.random.rand(N // 2, N) * 10 + 5,
         cmap="BuRd",
         transform=uplt.PlateCarree(),
         edgefix=False,

--- a/ultraplot/tests/test_statistical_plotting.py
+++ b/ultraplot/tests/test_statistical_plotting.py
@@ -8,10 +8,11 @@ import pytest
 def test_statistical_boxplot():
     # Sample data
     N = 500
-    state = np.random.RandomState(51423)
-    data1 = state.normal(size=(N, 5)) + 2 * (state.rand(N, 5) - 0.5) * np.arange(5)
+    data1 = np.random.normal(size=(N, 5)) + 2 * (
+        np.random.rand(N, 5) - 0.5
+    ) * np.arange(5)
     data1 = pd.DataFrame(data1, columns=pd.Index(list("abcde"), name="label"))
-    data2 = state.rand(100, 7)
+    data2 = np.random.rand(100, 7)
     data2 = pd.DataFrame(data2, columns=pd.Index(list("abcdefg"), name="label"))
 
     # Figure
@@ -39,9 +40,8 @@ def test_statistical_boxplot():
 def test_panel_dist():
     # Sample data
     N = 500
-    state = np.random.RandomState(51423)
-    x = state.normal(size=(N,))
-    y = state.normal(size=(N,))
+    x = np.random.normal(size=(N,))
+    y = np.random.normal(size=(N,))
     bins = uplt.arange(-3, 3, 0.25)
 
     # Histogram with marginal distributions


### PR DESCRIPTION
This PR sets the seed prior to running any test. This prevents ordering effect if we refactor the tests down the line and ensures that each test is run from the same seed.

Note this will crash all the current baselines but this is fine.