### PR TITLE
rm dep warning

### DIFF
--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -1420,11 +1420,6 @@ class SubplotGrid(MutableSequence, list):
         # dedicated relevant commands that can be called from the grid (see below).
         import functools
 
-        warnings._warn_ultraplot(
-            "Calling arbitrary axes methods from SubplotGrid was deprecated in v0.8 "
-            "and will be removed in a future release. Please index the grid or loop "
-            "over the grid instead."
-        )
         if not self:
             return None
         objs = tuple(getattr(ax, attr) for ax in self)  # may raise error


### PR DESCRIPTION
I'm personally a strong proponent of calling plot methods directly on a series of axes. With that in mind, I believe we should remove this method, as I intend to continue supporting that approach. That said, I'm open to discussion if there's an important consideration I'm overlooking. One of UltraPlot’s strengths is its ability to simplify the management of subplot properties while still allowing fine-grained control. For that reason, I suggest we remove this statement.