### PR TITLE
Add network plotting to UltraPlot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,6 +236,7 @@ intersphinx_mapping = {
     "basemap": ("https://matplotlib.org/basemap/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable/", None),
+    "networkx": ("https://networkx.org/documentation/stable/", None),
 }
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,6 +130,7 @@ For more details, check the full :doc:`User guide <usage>` and :doc:`API Referen
    basics
    subplots
    cartesian
+   networks
    projections
    colorbars_legends
    insets_panels

--- a/docs/networks.py
+++ b/docs/networks.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+# %% [raw] raw_mimetype="text/restructuredtext"
+# Networks
+# ========
+
+# Visualizing Connections: Graphs!
+# ================================
+# Networks form a core aspect of any disciplines of science from engineering to biology. UltraPlot supports plotting networks using `networkx <https://networkx.org/>`__.  It provides an intuitive interface for plotting networks using :func:`~ultraplot.axes.PlotAxes.graph` to plot networks. Plot customization can be passed to the networkx backend, see for full details their documentation.
+# Layouts can be passed using strings, dicts or functions as long as they are compatible with networkx's layout functions.
+
+# Minimal Example
+# ===============
+# To plot a graph, use :func:`~ultraplot.axes.PlotAxes.graph`. You need to merely provide a graph and ultraplot will take care of the rest. UltraPlot will automatically style the layout to give sensible default. Every setting can be overidden if the user wants to customize the nodes, edges, or layout.
+# %%
+import networkx as nx, ultraplot as uplt, numpy as np
+
+g = nx.path_graph(10)
+A = nx.to_numpy_array(g)
+el = np.array(g.edges())
+
+fig, ax = uplt.subplots(ncols=3, refheight="3cm")
+ax[0].graph(g)  # We can plot graphs
+ax[1].graph(A)  # Or adjacency matrices and edgeslists
+ax[2].graph(el)
+ax.format(title=["From Graph", "From Adjacency Matrix", "From Edgelist"])
+uplt.show()
+
+
+# %% [raw] raw_mimetype="text/restructuredtext"
+# More Advanced Customization
+# ===========================
+# To customize a network plot, you can pass a dictionary of parameters to the :func:`~ultraplot.axes.PlotAxes.graph` function. These parameters are passed to the networkx backend, so you can refer to their documentation for more details. A more complicated example is shown below.
+# %%
+import networkx as nx, ultraplot as uplt, numpy as np
+
+# Generate some mock data
+g = nx.gn_graph(n=100).to_undirected()
+x = np.linspace(0, 10, 300)
+y = np.sin(x) + np.cos(10 * x) + np.random.randn(*x.shape) * 0.3
+layout = [[1, 2, 3], [1, 4, 5]]
+fig, ax = uplt.subplots(layout, share=0, figsize=(10, 4))
+
+# Plot network on an inset
+inax = ax[0].inset_axes([0.75, 0.75, 0.23, 0.23], zoom=False)
+ax[0].plot(x, y)
+ax[0].plot(x, y - np.random.rand(*x.shape))
+ax[0].format(xlabel="time $(t)$", ylabel="Amplitude", title="Inset example")
+inax.graph(
+    g,
+    layout="forceatlas2",
+    spines=True,
+    facecolor="white",
+    node_kw=dict(node_size=0.2),
+)
+
+# Show off different way of parsing inputs. When None is set it defaults to a Kamada Kawai
+circular = nx.circular_layout(g)
+layouts = [None, nx.arf_layout, circular, "random"]
+names = ["Kamada Kawai", "Arf layout", "Circular", "Random"]
+cmaps = ["viko", "bamo", "roma", "fes"]
+for axi, layout, name, cmap in zip(ax[1:], layouts, names, cmaps):
+    cmap = uplt.colormaps.get_cmap(cmap)
+    colors = cmap(np.linspace(0, 1, g.number_of_nodes(), 0))
+    axi.graph(g, layout=layout, node_kw=dict(node_color=colors))
+    axi.set_title(name)
+uplt.show()

--- a/docs/networks.py
+++ b/docs/networks.py
@@ -23,7 +23,7 @@
 
 # Minimal Example
 # ===============
-# To plot a graph, use :func:`~ultraplot.axes.PlotAxes.graph`. You need to merely provide a graph and ultraplot will take care of the rest. UltraPlot will automatically style the layout to give sensible default. Every setting can be overidden if the user wants to customize the nodes, edges, or layout.
+# To plot a graph, use :func:`~ultraplot.axes.PlotAxes.graph`. You need to merely provide a graph and UltraPlot will take care of the rest. UltraPlot will automatically style the layout to give sensible default. Every setting can be overidden if the user wants to customize the nodes, edges, or layout.
 # %%
 import networkx as nx, ultraplot as uplt, numpy as np
 

--- a/docs/networks.py
+++ b/docs/networks.py
@@ -24,6 +24,8 @@
 # Minimal Example
 # ===============
 # To plot a graph, use :func:`~ultraplot.axes.PlotAxes.graph`. You need to merely provide a graph and UltraPlot will take care of the rest. UltraPlot will automatically style the layout to give sensible default. Every setting can be overidden if the user wants to customize the nodes, edges, or layout.
+#
+# By default, UltraPlot automatically styles the plot by removing the background and spines, and adjusting the layout to fit within a normalized [0,1] coordinate box. It also applies an equal aspect ratio to ensure square dimensions, which is ideal for the default circular markers. Additional customization—such as modifying labels, legends, axis limits, and more—can be done using :func:~ultraplot.axes.Cartesian.format to override the default styling.
 # %%
 import networkx as nx, ultraplot as uplt, numpy as np
 

--- a/docs/networks.py
+++ b/docs/networks.py
@@ -56,7 +56,7 @@ layout = [[1, 2, 3], [1, 4, 5]]
 fig, ax = uplt.subplots(layout, share=0, figsize=(10, 4))
 
 # Plot network on an inset
-inax = ax[0].inset_axes([0.75, 0.75, 0.23, 0.23], zoom=False)
+inax = ax[0].inset_axes([0.25, 0.75, 0.5, 0.5], zoom=False)
 ax[0].plot(x, y)
 ax[0].plot(x, y - np.random.rand(*x.shape))
 ax[0].format(xlabel="time $(t)$", ylabel="Amplitude", title="Inset example")
@@ -64,6 +64,11 @@ inax.graph(
     g,
     layout="forceatlas2",
     node_kw=dict(node_size=0.2),
+)
+inax.format(
+    facecolor="white",
+    xspineloc="both",
+    yspineloc="both",
 )
 
 # Show off different way of parsing inputs. When None is set it defaults to a Kamada Kawai

--- a/docs/networks.py
+++ b/docs/networks.py
@@ -42,7 +42,7 @@ uplt.show()
 # %% [raw] raw_mimetype="text/restructuredtext"
 # More Advanced Customization
 # ===========================
-# To customize a network plot, you can pass a dictionary of parameters to the :func:`~ultraplot.axes.PlotAxes.graph` function. These parameters are passed to the networkx backend, so you can refer to their documentation for more details. A more complicated example is shown below.
+# To customize a network plot, you can pass a dictionary of parameters to the :func:`~ultraplot.axes.PlotAxes.graph` function. These parameters are passed to the networkx backend, so you can refer to their documentation for more details (:func:`~networkx.draw`, :func:`~networkx.draw_networkx`, :func:`~networkx.draw_networkx_nodes`, :func:`~networkx.draw_networkx_edges`, :func:`~networkx.draw_networkx_labels`). A more complicated example is shown below.
 # %%
 import networkx as nx, ultraplot as uplt, numpy as np
 

--- a/docs/networks.py
+++ b/docs/networks.py
@@ -63,8 +63,6 @@ ax[0].format(xlabel="time $(t)$", ylabel="Amplitude", title="Inset example")
 inax.graph(
     g,
     layout="forceatlas2",
-    spines=True,
-    facecolor="white",
     node_kw=dict(node_size=0.2),
 )
 

--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,6 @@ dependencies:
   - basemap >=1.4.1
   - pre-commit
   - sphinx-design
+  - networkx
   - pip:
       - git+https://github.com/ultraplot/UltraTheme.git

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -7,6 +7,7 @@ import copy
 import inspect
 import re
 from numbers import Integral
+from typing import Union, Iterable
 
 import matplotlib.axes as maxes
 import matplotlib.axis as maxis
@@ -3316,6 +3317,21 @@ class Axes(maxes.Axes):
             }
         )
         return obj
+
+    def _toggle_spines(self, spines: Union[bool, Iterable]):
+        """
+        Turns spines on or off depending on input. Spines can be a list such as ['left', 'right'] etc
+        """
+        if spines:
+            if np.iterable(spines):
+                for spine in spines:
+                    self.spines[spine].set_visible(True)
+            else:
+                for spine in self.spines.values():
+                    spine.set_visible(True)
+        else:
+            for spine in self.spines.values():
+                spine.set_visible(False)
 
     def _iter_axes(self, hidden=False, children=False, panels=True):
         """

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -8,6 +8,7 @@ import inspect
 import re
 from numbers import Integral
 from typing import Union, Iterable
+from collections.abc import Iterable as IterableType
 
 import matplotlib.axes as maxes
 import matplotlib.axis as maxis
@@ -3323,17 +3324,18 @@ class Axes(maxes.Axes):
         Turns spines on or off depending on input. Spines can be a list such as ['left', 'right'] etc
         """
         if spines:
-            if np.iterable(spines):
-                toggle_spines = {spine: True for spine in spines}
-            elif spines is bool:
-                toggler = spines
-                toggle_spines = {spine: toggler for spine in self.spines}
-            elif spines is str:
-                toggle_spines = dict(spines=True)
-            else:
-                raise ValueError(
-                    f"Invalid input for spines. Received {type(spines)} expecting iterable, string or boolean"
-                )
+            match spines:
+                case IterableType():
+                    toggle_spines = {spine: True for spine in spines}
+                case bool():
+                    toggler = spines
+                    toggle_spines = {spine: toggler for spine in self.spines}
+                case str():
+                    toggle_spines = dict(spines=True)
+                case _:
+                    raise ValueError(
+                        f"Invalid input for spines. Received {type(spines)} expecting iterable, string or boolean"
+                    )
             for side, spine in self.spines.items():
                 spine.set_visible(False)
                 if side in toggle_spines:

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3324,10 +3324,19 @@ class Axes(maxes.Axes):
         """
         if spines:
             if np.iterable(spines):
-                for spine in spines:
-                    self.spines[spine].set_visible(True)
+                toggle_spines = {spine: True for spine in spines}
+            elif spines is bool:
+                toggler = spines
+                toggle_spines = {spine: toggler for spine in self.spines}
+            elif spines is str:
+                toggle_spines = dict(spines=True)
             else:
-                for spine in self.spines.values():
+                raise ValueError(
+                    f"Invalid input for spines. Received {type(spines)} expecting iterable, string or boolean"
+                )
+            for side, spine in self.spines.items():
+                spine.set_visible(False)
+                if side in toggle_spines:
                     spine.set_visible(True)
         else:
             for spine in self.spines.values():

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3325,13 +3325,13 @@ class Axes(maxes.Axes):
         """
         if spines:
             match spines:
+                case str():
+                    toggle_spines = {spines: True}
                 case IterableType():
                     toggle_spines = {spine: True for spine in spines}
                 case bool():
                     toggler = spines
                     toggle_spines = {spine: toggler for spine in self.spines}
-                case str():
-                    toggle_spines = dict(spines=True)
                 case _:
                     raise ValueError(
                         f"Invalid input for spines. Received {type(spines)} expecting iterable, string or boolean"

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3318,7 +3318,7 @@ class Axes(maxes.Axes):
         )
         return obj
 
-    def _toggle_spines(self, spines: Union[bool, Iterable]):
+    def _toggle_spines(self, spines: Union[bool, Iterable, str]):
         """
         Turns spines on or off depending on input. Spines can be a list such as ['left', 'right'] etc
         """

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1120,6 +1120,9 @@ See also
 --------
 networkx.draw
 networkx.draw_networkx
+networkx.draw_networkx_nodes
+networkx.draw_networkx_edges
+networkx.draw_networkx_labels
 """
 
 docstring._snippet_manager["plot.graph"] = _graph_docstring

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1106,7 +1106,7 @@ aspect : {'equal', 'auto'} or float, default: 'equal'
     `'auto'` lets the axes scale independently. A float can specify a custom aspect ratio.
 facecolor : str or None, default: None
     The background color of the plot area. If ``None``, the default facecolor is used.
-spines : bool or iterable, default: False
+spines : bool, iterable or str, default: False
     Whether to show axis spines (borders around the plot). If `True`, all spines are shown.
     If an iterable is given, only the specified spines (e.g., ``['left', 'bottom']``) are displayed.
 rescale : bool, default: False
@@ -3741,7 +3741,7 @@ class PlotAxes(base.Axes):
         grid=False,
         aspect="equal",
         facecolor: Union[str, None] = None,
-        spines: Union[bool, Iterable] = False,
+        spines: Union[bool, Iterable, str] = False,
         rescale=True,
     ):
         """

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3850,7 +3850,7 @@ class PlotAxes(base.Axes):
         # Apply styling
         self.set_aspect(aspect)
         self.grid(grid)
-        self.set_facecolor("none")
+        self.set_facecolor(facecolor)
         self._toggle_spines(spines)
         return nodes, edges, labels
 

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1104,7 +1104,7 @@ grid : bool, default: False
 aspect : {'equal', 'auto'} or float, default: 'equal'
     The aspect ratio of the plot. `'equal'` ensures that the units are the same in every direction.
     `'auto'` lets the axes scale independently. A float can specify a custom aspect ratio.
-facecolor : str or None, default: None
+facecolor : str or None, default: 'none'
     The background color of the plot area. If ``None``, the default facecolor is used.
 spines : bool, iterable or str, default: False
     Whether to show axis spines (borders around the plot). If `True`, all spines are shown.
@@ -3740,7 +3740,7 @@ class PlotAxes(base.Axes):
         edges: Union[bool, Iterable] = True,
         grid=False,
         aspect="equal",
-        facecolor: Union[str, None] = None,
+        facecolor: Union[str, None] = "none",
         spines: Union[bool, Iterable, str] = False,
         rescale=True,
     ):

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3842,10 +3842,10 @@ class PlotAxes(base.Axes):
             labels = nx.draw_networkx_labels(g, pos=pos, ax=self, **label_kw)
 
         # Apply styling
-        self.set_aspect(aspect)
-        self.grid(grid)
-        self.set_facecolor(facecolor)
-        self._toggle_spines(spines)
+        self.set_aspect(rc["graph.aspect"])
+        self.grid(rc["graph.draw_grid"])
+        self.set_facecolor(rc["graph.facecolor"])
+        self._toggle_spines(rc["graph.draw_spines"])
         return nodes, edges, labels
 
     @staticmethod

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1079,6 +1079,15 @@ g : networkx.Graph
 layout : callable or dict, optional
     A layout function or a precomputed dict mapping nodes to 2D positions. If a function
     is given, it is called as ``layout(g, **layout_kw)`` to compute positions.
+nodes : bool or iterable, default: True
+    Which nodes to draw. If `True`, all nodes are drawn. If an iterable is provided, only
+    the specified nodes are included. This effectively acts as `nodelist` in :func:`networkx.draw_networkx_nodes`.
+edges : bool or iterable, default: True
+    Which edges to draw. If `True`, all edges are drawn. If an iterable of edge tuples is
+    provided, only those edges are included. This effectively acts as `edgelist` in :func:`networkx.draw_networkx_edges`.
+labels : bool or iterable, default: False
+    Whether to show node labels. If `True`, labels are drawn using node names. If an
+    iterable is given, only those nodes are labeled.
 layout_kw : dict, default: {}
     Keyword arguments passed to the layout function, if `layout` is callable.
 node_kw : dict, default: {}
@@ -1090,26 +1099,8 @@ edge_kw : dict, default: {}
 label_kw : dict, default: {}
     Additional keyword arguments passed to the label drawing function, such as font size,
     font color, background color, alignment, etc (see :func:`networkx.draw_networkx_labels`).
-labels : bool or iterable, default: False
-    Whether to show node labels. If `True`, labels are drawn using node names. If an
-    iterable is given, only those nodes are labeled.
-nodes : bool or iterable, default: True
-    Which nodes to draw. If `True`, all nodes are drawn. If an iterable is provided, only
-    the specified nodes are included. This effectively acts as `nodelist` in :func:`networkx.draw_networkx_nodes`.
-edges : bool or iterable, default: True
-    Which edges to draw. If `True`, all edges are drawn. If an iterable of edge tuples is
-    provided, only those edges are included. This effectively acts as `edgelist` in :func:`networkx.draw_networkx_edges`.
-grid : bool, default: False
-    Whether to show a background grid.
-aspect : {'equal', 'auto'} or float, default: 'equal'
-    The aspect ratio of the plot. `'equal'` ensures that the units are the same in every direction.
-    `'auto'` lets the axes scale independently. A float can specify a custom aspect ratio.
-facecolor : str or None, default: 'none'
-    The background color of the plot area. If ``None``, the default facecolor is used.
-spines : bool, iterable or str, default: False
-    Whether to show axis spines (borders around the plot). If `True`, all spines are shown.
-    If an iterable is given, only the specified spines (e.g., ``['left', 'bottom']``) are displayed.
-rescale : bool,  None, default: None. When set to none it checks for `rc["graph.rescale"]` which defaults to `True`. This performs a rescale such that the node position is within a [0, 1] x [0, 1] box.
+rescale : bool,  None, default: None.
+    When set to none it checks for `rc["graph.rescale"]` which defaults to `True`. This performs a rescale such that the node position is within a [0, 1] x [0, 1] box.
 Returns
 -------
 Nodes, edges, labels output from the networkx drawing functions.
@@ -3729,17 +3720,13 @@ class PlotAxes(base.Axes):
         self,
         g: Union["nx.Graph", np.ndarray],
         layout=None,
+        nodes: Union[None, bool, Iterable] = None,
+        edges: Union[None, bool, Iterable] = None,
+        labels: Union[None, bool, Iterable] = None,
         layout_kw={},
         node_kw={},
         edge_kw={},
         label_kw={},
-        labels: Union[None, bool, Iterable] = None,
-        nodes: Union[None, bool, Iterable] = None,
-        edges: Union[None, bool, Iterable] = None,
-        grid: Union[None, str] = None,
-        aspect: Union[None, str] = None,
-        facecolor: Union[None, str] = None,
-        spines: Union[None, bool, Iterable, str] = None,
         rescale: Union[None, bool] = None,
     ):
         """

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1082,23 +1082,23 @@ layout : callable or dict, optional
 layout_kw : dict, default: {}
     Keyword arguments passed to the layout function, if `layout` is callable.
 node_kw : dict, default: {}
-    Additional keyword arguments passed to the node drawing function. These can include
+    Additional keyword arguments passed to the node drawing function (see :func:`networkx.draw_networkx_nodes`). These can include
     size, color, edgecolor, cmap, alpha, etc., depending on the backend used.
 edge_kw : dict, default: {}
     Additional keyword arguments passed to the edge drawing function. These can include
-    width, color, style, alpha, arrows, etc.
+    width, color, style, alpha, arrows, etc (see :func:`networkx.draw_networkx_edges`).
 label_kw : dict, default: {}
     Additional keyword arguments passed to the label drawing function, such as font size,
-    font color, background color, alignment, etc.
+    font color, background color, alignment, etc (see :func:`networkx.draw_networkx_labels`).
 labels : bool or iterable, default: False
     Whether to show node labels. If `True`, labels are drawn using node names. If an
     iterable is given, only those nodes are labeled.
 nodes : bool or iterable, default: True
     Which nodes to draw. If `True`, all nodes are drawn. If an iterable is provided, only
-    the specified nodes are included.
+    the specified nodes are included. This effectively acts as `nodelist` in :func:`networkx.draw_networkx_nodes`.
 edges : bool or iterable, default: True
     Which edges to draw. If `True`, all edges are drawn. If an iterable of edge tuples is
-    provided, only those edges are included.
+    provided, only those edges are included. This effectively acts as `edgelist` in :func:`networkx.draw_networkx_edges`.
 grid : bool, default: False
     Whether to show a background grid.
 aspect : {'equal', 'auto'} or float, default: 'equal'

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3737,10 +3737,6 @@ class PlotAxes(base.Axes):
         labels = _not_none(labels, rc["graph.draw_labels"])
         nodes = _not_none(nodes, rc["graph.draw_nodes"])
         edges = _not_none(edges, rc["graph.draw_edges"])
-        grid = _not_none(grid, rc["graph.draw_grid"])
-        aspect = _not_none(aspect, rc["graph.aspect"])
-        facecolor = _not_none(facecolor, rc["graph.facecolor"])
-        spines = _not_none(spines, rc["graph.spines"])
         rescale = _not_none(rescale, rc["graph.rescale"])
 
         match g:

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3719,7 +3719,7 @@ class PlotAxes(base.Axes):
     def graph(
         self,
         g: Union["nx.Graph", np.ndarray],
-        layout=None,
+        layout: Union[str, dict, Callable] = None,
         nodes: Union[None, bool, Iterable] = None,
         edges: Union[None, bool, Iterable] = None,
         labels: Union[None, bool, Iterable] = None,

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3735,19 +3735,28 @@ class PlotAxes(base.Axes):
         node_kw={},
         edge_kw={},
         label_kw={},
-        labels: Union[bool, Iterable] = False,
-        nodes: Union[bool, Iterable] = True,
-        edges: Union[bool, Iterable] = True,
-        grid=False,
-        aspect="equal",
-        facecolor: Union[str, None] = "none",
-        spines: Union[bool, Iterable, str] = False,
-        rescale=True,
+        labels: Union[None, bool, Iterable] = None,
+        nodes: Union[None, bool, Iterable] = None,
+        edges: Union[None, bool, Iterable] = None,
+        grid: Union[None, str] = None,
+        aspect: Union[None, str] = None,
+        facecolor: Union[None, str] = None,
+        spines: Union[None, bool, Iterable, str] = None,
+        rescale: Union[None, bool] = None,
     ):
         """
         %(plot.graph)s
         """
         import networkx as nx
+
+        labels = _not_none(labels, rc["graph.draw_labels"])
+        nodes = _not_none(nodes, rc["graph.draw_nodes"])
+        edges = _not_none(edges, rc["graph.draw_edges"])
+        grid = _not_none(grid, rc["graph.draw_grid"])
+        aspect = _not_none(aspect, rc["graph.aspect"])
+        facecolor = _not_none(facecolor, rc["graph.facecolor"])
+        spines = _not_none(spines, rc["graph.spines"])
+        rescale = _not_none(rescale, rc["graph.rescale"])
 
         match g:
             case np.ndarray():

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1109,8 +1109,7 @@ facecolor : str or None, default: 'none'
 spines : bool, iterable or str, default: False
     Whether to show axis spines (borders around the plot). If `True`, all spines are shown.
     If an iterable is given, only the specified spines (e.g., ``['left', 'bottom']``) are displayed.
-rescale : bool,  None, default: None. When set to none it checks for `rc["graph.rescale"]` which defaults to `True`. This performs a rescale such that the node size is proportional to the figure size.  This attempts to prevent manual rescaling of the node_size. When `node_size` is not provided in `node_kw`, this option is ignored.
-
+rescale : bool,  None, default: None. When set to none it checks for `rc["graph.rescale"]` which defaults to `True`. This performs a rescale such that the node position is within a [0, 1] x [0, 1] box.
 Returns
 -------
 Nodes, edges, labels output from the networkx drawing functions.
@@ -3785,9 +3784,6 @@ class PlotAxes(base.Axes):
             case _:
                 pos = nx.kamada_kawai_layout(g)
 
-        # Ignore rescaling if user wants to set node_size
-        if node_kw.get("node_size", None):
-            rescale = False
         if rescale:
             # Normalize node positions to fit in a [0, 1] x [0, 1] box.
 

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1074,25 +1074,25 @@ Plot a networkx graph with flexible node, edge, and label options.
 Parameters
 ----------
 g : networkx.Graph
-    The graph object to be plotted. Can be any subclass of `networkx.Graph`, such as
-    `networkx.DiGraph` or `networkx.MultiGraph`.
+    The graph object to be plotted. Can be any subclass of :class:`networkx.Graph`, such as
+    :class:`networkx.DiGraph` or :class:`networkx.MultiGraph`.
 layout : callable or dict, optional
     A layout function or a precomputed dict mapping nodes to 2D positions. If a function
-    is given, it is called as ``layout(g, **layout_kw)`` to compute positions.
-nodes : bool or iterable, default: True
+    is given, it is called as ``layout(g, **layout_kw)`` to compute positions. See :func:`networkx.draw` for more information.
+nodes : bool or iterable, default: rc["graph.draw_nodes"]
     Which nodes to draw. If `True`, all nodes are drawn. If an iterable is provided, only
     the specified nodes are included. This effectively acts as `nodelist` in :func:`networkx.draw_networkx_nodes`.
-edges : bool or iterable, default: True
+edges : bool or iterable, default: rc["graph.draw_edges"]
     Which edges to draw. If `True`, all edges are drawn. If an iterable of edge tuples is
     provided, only those edges are included. This effectively acts as `edgelist` in :func:`networkx.draw_networkx_edges`.
-labels : bool or iterable, default: False
+labels : bool or iterable, default: `rc["graph.draw_labels`]
     Whether to show node labels. If `True`, labels are drawn using node names. If an
     iterable is given, only those nodes are labeled.
 layout_kw : dict, default: {}
-    Keyword arguments passed to the layout function, if `layout` is callable.
+    Keyword arguments passed to the layout function, if `layout` is callable, see <https://networkx.org/documentation/stable/reference/drawing.html> for more information.
 node_kw : dict, default: {}
     Additional keyword arguments passed to the node drawing function (see :func:`networkx.draw_networkx_nodes`). These can include
-    size, color, edgecolor, cmap, alpha, etc., depending on the backend used.
+    size, color, edgecolor, cmap, alpha, etc., depending on the backend used, see :func:`networkx.draw_networkx_nodes`.
 edge_kw : dict, default: {}
     Additional keyword arguments passed to the edge drawing function. These can include
     width, color, style, alpha, arrows, etc (see :func:`networkx.draw_networkx_edges`).

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1110,7 +1110,7 @@ spines : bool, iterable or str, default: False
     Whether to show axis spines (borders around the plot). If `True`, all spines are shown.
     If an iterable is given, only the specified spines (e.g., ``['left', 'bottom']``) are displayed.
 rescale : bool, default: False
-    Whether to rescale the plot to fit the data. See networkx docs for more information
+    Whether to rescale the plot to fit the data. See networkx docs for more information.
 
 Returns
 -------

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1109,8 +1109,7 @@ facecolor : str or None, default: 'none'
 spines : bool, iterable or str, default: False
     Whether to show axis spines (borders around the plot). If `True`, all spines are shown.
     If an iterable is given, only the specified spines (e.g., ``['left', 'bottom']``) are displayed.
-rescale : bool, default: False
-    Whether to rescale the plot to fit the data. See networkx docs for more information.
+rescale : bool,  None, default: None. When set to none it checks for `rc["graph.rescale"]` which defaults to `True`. This performs a rescale such that the node size is proportional to the figure size.  This attempts to prevent manual rescaling of the node_size. When `node_size` is not provided in `node_kw`, this option is ignored.
 
 Returns
 -------
@@ -3786,6 +3785,9 @@ class PlotAxes(base.Axes):
             case _:
                 pos = nx.kamada_kawai_layout(g)
 
+        # Ignore rescaling if user wants to set node_size
+        if node_kw.get("node_size", None):
+            rescale = False
         if rescale:
             # Normalize node positions to fit in a [0, 1] x [0, 1] box.
 

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1255,7 +1255,7 @@ _rc_ultraplot_table = {
         "The aspect ratio of the graph.",
     ),
     "graph.facecolor": ("none", _validate_color, "The facecolor of the graph."),
-    "graph.spines": (
+    "graph.draw_spines": (
         False,
         _validate_bool_or_iterable,
         "If ``True`` draws the spines for all the edges, otherwise only the edges that are in the iterable.",

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -310,6 +310,14 @@ def _validate_color(value, alternative=None):
         raise error
 
 
+def _validate_bool_or_iterable(value):
+    if isinstance(value, bool):
+        return _validate_bool(value)
+    elif np.isiterable(value):
+        return value
+    raise ValueError(f"{value!r} is not a valid bool or iterable of node labels.")
+
+
 def _validate_fontprops(s):
     """
     Parse font property with support for ``'regular'`` placeholder.
@@ -1219,6 +1227,43 @@ _rc_ultraplot_table = {
         _validate_bool,
         "If ``True`` (the default), polar `~ultraplot.axes.GeoAxes` like ``'npstere'`` "
         "and ``'spstere'`` are bounded with circles rather than squares.",
+    ),
+    # Graphs
+    "graph.draw_nodes": (
+        True,
+        _validate_bool_or_iterable,
+        "If ``True`` draws the nodes for all the nodes, otherwise only the nodes that are in the iterable.",
+    ),
+    "graph.draw_edges": (
+        True,
+        _validate_bool_or_iterable,
+        "If ``True`` draws the edges for all the edges, otherwise only the edges that are in the iterable.",
+    ),
+    "graph.draw_labels": (
+        False,
+        _validate_bool_or_iterable,
+        "If ``True`` draws the labels for all the nodes, otherwise only the nodes that are in the iterable.",
+    ),
+    "graph.draw_grid": (
+        False,
+        _validate_bool,
+        "If ``True`` draws the grid for all the edges, otherwise only the edges that are in the iterable.",
+    ),
+    "graph.aspect": (
+        "equal",
+        _validate_belongs("equal", "auto"),
+        "The aspect ratio of the graph.",
+    ),
+    "graph.facecolor": ("none", _validate_color, "The facecolor of the graph."),
+    "graph.spines": (
+        False,
+        _validate_bool_or_iterable,
+        "If ``True`` draws the spines for all the edges, otherwise only the edges that are in the iterable.",
+    ),
+    "graph.rescale": (
+        True,
+        _validate_bool,
+        "If ``True`` rescales the graph to fit the data.",
     ),
     # Gridlines
     # NOTE: Here 'grid' and 'gridminor' or *not* aliases for native 'axes.grid' and

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -523,3 +523,59 @@ def test_heatmap_labels():
     fig, ax = uplt.subplots()
     ax.heatmap(x, labels=True)
     return fig
+
+
+@pytest.mark.mpl_image_compare()
+def test_networks():
+    """
+    Create a baseline network graph that tests
+    a few features. It is not the prettiest graphs but highlights what the functions can do.
+    """
+    import networkx as nx
+
+    graphs = [
+        nx.karate_club_graph(),
+        nx.florentine_families_graph(),
+        nx.davis_southern_women_graph(),
+        nx.les_miserables_graph(),
+        nx.krackhardt_kite_graph(),
+    ]
+    facecolors = ["#CC7722", "#254441", "#43AA8B", "#EF3054", "#F7F7FF"]
+    positions = [
+        (0.05, 0.75),
+        (0.75, 0.75),
+        (0.05, 0.0),
+        (0.75, 0.0),
+    ]
+
+    fig, ax = uplt.subplots()
+    ax.graph(graphs[-1], facecolor=facecolors[-1], node_kw=dict(node_size=300))
+    ax.margins(0.75)
+    ax.set_aspect("equal", "box")
+
+    spines = [
+        ["bottom", "right"],
+        ["left", "bottom"],
+        ["top", "right"],
+        ["top", "left"],
+    ]
+    edge_alphas = [1, 0.75, 0.5, 0.25]
+
+    layouts = ["arf", "spring", "circular", "random"]
+    cmaps = ["acton", "viko", "roma", "blues"]
+    for g, facecolor, pos, layout, spines, alpha, cmap in zip(
+        graphs, facecolors, positions, layouts, spines, edge_alphas, cmaps
+    ):
+        node_color = uplt.colormaps.get_cmap(cmap)(np.linspace(0, 1, len(g)))
+        inax = ax.inset_axes([*pos, 0.2, 0.2], zoom=0)
+        inax.graph(
+            g,
+            layout=layout,
+            facecolor=facecolor,
+            spines=spines,
+            edge_kw=dict(alpha=alpha),
+            node_kw=dict(node_color=node_color),
+        )
+        for spine in inax.spines.values():
+            spine.set_linewidth(3)
+    return fig

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -550,13 +550,14 @@ def test_networks():
     ]
 
     fig, ax = uplt.subplots()
-    ax.graph(graphs[-1], facecolor=facecolors[-1], node_kw=dict(node_size=300))
+    ax.graph(graphs[-1], node_kw=dict(node_size=300))
+    ax.format(facecolor=facecolors[-1])
     ax.margins(0.75)
     ax.set_aspect("equal", "box")
 
     spines = [
         ["bottom", "right"],
-        ["left", "bottom"],
+        ["bottom", "left"],
         ["top", "right"],
         ["top", "left"],
     ]
@@ -572,10 +573,13 @@ def test_networks():
         inax.graph(
             g,
             layout=layout,
-            facecolor=facecolor,
-            spines=spines,
             edge_kw=dict(alpha=alpha),
             node_kw=dict(node_color=node_color),
+        )
+        xspine, yspine = spines
+        inax[0]._toggle_spines(spines)
+        inax.format(
+            facecolor=facecolor,
         )
         for spine in inax.spines.values():
             spine.set_linewidth(3)

--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -579,6 +579,7 @@ def test_networks():
         for spine in inax.spines.values():
             spine.set_linewidth(3)
 
+
 def test_bar_alpha():
     """
     Verify that alphas are applied over the columns

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -187,3 +187,20 @@ def test_subset_format():
     # Shorter than number of axs
     with pytest.raises(ValueError):
         axs.format(title=["a"])
+
+
+def test_toggling_spines():
+    """Test private function to toggle spines"""
+    fig, ax = uplt.subplots()
+    # Need to get the actual ax not the SubplotGridspec
+    ax[0]._toggle_spines(True)
+    assert ax.spines["bottom"].get_visible()
+    assert ax.spines["top"].get_visible()
+    assert ax.spines["left"].get_visible()
+    assert ax.spines["right"].get_visible()
+    ax[0]._toggle_spines(False)
+    assert not ax.spines["bottom"].get_visible()
+    assert not ax.spines["top"].get_visible()
+    assert not ax.spines["left"].get_visible()
+    ax[0]._toggle_spines(spines=["left"])
+    assert ax.spines["left"].get_visible()

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -204,3 +204,7 @@ def test_toggling_spines():
     assert not ax.spines["left"].get_visible()
     ax[0]._toggle_spines(spines=["left"])
     assert ax.spines["left"].get_visible()
+    ax[0]._toggle_spines(spines="right")
+    assert ax.spines["right"].get_visible()
+    with pytest.raises(ValueError):
+        ax[0]._toggle_spines(spines=1)

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -206,5 +206,6 @@ def test_toggling_spines():
     assert ax.spines["left"].get_visible()
     ax[0]._toggle_spines(spines="right")
     assert ax.spines["right"].get_visible()
+    assert not ax.spines["left"].get_visible()
     with pytest.raises(ValueError):
         ax[0]._toggle_spines(spines=1)

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -193,17 +193,24 @@ def test_toggling_spines():
     """Test private function to toggle spines"""
     fig, ax = uplt.subplots()
     # Need to get the actual ax not the SubplotGridspec
+    # Turn all spines on
     ax[0]._toggle_spines(True)
     assert ax.spines["bottom"].get_visible()
     assert ax.spines["top"].get_visible()
     assert ax.spines["left"].get_visible()
     assert ax.spines["right"].get_visible()
+    # Turn all spines off
     ax[0]._toggle_spines(False)
     assert not ax.spines["bottom"].get_visible()
     assert not ax.spines["top"].get_visible()
     assert not ax.spines["left"].get_visible()
+    assert not ax.spines["right"].get_visible()
+    # Test toggling specific spines
     ax[0]._toggle_spines(spines=["left"])
     assert ax.spines["left"].get_visible()
+
+    # If we toggle right only right is on
+    # So left should be off again
     ax[0]._toggle_spines(spines="right")
     assert ax.spines["right"].get_visible()
     assert not ax.spines["left"].get_visible()

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -72,7 +72,9 @@ def test_graph_layout_input():
 
 
 def test_graph_rescale():
-    """ """
+    """
+    Graphs can be normalized within a box [0,1]^2 using rescale.
+    """
     import networkx as nx
 
     g = nx.path_graph(5)

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -92,7 +92,7 @@ def test_graph_rescale():
     xlim_not_scaled = ax.get_xlim()
     ylim_not_scaled = ax.get_ylim()
 
-    assert xlim_not_scaled[0] != xlim_scaled[0]
-    assert xlim_not_scaled[1] != xlim_scaled[1]
-    assert ylim_not_scaled[0] != ylim_scaled[0]
-    assert ylim_not_scaled[1] != ylim_scaled[1]
+    assert not np.allclose(xlim_not_scaled[0], xlim_scaled[0])
+    assert not np.allclose(xlim_not_scaled[1], xlim_scaled[1])
+    assert not np.allclose(ylim_not_scaled[0], ylim_scaled[0])
+    assert not np.allclose(ylim_not_scaled[1], ylim_scaled[1])

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -1,0 +1,96 @@
+from cycler import V
+from pandas.core.arrays.arrow.accessors import pa
+import ultraplot as uplt, pytest, numpy as np
+
+"""
+This file is used to test base properties of ultraplot.axes.plot. For higher order plotting related functions, please use 1d and 2plots
+"""
+
+
+def test_graph_nodes_kw():
+    """Test the graph method by setting keywords for nodes"""
+    import networkx as nx
+
+    g = nx.path_graph(5)
+    labels_in = {node: node for node in range(2)}
+
+    fig, ax = uplt.subplots()
+    nodes, edges, labels = ax.graph(g, nodes=[0, 1], labels=labels_in)
+
+    # Expecting 2 nodes 1 edge
+    assert len(edges.get_offsets()) == 1
+    assert len(nodes.get_offsets()) == 2
+    assert len(labels) == len(labels_in)
+
+
+def test_graph_edges_kw():
+    """Test the graph method by setting keywords for nodes"""
+    import networkx as nx
+
+    g = nx.path_graph(5)
+    edges_in = [(0, 1)]
+
+    fig, ax = uplt.subplots()
+    nodes, edges, labels = ax.graph(g, edges=edges_in)
+
+    # Expecting 2 nodes 1 edge
+    assert len(edges.get_offsets()) == 1
+    assert len(nodes.get_offsets()) == 2
+    assert labels == False
+
+
+def test_graph_input():
+    """
+    Graph function should show labels when asked
+    """
+    import networkx as nx
+
+    g = nx.path_graph(5)
+    A = nx.to_numpy_array(g)
+    el = np.array(g.edges())
+    fig, ax = uplt.subplots()
+    # Test input methods
+    ax.graph(g)  # Graphs
+    ax.graph(A)  # Adjcency matrices
+    ax.graph(el)  # edgelists
+    with pytest.raises(TypeError):
+        ax.graph("invalid_input")
+
+
+def test_graph_layout_input():
+    """
+    Graph function should show labels when asked
+    """
+    import networkx as nx
+
+    g = nx.path_graph(5)
+    circular = nx.circular_layout(g)
+    layouts = [None, nx.spring_layout, circular, "forceatlas2", "spring_layout"]
+    fig, ax = uplt.subplots(ncols=len(layouts))
+    for axi, layout in zip(ax[1:], layouts):
+        axi.graph(g, layout=layout)
+
+
+def test_graph_rescale():
+    """ """
+    import networkx as nx
+
+    g = nx.path_graph(5)
+    layout = nx.spring_layout(g)
+
+    fig, ax = uplt.subplots()
+    nodes_rescaled = ax.graph(g, layout=layout, rescale=True)[0]
+
+    xlim_scaled = ax.get_xlim()
+    ylim_scaled = ax.get_ylim()
+
+    fig, ax = uplt.subplots()
+    nodes_not_rescaled = ax.graph(g, layout=layout, rescale=False)[0]
+
+    xlim_not_scaled = ax.get_xlim()
+    ylim_not_scaled = ax.get_ylim()
+
+    assert xlim_not_scaled[0] != xlim_scaled[0]
+    assert xlim_not_scaled[1] != xlim_scaled[1]
+    assert ylim_not_scaled[0] != ylim_scaled[0]
+    assert ylim_not_scaled[1] != ylim_scaled[1]

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -41,7 +41,7 @@ def test_graph_edges_kw():
 
 def test_graph_input():
     """
-    Graph function should show labels when asked
+    Test graph input methods. We allow for graphs, adjacency matrices, and edgelists.
     """
     import networkx as nx
 
@@ -59,7 +59,7 @@ def test_graph_input():
 
 def test_graph_layout_input():
     """
-    Graph function should show labels when asked
+    Test for different input methods for layout. We allow for None, strings, dicts, and functions.
     """
     import networkx as nx
 

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -59,7 +59,7 @@ def test_graph_input():
 
 def test_graph_layout_input():
     """
-    Test for different input methods for layout. We allow for None, strings, dicts, and functions.
+    Test if layout is in a [0, 1] x [0, 1] box
     """
     import networkx as nx
 
@@ -73,26 +73,27 @@ def test_graph_layout_input():
 
 def test_graph_rescale():
     """
-    Graphs can be normalized within a box [0,1]^2 using rescale.
+    Graphs can be normalized such that the node size is the same independnt of the fig size
     """
     import networkx as nx
 
     g = nx.path_graph(5)
     layout = nx.spring_layout(g)
+    # shift layout outside the box
+    layout = {node: np.array(pos) + np.array([10, 10]) for node, pos in layout.items()}
 
     fig, ax = uplt.subplots()
-    nodes_rescaled = ax.graph(g, layout=layout, rescale=True)[0]
+    nodes1 = ax.graph(g, layout=layout, rescale=True)[0]
 
-    xlim_scaled = ax.get_xlim()
-    ylim_scaled = ax.get_ylim()
+    xlim_scaled = np.array(ax.get_xlim())
+    ylim_scaled = np.array(ax.get_ylim())
 
     fig, ax = uplt.subplots()
-    nodes_not_rescaled = ax.graph(g, layout=layout, rescale=False)[0]
+    nodes2 = ax.graph(g, layout=layout, rescale=False)[0]
 
-    xlim_not_scaled = ax.get_xlim()
-    ylim_not_scaled = ax.get_ylim()
-
-    assert not np.allclose(xlim_not_scaled[0], xlim_scaled[0])
-    assert not np.allclose(xlim_not_scaled[1], xlim_scaled[1])
-    assert not np.allclose(ylim_not_scaled[0], ylim_scaled[0])
-    assert not np.allclose(ylim_not_scaled[1], ylim_scaled[1])
+    for x, y in nodes1.get_offsets():
+        assert x >= 0 and x <= 1
+        assert y >= 0 and y <= 1
+    for x, y in nodes2.get_offsets():
+        assert x > 1
+        assert y > 1


### PR DESCRIPTION
# Why this PR?

Networks are the base of many disciplines, and visualizing them is an important part of understanding how "intuitively" graphs differ from one another. A pet peeve of mine is that network plotting is verbose or too opaque with poor chosen defaults, preventing clear communication of the intended purpose: highlighting connections.

This PR presents an interface for plotting networkx graphs. It provides sensible defaults and makes beautiful default plots while still allowing access to changes when needed. Networkx has grown to be the often de facto standard for visualizing and base analysis of small to medium networks in python. It has a nice drawing interface that is unfortunately a bit verbose. By drawing on the power of networkx, we can enhance the plotting experience by providing a tight interface with networkx and matplotlib, while preventing the verbose of the former.  Other backends could be added (such as networkit, graphtool and others) but for now networkx is supported.

