### PR TITLE
override logx/y/log with updated docstring

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -24,6 +24,7 @@ import matplotlib.image as mimage
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 import matplotlib.ticker as mticker
+import matplotlib.pyplot as mplt
 import matplotlib as mpl
 from packaging import version
 import numpy as np
@@ -343,6 +344,25 @@ sequential, diverging, cyclic, qualitative : bool, default: None
 docstring._snippet_manager["plot.cycle"] = _cycle_docstring
 docstring._snippet_manager["plot.cmap_norm"] = _cmap_norm_docstring
 
+_log_doc = """
+Plot {kind}
+
+UltraPlot is optimized for visualizing logarithmic scales by default. For cases with large differences in magnitude,
+we recommend setting `rc["formatter.log"] = True` to enhance axis label formatting.
+{matplotlib_doc}
+"""
+
+docstring._snippet_manager["plot.loglog"] = _log_doc.format(
+    kind="loglog", matplotlib_doc=mplt.loglog.__doc__
+)
+
+docstring._snippet_manager["plot.semilogy"] = _log_doc.format(
+    kind="semilogy", matplotlib_doc=mplt.semilogy.__doc__
+)
+
+docstring._snippet_manager["plot.semilogx"] = _log_doc.format(
+    kind="semilogx", matplotlib_doc=mplt.semilogx.__doc__
+)
 
 # Levels docstrings
 # NOTE: In some functions we only need some components
@@ -3199,6 +3219,44 @@ class PlotAxes(base.Axes):
         %(plot.plotx)s
         """
         return self.plotx(*args, **kwargs)
+
+    @docstring._snippet_manager
+    def loglog(self, *args, **kwargs):
+        """
+        %(plot.loglog)s
+        """
+        objs = self._call_native("loglog", *args, **kwargs)
+        if rc["formatter.log"]:
+            self.format(
+                xticklabels="log",
+                ytickslabels="log",
+            )
+        return objs
+
+    @docstring._snippet_manager
+    def semilogy(self, *args, **kwargs):
+        """
+        %(plot.semilogy)s
+        """
+
+        objs = self._call_native("semilogy", *args, **kwargs)
+        if rc["formatter.log"]:
+            self.format(
+                xformatter="log",
+            )
+        return objs
+
+    @docstring._snippet_manager
+    def semilogx(self, *args, **kwargs):
+        """
+        %(plot.semilogx)s
+        """
+        objs = self._call_native("semilogx", *args, **kwargs)
+        if rc["formatter.log"]:
+            self.format(
+                xformatter="log",
+            )
+        return objs
 
     @inputs._preprocess_or_redirect("x", "y", allow_extra=True)
     @docstring._concatenate_inherited

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3228,8 +3228,8 @@ class PlotAxes(base.Axes):
         objs = self._call_native("loglog", *args, **kwargs)
         if rc["formatter.log"]:
             self.format(
-                xticklabels="log",
-                ytickslabels="log",
+                xformatter="log",
+                yformatter="log",
             )
         return objs
 
@@ -3242,7 +3242,7 @@ class PlotAxes(base.Axes):
         objs = self._call_native("semilogy", *args, **kwargs)
         if rc["formatter.log"]:
             self.format(
-                xformatter="log",
+                yformatter="log",
             )
         return objs
 

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1200,7 +1200,8 @@ _rc_ultraplot_table = {
     "formatter.log": (
         False,
         _validate_bool,
-        "Whether to use log scale for semilog or loglog plots.",
+        "Whether to use log formatting (e.g., $10^{4}$) for "
+        "logarithmically scaled axis tick labels.",
     ),
     "formatter.limits": (
         [-5, 6],  # must be list or else validated

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1197,6 +1197,11 @@ _rc_ultraplot_table = {
         _validate_bool,
         "Whether to trim trailing decimal zeros on tick labels.",
     ),
+    "formatter.log": (
+        False,
+        _validate_bool,
+        "Whether to use log scale for semilog or loglog plots.",
+    ),
     "formatter.limits": (
         [-5, 6],  # must be list or else validated
         _validate["axes.formatter.limits"],

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -231,35 +231,52 @@ def test_setting_log_with_rc():
     """
     Test setting log scale with rc context manager
     """
+    import re
+
     uplt.rc["formatter.log"] = True
     x, y = np.linspace(0, 1e6, 10), np.linspace(0, 1e6, 10)
 
+    def check_ticks(axis, target=True):
+        pattern = r"\$\\mathdefault\{10\^\{(\d+)\}\}\$"
+        for tick in axis.get_ticklabels():
+            match = re.match(pattern, tick.get_text())
+            expectation = False
+            if match:
+                expectation = True
+            assert expectation == target
+
+    def reset(ax):
+        ax.set_xscale("linear")
+        ax.set_yscale("linear")
+
+    funcs = [
+        "semilogx",
+        "semilogy",
+        "loglog",
+    ]
+    conditions = [
+        ["x"],
+        ["y"],
+        ["x", "y"],
+    ]
+
     fig, ax = uplt.subplots()
-    ax.semilogy(x, y)
-    assert ax.get_yscale() == "log"
-    ax.semilogx(x, y)
-    assert ax.get_xscale() == "log"
-    ax.loglog(x, y)
-    assert ax.get_xscale() == "log"
-    assert ax.get_yscale() == "log"
+    for func, targets in zip(funcs, conditions):
+        reset(ax)
+        # Call the function
+        getattr(ax, func)(x, y)
+        # Check if the formatter is set
+        for target in targets:
+            axi = getattr(ax, f"{target}axis")
+            check_ticks(axi, target=True)
 
     uplt.rc["formatter.log"] = False
     fig, ax = uplt.subplots()
-    ax.semilogx(x, y)
-    assert ax.get_xscale() == "log"
-    assert ax.get_yscale() == "linear"
-
-    # Reset xscale
-    ax.set_xscale("linear")
-    ax.semilogy(x, y)
-    assert ax.get_xscale() == "linear"
-    assert ax.get_yscale() == "log"
-
-    ax.set_xscale("log")
-    ax.set_yscale("linear")
-    ax.loglog(x, y)
-
-    assert ax.get_xscale() == "log"
-    assert ax.get_yscale() == "log"
+    for func, targets in zip(funcs, conditions):
+        reset(ax)
+        getattr(ax, func)(x, y)
+        for target in targets:
+            axi = getattr(ax, f"{target}axis")
+            check_ticks(axi, target=False)
 
     return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -225,3 +225,41 @@ def test_quiver_discrete_colors():
     ax.quiver(X - 2, Y, U, V, C)
     ax.quiver(X - 3, Y, U, V, color="red", infer_rgb=True)
     return fig
+
+
+def test_setting_log_with_rc():
+    """
+    Test setting log scale with rc context manager
+    """
+    uplt.rc["formatter.log"] = True
+    x, y = np.linspace(0, 1e6, 10), np.linspace(0, 1e6, 10)
+
+    fig, ax = uplt.subplots()
+    ax.semilogy(x, y)
+    assert ax.get_yscale() == "log"
+    ax.semilogx(x, y)
+    assert ax.get_xscale() == "log"
+    ax.loglog(x, y)
+    assert ax.get_xscale() == "log"
+    assert ax.get_yscale() == "log"
+
+    uplt.rc["formatter.log"] = False
+    fig, ax = uplt.subplots()
+    ax.semilogx(x, y)
+    assert ax.get_xscale() == "log"
+    assert ax.get_yscale() == "linear"
+
+    # Reset xscale
+    ax.set_xscale("linear")
+    ax.semilogy(x, y)
+    assert ax.get_xscale() == "linear"
+    assert ax.get_yscale() == "log"
+
+    ax.set_xscale("log")
+    ax.set_yscale("linear")
+    ax.loglog(x, y)
+
+    assert ax.get_xscale() == "log"
+    assert ax.get_yscale() == "log"
+
+    return fig


### PR DESCRIPTION
This PR introduces a new rc parameters `formatter.log` which is set to `False` by default. When set to true it automatically applies a `log` scale for x, y or both depending on the plotting function used (`semilogx, semilogy`, and `loglog` respectively).  

Addresses #199 