### PR TITLE
Add pyarrow to rm pandas error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,6 @@ dependencies:
   - basemap >=1.4.1
   - pre-commit
   - sphinx-design
+  - pyarrow
   - pip:
       - git+https://github.com/ultraplot/UltraTheme.git


### PR DESCRIPTION
Current workflows are failing due to a missing dep for pandas -- not sure why.  Temporarily adding this such that the workflows can run.