### PR TITLE
Discrete colors for quiver

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2339,7 +2339,7 @@ class PlotAxes(base.Axes):
             if infer_rgb and (
                 inputs._is_categorical(c) or c.ndim == 2 and c.shape[1] in (3, 4)
             ):  # noqa: E501
-                c = list(map(pcolors.to_rgba, c))  # avoid iterating over columns
+                c = list(map(pcolors.to_hex, c))  # avoid iterating over columns
             else:
                 kwargs = self._parse_cmap(
                     x, y, c, plot_lines=True, default_discrete=False, **kwargs
@@ -4644,11 +4644,11 @@ class PlotAxes(base.Axes):
 
         if c is None and "color" not in kw:
             # Fallback to ensure single color functionality
+            if color is None:
+                color = rc["quiver.arrow_color"]
             kw["color"] = color
         a = [x, y, u, v]
         if c is not None:
-            # Setting colors goes through color
-            c_shape = np.shape(c)
             # If U is 1D we are dealing with arrows
             if len(u.shape) == 1:
                 kw["color"] = c

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -4642,10 +4642,8 @@ class PlotAxes(base.Axes):
 
         a = [x, y, u, v]
         if c is not None:
-            if inputs._is_categorical(c):
-                kw["color"] = c
-            else:
-                a.append(c)
+            c = mcolors.to_rgba_array(c)
+            kw["color"] = c
         kw.pop("colorbar_kw", None)  # added by _parse_cmap
         m = self._call_native("quiver", *a, **kw)
         return m

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2339,7 +2339,8 @@ class PlotAxes(base.Axes):
             if infer_rgb and (
                 inputs._is_categorical(c) or c.ndim == 2 and c.shape[1] in (3, 4)
             ):  # noqa: E501
-                c = list(map(pcolors.to_hex, c))  # avoid iterating over columns
+                c = list(map(pcolors.to_rgba, c))  # avoid iterating over columns
+                c = np.asarray(c)
             else:
                 kwargs = self._parse_cmap(
                     x, y, c, plot_lines=True, default_discrete=False, **kwargs
@@ -4642,8 +4643,11 @@ class PlotAxes(base.Axes):
 
         a = [x, y, u, v]
         if c is not None:
-            c = mcolors.to_rgba_array(c)
-            kw["color"] = c
+            # Setting colors goes through color
+            if c.shape[0] <= x.shape[0]:
+                kw["color"] = list(c)
+            else:
+                a.append(c)
         kw.pop("colorbar_kw", None)  # added by _parse_cmap
         m = self._call_native("quiver", *a, **kw)
         return m

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -4642,6 +4642,9 @@ class PlotAxes(base.Axes):
             color, c = c, None
             kw["color"] = color
 
+        if c is None and "color" not in kw:
+            # Fallback to ensure single color functionality
+            kw["color"] = color
         a = [x, y, u, v]
         if c is not None:
             # Setting colors goes through color

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2553,6 +2553,7 @@ class PlotAxes(base.Axes):
         # NOTE: ContourSet natively stores 'extend' on the result but for other
         # classes we need to hide it on the object.
         kwargs.update({"cmap": cmap, "norm": norm})
+
         if plot_contours:
             kwargs.update({"levels": levels, "extend": extend})
         else:
@@ -4638,11 +4639,13 @@ class PlotAxes(base.Axes):
         color = None
         if mcolors.is_color_like(c):
             color, c = c, None
-        if color is not None:
-            kw["color"] = color
+
         a = [x, y, u, v]
         if c is not None:
-            a.append(c)
+            if inputs._is_categorical(c):
+                kw["color"] = c
+            else:
+                a.append(c)
         kw.pop("colorbar_kw", None)  # added by _parse_cmap
         m = self._call_native("quiver", *a, **kw)
         return m

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -4637,7 +4637,7 @@ class PlotAxes(base.Axes):
         kw.update(_pop_props(kw, "line"))  # applied to arrow outline
         c, kw = self._parse_color(x, y, c, **kw)
         color = None
-        # Handle case where c a singular color
+        # Handle case where c is a singular color
         if mcolors.is_color_like(c):
             color, c = c, None
             kw["color"] = color

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -4640,12 +4640,13 @@ class PlotAxes(base.Axes):
         color = None
         if mcolors.is_color_like(c):
             color, c = c, None
+            kw["color"] = color
 
         a = [x, y, u, v]
         if c is not None:
             # Setting colors goes through color
             if c.shape[0] <= x.shape[0]:
-                kw["color"] = list(c)
+                kw["color"] = c
             else:
                 a.append(c)
         kw.pop("colorbar_kw", None)  # added by _parse_cmap

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2340,7 +2340,6 @@ class PlotAxes(base.Axes):
                 inputs._is_categorical(c) or c.ndim == 2 and c.shape[1] in (3, 4)
             ):  # noqa: E501
                 c = list(map(pcolors.to_rgba, c))  # avoid iterating over columns
-                c = np.asarray(c)
             else:
                 kwargs = self._parse_cmap(
                     x, y, c, plot_lines=True, default_discrete=False, **kwargs
@@ -4638,6 +4637,7 @@ class PlotAxes(base.Axes):
         kw.update(_pop_props(kw, "line"))  # applied to arrow outline
         c, kw = self._parse_color(x, y, c, **kw)
         color = None
+        # Handle case where c a singular color
         if mcolors.is_color_like(c):
             color, c = c, None
             kw["color"] = color
@@ -4648,8 +4648,11 @@ class PlotAxes(base.Axes):
         a = [x, y, u, v]
         if c is not None:
             # Setting colors goes through color
-            if c.shape[0] <= x.shape[0]:
+            c_shape = np.shape(c)
+            # If U is 1D we are dealing with arrows
+            if len(u.shape) == 1:
                 kw["color"] = c
+            # Otherwise we assume we are populating a field
             else:
                 a.append(c)
         kw.pop("colorbar_kw", None)  # added by _parse_cmap

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -4640,13 +4640,10 @@ class PlotAxes(base.Axes):
         # Handle case where c is a singular color
         if mcolors.is_color_like(c):
             color, c = c, None
+
+        if color is not None:
             kw["color"] = color
 
-        if c is None and "color" not in kw:
-            # Fallback to ensure single color functionality
-            if color is None:
-                color = rc["quiver.arrow_color"]
-            kw["color"] = color
         a = [x, y, u, v]
         if c is not None:
             # If U is 1D we are dealing with arrows

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1538,11 +1538,6 @@ _rc_ultraplot_table = {
     ),
     "ocean.color": (WHITE, _validate_color, "Face color for ocean patches."),
     "ocean.zorder": (ZPATCHES, _validate_float, "Z-order for ocean patches."),
-    "quiver.arrow_color": (
-        BLACK,
-        _validate_color,
-        "Color for quiver arrows.",
-    ),
     # Geographic resolution
     "reso": (
         "lo",

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1538,6 +1538,11 @@ _rc_ultraplot_table = {
     ),
     "ocean.color": (WHITE, _validate_color, "Face color for ocean patches."),
     "ocean.zorder": (ZPATCHES, _validate_float, "Z-order for ocean patches."),
+    "quiver.arrow_color": (
+        BLACK,
+        _validate_color,
+        "Color for quiver arrows.",
+    ),
     # Geographic resolution
     "reso": (
         "lo",

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -221,5 +221,4 @@ def test_quiver_discrete_colors():
     C = np.random.rand(3, 4)
     ax.quiver(X - 2, Y, U, V, C)
     ax.quiver(X - 3, Y, U, V, color="red", infer_rgb=True)
-    uplt.show(block=1)
     return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -213,7 +213,8 @@ def test_quiver_discrete_colors():
     fig, ax = uplt.subplots()
     q = ax.quiver(X, Y, U, V, color=colors, infer_rgb=True)
     for color in colors:
-        assert uplt.colors.mcolors.to_rgba(color) in q.get_facecolors()
+        expected_rgba = uplt.colors.mcolors.to_rgba(color)
+        assert any(np.allclose(expected_rgba, facecolor) for facecolor in q.get_facecolors())
     C = ["#ff0000", "#00ff00", "#0000ff"]
     ax.quiver(X - 1, Y, U, V, color=C, infer_rgb=True)
 

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -205,11 +205,9 @@ def test_quiver_discrete_colors():
     X = np.array([0, 1, 2])
     Y = np.array([0, 1, 2])
 
-    # Composantes des vecteurs
     U = np.array([1, 1, 0])
     V = np.array([0, 1, 1])
 
-    # Liste de couleurs (une par vecteur)
     colors = ["r", "g", "b"]
 
     fig, ax = uplt.subplots()

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -220,5 +220,6 @@ def test_quiver_discrete_colors():
     # pass rgba values
     C = np.random.rand(3, 4)
     ax.quiver(X - 2, Y, U, V, C)
-    # ax.quivker(X - 3, Y, U, V, color="red")
+    ax.quiver(X - 3, Y, U, V, color="red", infer_rgb=True)
+    uplt.show(block=1)
     return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -213,6 +213,11 @@ def test_quiver_discrete_colors():
     fig, ax = uplt.subplots()
     q = ax.quiver(X, Y, U, V, color=colors, infer_rgb=True)
     for color in colors:
-
         assert uplt.colors.mcolors.to_rgba(color) in q.get_facecolors()
+    C = ["#ff0000", "#00ff00", "#0000ff"]
+    C = uplt.colors.mcolors.to_rgba_array(C)
+    ax.quiver(X - 1, Y, U, V, C)
+
+    C = np.random.rand(3, 4)
+    ax.quiver(X - 2, Y, U, V, C)
     return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -215,9 +215,10 @@ def test_quiver_discrete_colors():
     for color in colors:
         assert uplt.colors.mcolors.to_rgba(color) in q.get_facecolors()
     C = ["#ff0000", "#00ff00", "#0000ff"]
-    C = uplt.colors.mcolors.to_rgba_array(C)
-    ax.quiver(X - 1, Y, U, V, C)
+    ax.quiver(X - 1, Y, U, V, color=C, infer_rgb=True)
 
+    # pass rgba values
     C = np.random.rand(3, 4)
     ax.quiver(X - 2, Y, U, V, C)
+    # ax.quivker(X - 3, Y, U, V, color="red")
     return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -196,3 +196,25 @@ def test_boxplot_mpl_versions(
                 assert "vert" not in kwargs
             else:
                 assert "orientation" not in kwargs
+
+
+def test_quiver_discrete_colors():
+    """
+    Edge case where colors are discrete for quiver plots
+    """
+    X = np.array([0, 1, 2])
+    Y = np.array([0, 1, 2])
+
+    # Composantes des vecteurs
+    U = np.array([1, 1, 0])
+    V = np.array([0, 1, 1])
+
+    # Liste de couleurs (une par vecteur)
+    colors = ["r", "g", "b"]
+
+    fig, ax = uplt.subplots()
+    q = ax.quiver(X, Y, U, V, color=colors, infer_rgb=True)
+    for color in colors:
+
+        assert uplt.colors.mcolors.to_rgba(color) in q.get_facecolors()
+    return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -214,7 +214,9 @@ def test_quiver_discrete_colors():
     q = ax.quiver(X, Y, U, V, color=colors, infer_rgb=True)
     for color in colors:
         expected_rgba = uplt.colors.mcolors.to_rgba(color)
-        assert any(np.allclose(expected_rgba, facecolor) for facecolor in q.get_facecolors())
+        assert any(
+            np.allclose(expected_rgba, facecolor) for facecolor in q.get_facecolors()
+        )
     C = ["#ff0000", "#00ff00", "#0000ff"]
     ax.quiver(X - 1, Y, U, V, color=C, infer_rgb=True)
 


### PR DESCRIPTION
Fix and issue where categorical data is used for quiver plots. Fixes #197 

```python
import ultraplot as uplt, numpy as np

X = np.array([0, 1, 2])
Y = np.array([0, 1, 2])

U = np.array([1, 1, 0])
V = np.array([0, 1, 1])

import matplotlib.colors

colors = ["red", "green", "blue"]  

colors = [matplotlib.colors.to_rgb(color) for color in colors]

fig, ax = uplt.subplots()
q = ax.quiver(X, Y, U, V, colors=colors, infer_rgb=True)

ax.set_aspect("equal")
uplt.show()
```