### PR TITLE
Fix network linking in docs and api refs

### DIFF
--- a/docs/networks.py
+++ b/docs/networks.py
@@ -17,15 +17,15 @@
 # ========
 
 # Visualizing Connections: Graphs!
-# ================================
+# --------------------------------
 # Networks form a core aspect of any disciplines of science from engineering to biology. UltraPlot supports plotting networks using `networkx <https://networkx.org/>`__.  It provides an intuitive interface for plotting networks using :func:`~ultraplot.axes.PlotAxes.graph` to plot networks. Plot customization can be passed to the networkx backend, see for full details their documentation.
 # Layouts can be passed using strings, dicts or functions as long as they are compatible with networkx's layout functions.
 
 # Minimal Example
-# ===============
+# ---------------
 # To plot a graph, use :func:`~ultraplot.axes.PlotAxes.graph`. You need to merely provide a graph and UltraPlot will take care of the rest. UltraPlot will automatically style the layout to give sensible default. Every setting can be overidden if the user wants to customize the nodes, edges, or layout.
 #
-# By default, UltraPlot automatically styles the plot by removing the background and spines, and adjusting the layout to fit within a normalized [0,1] coordinate box. It also applies an equal aspect ratio to ensure square dimensions, which is ideal for the default circular markers. Additional customization—such as modifying labels, legends, axis limits, and more—can be done using :func:~ultraplot.axes.Cartesian.format to override the default styling.
+# By default, UltraPlot automatically styles the plot by removing the background and spines, and adjusting the layout to fit within a normalized [0,1] coordinate box. It also applies an equal aspect ratio to ensure square dimensions, which is ideal for the default circular markers. Additional customization—such as modifying labels, legends, axis limits, and more—can be done using :func:`~ultraplot.axes.CartesianAxes.format` to override the default styling.
 # %%
 import networkx as nx, ultraplot as uplt, numpy as np
 
@@ -43,8 +43,8 @@ uplt.show()
 
 # %% [raw] raw_mimetype="text/restructuredtext"
 # More Advanced Customization
-# ===========================
-# To customize a network plot, you can pass a dictionary of parameters to the :func:`~ultraplot.axes.PlotAxes.graph` function. These parameters are passed to the networkx backend, so you can refer to their documentation for more details (:func:`~networkx.draw`, :func:`~networkx.draw_networkx`, :func:`~networkx.draw_networkx_nodes`, :func:`~networkx.draw_networkx_edges`, :func:`~networkx.draw_networkx_labels`). A more complicated example is shown below.
+# ---------------------------
+# To customize a network plot, you can pass a dictionary of parameters to the :func:`~ultraplot.axes.PlotAxes.graph` function. These parameters are passed to the networkx backend, so you can refer to their documentation for more details (:func:`~networkx.drawing.nx_pylab.draw`, :func:`~networkx.drawing.nx_pylab.draw_networkx`, :func:`~networkx.drawing.nx_pylab.draw_networkx_nodes`, :func:`~networkx.drawing.nx_pylab.draw_networkx_edges`, :func:`~networkx.drawing.nx_pylab.draw_networkx_labels`). A more complicated example is shown below.
 # %%
 import networkx as nx, ultraplot as uplt, numpy as np
 

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -1081,27 +1081,27 @@ g : networkx.Graph
     :class:`networkx.DiGraph` or :class:`networkx.MultiGraph`.
 layout : callable or dict, optional
     A layout function or a precomputed dict mapping nodes to 2D positions. If a function
-    is given, it is called as ``layout(g, **layout_kw)`` to compute positions. See :func:`networkx.draw` for more information.
+    is given, it is called as ``layout(g, **layout_kw)`` to compute positions. See :func:`networkx.drawing.nx_pylab.draw` for more information.
 nodes : bool or iterable, default: rc["graph.draw_nodes"]
     Which nodes to draw. If `True`, all nodes are drawn. If an iterable is provided, only
-    the specified nodes are included. This effectively acts as `nodelist` in :func:`networkx.draw_networkx_nodes`.
+    the specified nodes are included. This effectively acts as `nodelist` in :func:`networkx.drawing.nx_pylab.draw_networkx_nodes`.
 edges : bool or iterable, default: rc["graph.draw_edges"]
     Which edges to draw. If `True`, all edges are drawn. If an iterable of edge tuples is
-    provided, only those edges are included. This effectively acts as `edgelist` in :func:`networkx.draw_networkx_edges`.
+    provided, only those edges are included. This effectively acts as `edgelist` in :func:`networkx.drawing.nx_pylab.draw_networkx_edges`.
 labels : bool or iterable, default: `rc["graph.draw_labels`]
     Whether to show node labels. If `True`, labels are drawn using node names. If an
     iterable is given, only those nodes are labeled.
 layout_kw : dict, default: {}
-    Keyword arguments passed to the layout function, if `layout` is callable, see <https://networkx.org/documentation/stable/reference/drawing.html> for more information.
+    Keyword arguments passed to the layout function, if `layout` is callable, see `networkx's drawing functions <https://networkx.org/documentation/stable/reference/drawing.html>`_ for more information.
 node_kw : dict, default: {}
-    Additional keyword arguments passed to the node drawing function (see :func:`networkx.draw_networkx_nodes`). These can include
-    size, color, edgecolor, cmap, alpha, etc., depending on the backend used, see :func:`networkx.draw_networkx_nodes`.
+    Additional keyword arguments passed to the node drawing function (see :func:`networkx.drawing.nx_pylab.draw_networkx_nodes`). These can include
+    size, color, edgecolor, cmap, alpha, etc., depending on the backend used, see :func:`networkx.drawing.nx_pylab.draw_networkx_nodes`.
 edge_kw : dict, default: {}
     Additional keyword arguments passed to the edge drawing function. These can include
-    width, color, style, alpha, arrows, etc (see :func:`networkx.draw_networkx_edges`).
+    width, color, style, alpha, arrows, etc (see :func:`networkx.drawing.nx_pylab.draw_networkx_edges`).
 label_kw : dict, default: {}
     Additional keyword arguments passed to the label drawing function, such as font size,
-    font color, background color, alignment, etc (see :func:`networkx.draw_networkx_labels`).
+    font color, background color, alignment, etc (see :func:`networkx.drawing.nx_pylab.draw_networkx_labels`).
 rescale : bool,  None, default: None.
     When set to none it checks for `rc["graph.rescale"]` which defaults to `True`. This performs a rescale such that the node position is within a [0, 1] x [0, 1] box.
 Returns


### PR DESCRIPTION
Networkx requires full path names for drawing functions. This PR fixes minor linking issues on the docs page and in the api for networkx functions.