### PR TITLE
sensible defaults and unittest

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -544,8 +544,8 @@ rasterize : bool, default: :rc:`colorbar.rasterize`
     Whether to rasterize the colorbar solids. The matplotlib default was ``True``
     but ultraplot changes this to ``False`` since rasterization can cause misalignment
     between the color patches and the colorbar outline.
-outline : bool, default : True
-    Controls the visibility of the frame. When set to False, the spines of the colorbar are hidden.
+outline : bool, None default : None
+    Controls the visibility of the frame. When set to False, the spines of the colorbar are hidden. If set to `None` it uses the `rc['colorbar.outline']` value.
 labelrotation : str, float, default: "auto"
     Controls the rotation of the colorbar label. When set to auto it produces a sensible default where the rotation is adjusted to where the colorbar is located. For example, a horizontal colorbar with a label to the left or right will match the horizontal alignment and rotate the label to 0 degrees. Users can provide a float to rotate to any arbitrary angle.
 
@@ -1042,7 +1042,7 @@ class Axes(maxes.Axes):
         linewidth=None,
         edgefix=None,
         rasterized=None,
-        outline: bool = True,
+        outline: Union[bool, None] = None,
         labelrotation: Union[str, float] = "auto",
         **kwargs,
     ):
@@ -1236,6 +1236,7 @@ class Axes(maxes.Axes):
             orientation=orientation,
             **kwargs,
         )
+        outline = _not_none(outline, rc["colorbar.outline"])
         obj.outline.set_visible(outline)
         obj.ax.grid(False)
         # obj.minorlocator = minorlocator  # backwards compatibility

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -546,8 +546,8 @@ rasterize : bool, default: :rc:`colorbar.rasterize`
     between the color patches and the colorbar outline.
 outline : bool, None default : None
     Controls the visibility of the frame. When set to False, the spines of the colorbar are hidden. If set to `None` it uses the `rc['colorbar.outline']` value.
-labelrotation : str, float, default: "auto"
-    Controls the rotation of the colorbar label. When set to auto it produces a sensible default where the rotation is adjusted to where the colorbar is located. For example, a horizontal colorbar with a label to the left or right will match the horizontal alignment and rotate the label to 0 degrees. Users can provide a float to rotate to any arbitrary angle.
+labelrotation : str, float, default: None
+    Controls the rotation of the colorbar label. When set to None it takes on the value of `rc["colorbar.labelrotation"]`. When set to auto it produces a sensible default where the rotation is adjusted to where the colorbar is located. For example, a horizontal colorbar with a label to the left or right will match the horizontal alignment and rotate the label to 0 degrees. Users can provide a float to rotate to any arbitrary angle.
 
 
 

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1222,6 +1222,10 @@ class Axes(maxes.Axes):
         # Create colorbar and update ticks and axis direction
         # NOTE: This also adds the guides._update_ticks() monkey patch that triggers
         # updates to DiscreteLocator when parent axes is drawn.
+        orientation = _not_none(
+            kwargs.pop("orientation", None), kwargs.pop("vert", None)
+        )
+
         obj = cax._colorbar_fill = cax.figure.colorbar(
             mappable,
             cax=cax,
@@ -1229,6 +1233,7 @@ class Axes(maxes.Axes):
             format=formatter,
             drawedges=grid,
             extendfrac=extendfrac,
+            orientation=orientation,
             **kwargs,
         )
         obj.outline.set_visible(outline)
@@ -1319,6 +1324,8 @@ class Axes(maxes.Axes):
                     elif labelloc == "left":
                         kw_label["va"] = "top"
                     labelrotation = -90
+                case (True, None, _):
+                    labelrotation = 90
                 # Horizontal colorbar
                 case (False, _, _):
                     if labelloc == "left":

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1043,7 +1043,7 @@ class Axes(maxes.Axes):
         edgefix=None,
         rasterized=None,
         outline: Union[bool, None] = None,
-        labelrotation: Union[str, float] = "auto",
+        labelrotation: Union[str, float] = None,
         **kwargs,
     ):
         """
@@ -1312,6 +1312,7 @@ class Axes(maxes.Axes):
                 case _:
                     raise ValueError("Location not understood.")
             axis.set_label_position(labelloc)
+        labelrotation = _not_none(labelrotation, rc["colorbar.labelrotation"])
         if labelrotation == "auto":
             # When set to auto, we make the colorbar appear "natural". For example, when we have a
             # horizontal colorbar on the top, but we want the label to the sides, we make sure that the horizontal alignment is correct and the labelrotation is horizontal. Below produces "sensible defaults", but can be overridden by the user.

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1331,17 +1331,18 @@ class Axes(maxes.Axes):
                 # Horizontal colorbar
                 case (False, _, _):
                     if labelloc == "left":
-                        kw_label["ha"] = "right"
                         kw_label["va"] = "center"
+                        labelrotation = 90
                     elif labelloc == "right":
-                        kw_label["ha"] = "left"
                         kw_label["va"] = "center"
-
-                    labelrotation = 0
+                        labelrotation = 270
+                    else:
+                        labelrotation = 0
                 case Number():
                     pass
                 case _:
                     labelrotation = 0
+            print(labelrotation)
 
             kw_label.update({"rotation": labelrotation})
         axis.label.update(kw_label)

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1342,7 +1342,6 @@ class Axes(maxes.Axes):
                     pass
                 case _:
                     labelrotation = 0
-            print(labelrotation)
 
             kw_label.update({"rotation": labelrotation})
         axis.label.update(kw_label)

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -992,6 +992,11 @@ _rc_ultraplot_table = {
         'Length of rectangular or triangular "extensions" for panel colorbars.'
         + _addendum_em,
     ),
+    "colorbar.outline": (
+        True,
+        _validate_bool,
+        "Whether to draw a frame around the colorbar.",
+    ),
     "colorbar.fancybox": (
         False,
         _validate_bool,

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -421,6 +421,15 @@ def _validate_units(dest):
     return _validate_units
 
 
+def _validate_float_or_auto(value):
+    if value == "auto":
+        return value
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        raise ValueError(f"Value must be a float or 'auto', got {value!r}")
+
+
 def _rst_table():
     """
     Return the setting names and descriptions in an RST-style table.
@@ -996,6 +1005,11 @@ _rc_ultraplot_table = {
         True,
         _validate_bool,
         "Whether to draw a frame around the colorbar.",
+    ),
+    "colorbar.labelrotation": (
+        "auto",
+        _validate_float_or_auto,
+        "Rotation of colorbar labels.",
     ),
     "colorbar.fancybox": (
         False,

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -304,6 +304,8 @@ def test_label_rotation_colorbar():
         tmp = getattr(cbar.ax, f"{which}axis").label
         if tmp.get_text() == mylabel:
             label = tmp
+            assert label.get_rotation() == 23
+            break
 
 
 def test_auto_labelrotation():

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -303,8 +303,7 @@ def test_label_rotation_colorbar():
     for which in "xy":
         tmp = getattr(cbar.ax, f"{which}axis").label
         if tmp.get_text() == mylabel:
-            assert label.get_rotation() == 23
-
+            label = tmp
 
 def test_auto_labelrotation():
     from itertools import product

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -330,11 +330,11 @@ def test_auto_labelrotation():
         is_horizontal = not is_vertical
 
         expected_rotation = 0
-        if is_vertical:
-            if labelloc == "left":
-                expected_rotation = 90
-            elif labelloc == "right":
-                expected_rotation = 270
+        if labelloc == "left":
+            expected_rotation = 90
+        elif labelloc == "right":
+            expected_rotation = 270
+
         actual_rotation = label.get_rotation()
         ax.set_title(f"loc={loc}, labelloc={labelloc}, rotation={actual_rotation}")
         assert actual_rotation == expected_rotation

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -305,6 +305,7 @@ def test_label_rotation_colorbar():
         if tmp.get_text() == mylabel:
             label = tmp
 
+
 def test_auto_labelrotation():
     from itertools import product
 

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -341,6 +341,7 @@ def test_auto_labelrotation():
         assert actual_rotation == expected_rotation
         uplt.close(fig)
 
+
 @pytest.mark.mpl_image_compare
 def test_label_placement_fig_colorbar2():
     """
@@ -351,4 +352,3 @@ def test_label_placement_fig_colorbar2():
     fig, axs = uplt.subplots(nrows=1, ncols=2)
     fig.colorbar(cmap, loc="bottom", label="My Label", labelloc="right")
     return fig
-

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -336,7 +336,6 @@ def test_auto_labelrotation():
                 expected_rotation = 270
         actual_rotation = label.get_rotation()
         ax.set_title(f"loc={loc}, labelloc={labelloc}, rotation={actual_rotation}")
-
         assert actual_rotation == expected_rotation
         uplt.close(fig)
 

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -296,9 +296,14 @@ def test_label_rotation_colorbar():
     label rotation is possible.
     """
     cmap = uplt.colormaps.get_cmap("viridis")
+    mylabel = "My Label"
     fig, ax = uplt.subplots()
     cbar = ax.colorbar(cmap, labelloc="top", loc="right", vert=False, labelrotation=23)
-    assert cbar.get_label().get_rotation() == 23
+    # Get the label Text object
+    for which in "xy":
+        tmp = getattr(cbar.ax, f"{which}axis").label
+        if tmp.get_text() == mylabel:
+            assert label.get_rotation() == 23
 
 
 def test_auto_labelrotation():

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -333,10 +333,5 @@ def test_auto_labelrotation():
         actual_rotation = label.get_rotation()
         ax.set_title(f"loc={loc}, labelloc={labelloc}, rotation={actual_rotation}")
 
-        try:
-            assert actual_rotation == expected_rotation
-        except:
-            print(is_horizontal, labelloc, loc)
-        uplt.show(block=1)
-
+        assert actual_rotation == expected_rotation
         uplt.close(fig)

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -288,3 +288,55 @@ def test_label_placement_colorbar():
     locs = "top bottom left right".split()
     for loc, labelloc in zip(locs, locs):
         ax.colorbar(h, loc=loc, labelloc=labelloc)
+
+
+def test_label_rotation_colorbar():
+    """
+    Ensure that all potential combinations of colorbar
+    label rotation is possible.
+    """
+    cmap = uplt.colormaps.get_cmap("viridis")
+    fig, ax = uplt.subplots()
+    cbar = ax.colorbar(cmap, labelloc="top", loc="right", vert=False, labelrotation=23)
+    assert cbar.get_label().get_rotation() == 23
+
+
+def test_auto_labelrotation():
+    from itertools import product
+
+    locs = ["top", "bottom", "left", "right"]
+    labellocs = ["top", "bottom", "left", "right"]
+
+    cmap = uplt.colormaps.get_cmap("viridis")
+    mylabel = "My Label"
+
+    for loc, labelloc in product(locs, labellocs):
+        fig, ax = uplt.subplots()
+        cbar = ax.colorbar(cmap, loc=loc, labelloc=labelloc, label=mylabel)
+
+        # Get the label Text object
+        for which in "xy":
+            tmp = getattr(cbar.ax, f"{which}axis").label
+            if tmp.get_text() == mylabel:
+                label = tmp
+                break
+
+        is_vertical = loc in ("left", "right")
+        is_horizontal = not is_vertical
+
+        expected_rotation = 0
+        if is_vertical:
+            if labelloc == "left":
+                expected_rotation = 90
+            elif labelloc == "right":
+                expected_rotation = 270
+        actual_rotation = label.get_rotation()
+        ax.set_title(f"loc={loc}, labelloc={labelloc}, rotation={actual_rotation}")
+
+        try:
+            assert actual_rotation == expected_rotation
+        except:
+            print(is_horizontal, labelloc, loc)
+        uplt.show(block=1)
+
+        uplt.close(fig)


### PR DESCRIPTION
The community indicated (@ToryDeng) that colorbar label placing may need some TLC. We recently introduced placing colorbar labels along the outside of the colorbar. This may cause unnecessary post processing as currently the placingo f the labels is not stylized. This PR adds sensible label placement for colorbars. It adds a new keyword `labelrotation` which is set to default to "auto" or can be set to any arbitrary number; please note the the alignment is then null and void. 

Furthermore, it adds the keyword `outline` which allows for turning on and off the outline frame of the colorbar.


Addresses #181 

@TorryDeng do you want to include an rc param for the frame or is this sufficient?