### PR TITLE
perf: run comparison tests at the same time as the main tests

### DIFF
--- a/.github/workflows/build-ultraplot.yml
+++ b/.github/workflows/build-ultraplot.yml
@@ -52,7 +52,6 @@ jobs:
           slug: Ultraplot/ultraplot
 
   compare-baseline:
-    needs: build-ultraplot
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This PR makes the test suite about 6 minutes faster by running the image comparison tests in parallel with the main test suite.