### PR TITLE
Skip sharing logic when colorbar is added to GeoPlots.

### DIFF
--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -748,8 +748,8 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         for axi in self.figure.axes:
             # If users use PlotAxes methods, we need not
             # toggle the gridliner labels; we can just skip.
-            if not isinstance(axi, GeoAxes):
-                continue
+            print(type(axi))
+
             sides = recoded.get(axi, [])
             tmp = default.copy()
             for side in sides:

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -746,8 +746,8 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             bottom=are_ticks_on,
         )
         for axi in self.figure.axes:
-            # If users have colormeshes on top
-            # we need to not run the logic below
+            # If users use PlotAxes methods, we need not
+            # toggle the gridliner labels; we can just skip.
             if not isinstance(axi, GeoAxes):
                 continue
             sides = recoded.get(axi, [])

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -748,7 +748,8 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         for axi in self.figure.axes:
             # If users use PlotAxes methods, we need not
             # toggle the gridliner labels; we can just skip.
-            print(type(axi))
+            if not isinstance(axi, GeoAxes):
+                continue
 
             sides = recoded.get(axi, [])
             tmp = default.copy()

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -746,8 +746,9 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             bottom=are_ticks_on,
         )
         for axi in self.figure.axes:
-            # If users use PlotAxes methods, we need not
-            # toggle the gridliner labels; we can just skip.
+            # If users call colorbar on the figure
+            # an axis is added which needs to skip the
+            # sharing that is specific for the GeoAxes.
             if not isinstance(axi, GeoAxes):
                 continue
 

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -9,7 +9,7 @@ from functools import partial
 try:
     # From python 3.12
     from typing import override
-except:
+except ImportError:
     # From Python 3.5
     from typing_extensions import override
 
@@ -746,6 +746,10 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             bottom=are_ticks_on,
         )
         for axi in self.figure.axes:
+            # If users have colormeshes on top
+            # we need to not run the logic below
+            if not isinstance(axi, GeoAxes):
+                continue
             sides = recoded.get(axi, [])
             tmp = default.copy()
             for side in sides:

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -579,3 +579,21 @@ def test_sharing_levels():
             else:
                 assert s == 2
         uplt.close(fig)
+
+
+@pytest.mark.mpl_image_compare
+def test_cartesian_and_geo():
+    """
+    Test that axis sharing does not prevent
+    running Cartesian based plot functions
+    """
+    fig, ax = uplt.subplots(
+        ncols=2,
+        proj="cyl",
+        share=True,
+    )
+    # Make small range to speed up plotting
+    ax.format(land=True, lonlim=(-10, 10), latlim=(-10, 10))
+    ax[0].pcolormesh(np.random.rand(10, 10))
+    ax[1].scatter(*np.random.rand(2, 100))
+    return fig

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -587,13 +587,23 @@ def test_cartesian_and_geo():
     Test that axis sharing does not prevent
     running Cartesian based plot functions
     """
+
     fig, ax = uplt.subplots(
         ncols=2,
         proj="cyl",
         share=True,
     )
-    # Make small range to speed up plotting
-    ax.format(land=True, lonlim=(-10, 10), latlim=(-10, 10))
-    ax[0].pcolormesh(np.random.rand(10, 10))
-    ax[1].scatter(*np.random.rand(2, 100))
+    original_toggler = ax[0]._toggle_gridliner_labels
+    with mock.patch.object(
+        ax[0],
+        "_toggle_gridliner_labels",
+        autospec=True,
+        side_effect=original_toggler,
+    ) as mocked:
+        # Make small range to speed up plotting
+        ax.format(land=True, lonlim=(-10, 10), latlim=(-10, 10))
+        ax[0].pcolormesh(np.random.rand(10, 10))
+        ax[1].scatter(*np.random.rand(2, 100))
+        ax[0]._apply_axis_sharing()
+        assert mocked.call_count == 1
     return fig


### PR DESCRIPTION
This PR addresses #217. The recent added feature of sharing GeoAxes did not test when `PlotAxes` methods are called on `GeoAxes`. We don't have to apply the GeoSharing there; alternatively we could add the private function to the CartesianPlots. In this PR we just skip these axes.