### PR TITLE
Move warning inside pytest config

### DIFF
--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -3,16 +3,6 @@ from pathlib import Path
 import warnings
 
 
-def pytest_configure():
-    # Surpress ultraplot config loading which mpl does not recognize
-    warnings.filterwarnings(
-        "ignore",
-        message=r"Bad key .* in file .*ultraplot\.yml",
-        category=UserWarning,
-        module="matplotlib",
-    )
-
-
 @pytest.fixture(autouse=True)
 def _reset_numpy_seed():
     """
@@ -77,6 +67,14 @@ class StoreFailedMplPlugin:
 # Register the plugin if the option is used
 def pytest_configure(config):
     print("Configuring StoreFailedMplPlugin")
+    # Surpress ultraplot config loading which mpl does not recognize
+    if rc_file := config.getoption("--mpl-default-style", None):
+        warnings.filterwarnings(
+            "ignore",
+            message=rf"Bad key .* in file .*" + rc_file,
+            category=UserWarning,
+            module="matplotlib",
+        )
     try:
         if config.getoption("--store-failed-only", False):
             print("Registering StoreFailedMplPlugin")

--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -2,10 +2,14 @@ import os, shutil, pytest, re, numpy as np
 from pathlib import Path
 import warnings
 
-warnings.simplefilter("ignore")
-warnings.filterwarnings(
-    "ignore", message="Bad key .* in file .*ultraplot.yml", module="matplotlib"
-)
+
+def pytest_configure():
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Bad key .* in file .*ultraplot\.yml",
+        category=UserWarning,
+        module="matplotlib",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -4,6 +4,7 @@ import warnings
 
 
 def pytest_configure():
+    # Surpress ultraplot config loading which mpl does not recognize
     warnings.filterwarnings(
         "ignore",
         message=r"Bad key .* in file .*ultraplot\.yml",


### PR DESCRIPTION
This PR moves the filter inside a pytest function such that it suppresses unrecognized rc parameters that are native to ultraplot but not matplotlib