### PR TITLE
Center figures in docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -193,6 +193,7 @@
 
 /* Optional: Ensure image respects container boundaries */
 .output_area.docutils.container img {
-    max-width: 100%; /* Prevents image from overflowing its container */
-    height: auto; /* Maintains aspect ratio */
+    width: 100%;
+    height: auto;
+    display: block;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -186,3 +186,13 @@
         display: none; /* Hide on smaller screens */
     }
 }
+
+.output_area.docutils.container {
+    text-align: center; /* Centers inline or inline-block children horizontally */
+}
+
+/* Optional: Ensure image respects container boundaries */
+.output_area.docutils.container img {
+    max-width: 100%; /* Prevents image from overflowing its container */
+    height: auto; /* Maintains aspect ratio */
+}


### PR DESCRIPTION
Moves the figures to center align rather than align left. It also fills the horizontal space  to make the plots bigger and more appealing.