### PR TITLE
Hotfix get_border_axes

### DIFF
--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -666,6 +666,9 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
                 target_axis=self._lataxis,
             )
 
+        # If we are not stale just return
+        if not self.stale:
+            return
         # Turn all labels off
         # Note: this action performs it for all the axes in
         # the figure. We use the stale here to only perform
@@ -701,6 +704,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             for side in sides:
                 tmp[side] = True
             axi._toggle_gridliner_labels(**tmp)
+        self.stale = True
 
     def _get_gridliner_labels(
         self,

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -745,6 +745,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             top=are_ticks_on,
             bottom=are_ticks_on,
         )
+        # print("-" * 64)
         for axi in self.figure.axes:
             # If users call colorbar on the figure
             # an axis is added which needs to skip the
@@ -756,6 +757,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             tmp = default.copy()
             for side in sides:
                 tmp[side] = True
+            # print(axi.number, tmp)
             axi._toggle_gridliner_labels(**tmp)
         self.stale = False
 

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -588,51 +588,6 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         if level >= 1 and labels:
             self._share_labels_with_others()
 
-    def _share_labels_with_others(self):
-        """
-        Enable label sharing with the axes.
-        """
-        # Turn all labels off
-        # Note: this action performs it for all the axes in
-        # the figure. We use the stale here to only perform
-        # it once as it is an expensive action.
-        border_axes = self.figure._get_border_axes()
-        # Recode:
-        recoded = {}
-        for direction, axes in border_axes.items():
-            for axi in axes:
-                recoded[axi] = recoded.get(axi, []) + [direction]
-
-        # We turn off the tick labels when the scale and
-        # ticks are shared (level >= 3)
-        are_ticks_on = False
-
-        default = dict(
-            left=are_ticks_on,
-            right=are_ticks_on,
-            top=are_ticks_on,
-            bottom=are_ticks_on,
-        )
-        for axi in self.figure.axes:
-            # If users call colorbar on the figure
-            # an axis is added which needs to skip the
-            # sharing that is specific for the GeoAxes.
-            if not isinstance(axi, GeoAxes):
-                continue
-
-            sides = recoded.get(axi, [])
-            tmp = default.copy()
-
-            gridlabels = self._get_gridliner_labels(
-                bottom=True, top=True, left=True, right=True
-            )
-            for side in sides:
-                if side in gridlabels and gridlabels[side]:
-                    tmp[side] = True
-
-            axi._toggle_gridliner_labels(**tmp)
-        self.stale = False
-
     @override
     def _sharey_setup(self, sharey, *, labels=True, limits=True):
         """

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -682,9 +682,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
 
         # We turn off the tick labels when the scale and
         # ticks are shared (level >= 3)
-        are_ticks_on = True
-        if self.figure._get_sharing_level() >= 3:
-            are_ticks_on = False
+        are_ticks_on = False
 
         default = dict(
             left=are_ticks_on,
@@ -701,8 +699,14 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
 
             sides = recoded.get(axi, [])
             tmp = default.copy()
+
+            gridlabels = self._get_gridliner_labels(
+                bottom=True, top=True, left=True, right=True
+            )
             for side in sides:
-                tmp[side] = True
+                if side in gridlabels and gridlabels[side]:
+                    tmp[side] = True
+
             axi._toggle_gridliner_labels(**tmp)
         self.stale = True
 

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -585,6 +585,54 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         if level > 1 and limits:
             self._share_limits_with(other, which=which)
 
+        if level >= 1 and labels:
+            self._share_labels_with_others()
+
+    def _share_labels_with_others(self):
+        """
+        Enable label sharing with the axes.
+        """
+        # Turn all labels off
+        # Note: this action performs it for all the axes in
+        # the figure. We use the stale here to only perform
+        # it once as it is an expensive action.
+        border_axes = self.figure._get_border_axes()
+        # Recode:
+        recoded = {}
+        for direction, axes in border_axes.items():
+            for axi in axes:
+                recoded[axi] = recoded.get(axi, []) + [direction]
+
+        # We turn off the tick labels when the scale and
+        # ticks are shared (level >= 3)
+        are_ticks_on = False
+
+        default = dict(
+            left=are_ticks_on,
+            right=are_ticks_on,
+            top=are_ticks_on,
+            bottom=are_ticks_on,
+        )
+        for axi in self.figure.axes:
+            # If users call colorbar on the figure
+            # an axis is added which needs to skip the
+            # sharing that is specific for the GeoAxes.
+            if not isinstance(axi, GeoAxes):
+                continue
+
+            sides = recoded.get(axi, [])
+            tmp = default.copy()
+
+            gridlabels = self._get_gridliner_labels(
+                bottom=True, top=True, left=True, right=True
+            )
+            for side in sides:
+                if side in gridlabels and gridlabels[side]:
+                    tmp[side] = True
+
+            axi._toggle_gridliner_labels(**tmp)
+        self.stale = False
+
     @override
     def _sharey_setup(self, sharey, *, labels=True, limits=True):
         """
@@ -666,55 +714,16 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
                 target_axis=self._lataxis,
             )
 
-        # If we are not stale just return
+        # This block is apart of the draw sequence as the
+        # gridliner object is created late in the
+        # build chain.
         if not self.stale:
             return
-
-        # If we are not  sharing labels, we return early
-        if self.figure._get_sharing_level() < 1:
+        if self.figure._get_sharing_level() == 0:
             return
-        # Turn all labels off
-        # Note: this action performs it for all the axes in
-        # the figure. We use the stale here to only perform
-        # it once as it is an expensive action.
-        border_axes = self.figure._get_border_axes()
-        # Recode:
-        recoded = {}
-        for direction, axes in border_axes.items():
-            for axi in axes:
-                recoded[axi] = recoded.get(axi, []) + [direction]
-
-        # We turn off the tick labels when the scale and
-        # ticks are shared (level >= 3)
-        are_ticks_on = False
-
-        default = dict(
-            left=are_ticks_on,
-            right=are_ticks_on,
-            top=are_ticks_on,
-            bottom=are_ticks_on,
-        )
-        for axi in self.figure.axes:
-            # If users call colorbar on the figure
-            # an axis is added which needs to skip the
-            # sharing that is specific for the GeoAxes.
-            if not isinstance(axi, GeoAxes):
-                continue
-
-            sides = recoded.get(axi, [])
-            tmp = default.copy()
-
-            gridlabels = self._get_gridliner_labels(
-                bottom=True, top=True, left=True, right=True
-            )
-            for side in sides:
-                if side in gridlabels and gridlabels[side]:
-                    tmp[side] = True
-
-            axi._toggle_gridliner_labels(**tmp)
-        # Mark the axes as stale to ensure that shared labels are updated.
-        # This is critical for enforcing shared axis labels and tick labels.
-        self.stale = True
+        # Share labels with all levels higher or equal
+        # to 1.
+        self._share_labels_with_others()
 
     def _get_gridliner_labels(
         self,
@@ -769,9 +778,43 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             target_axis.set_view_interval(*source_axis.get_view_interval())
             target_axis.set_minor_locator(source_axis.get_minor_locator())
 
-        if not self.stale:
-            return
+    def _share_labels_with_others(self):
+        """
+        Helpers function to ensure the labels
+        are shared for rectilinear GeoAxes.
+        """
+        # Turn all labels off
+        # Note: this action performs it for all the axes in
+        # the figure. We use the stale here to only perform
+        # it once as it is an expensive action.
+        border_axes = self.figure._get_border_axes()
+        # Recode:
+        recoded = {}
+        for direction, axes in border_axes.items():
+            for axi in axes:
+                recoded[axi] = recoded.get(axi, []) + [direction]
 
+        # We turn off the tick labels when the scale and
+        # ticks are shared (level >= 3)
+        are_ticks_on = False
+        default = dict(
+            left=are_ticks_on,
+            right=are_ticks_on,
+            top=are_ticks_on,
+            bottom=are_ticks_on,
+        )
+        for axi in self.figure.axes:
+            # If users call colorbar on the figure
+            # an axis is added which needs to skip the
+            # sharing that is specific for the GeoAxes.
+            if not isinstance(axi, GeoAxes):
+                continue
+
+            sides = recoded.get(axi, [])
+            tmp = default.copy()
+            for side in sides:
+                tmp[side] = True
+            axi._toggle_gridliner_labels(**tmp)
         self.stale = False
 
     @override

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -764,11 +764,14 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             # sharing that is specific for the GeoAxes.
             if not isinstance(axi, GeoAxes):
                 continue
-
+            gridlabels = self._get_gridliner_labels(
+                bottom=True, top=True, left=True, right=True
+            )
             sides = recoded.get(axi, [])
             tmp = default.copy()
             for side in sides:
-                tmp[side] = True
+                if side in gridlabels and gridlabels[side]:
+                    tmp[side] = True
             axi._toggle_gridliner_labels(**tmp)
         self.stale = False
 
@@ -1442,6 +1445,8 @@ class _CartopyAxes(GeoAxes, _GeoAxes):
             "bottom top left right".split(), [bottom, top, left, right]
         ):
             if side != True:
+                continue
+            if self.gridlines_major is None:
                 continue
             sides[dir] = getattr(self.gridlines_major, f"{dir}_label_artists")
         return sides

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -709,7 +709,6 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             )
             for side in sides:
                 if side in gridlabels and gridlabels[side]:
-                    print(gridlabels[side])
                     tmp[side] = True
 
             axi._toggle_gridliner_labels(**tmp)

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -669,6 +669,10 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         # If we are not stale just return
         if not self.stale:
             return
+
+        # If we are not  sharing labels, we return early
+        if self.figure._get_sharing_level() < 1:
+            return
         # Turn all labels off
         # Note: this action performs it for all the axes in
         # the figure. We use the stale here to only perform
@@ -705,6 +709,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             )
             for side in sides:
                 if side in gridlabels and gridlabels[side]:
+                    print(gridlabels[side])
                     tmp[side] = True
 
             axi._toggle_gridliner_labels(**tmp)

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -712,6 +712,8 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
                     tmp[side] = True
 
             axi._toggle_gridliner_labels(**tmp)
+        # Mark the axes as stale to ensure that shared labels are updated.
+        # This is critical for enforcing shared axis labels and tick labels.
         self.stale = True
 
     def _get_gridliner_labels(

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -745,7 +745,6 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             top=are_ticks_on,
             bottom=are_ticks_on,
         )
-        # print("-" * 64)
         for axi in self.figure.axes:
             # If users call colorbar on the figure
             # an axis is added which needs to skip the
@@ -757,7 +756,6 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             tmp = default.copy()
             for side in sides:
                 tmp[side] = True
-            # print(axi.number, tmp)
             axi._toggle_gridliner_labels(**tmp)
         self.stale = False
 

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -946,7 +946,7 @@ class Figure(mfigure.Figure):
 
         def is_border(pos, grid, target, direction):
             x, y = pos
-            # Check if we are at an edge
+            # Check if we are at an edge of the grid (out-of-bounds).
             if x < 0:
                 return True
             elif x > grid.shape[0] - 1:

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -967,7 +967,12 @@ class Figure(mfigure.Figure):
 
         for axi in all_axes:
             spec = axi.get_subplotspec()
-
+            # Check all cardinal directions. When we find a
+            #  border for any starting conditions we break and
+            # consider it a border. This could mean that for some
+            # partial overlaps we consider borders that should
+            # not be borders -- we are conservative in this
+            # regard
             for direction, d in directions.items():
                 found_border = False
                 xs = range(spec.rowspan.start, spec.rowspan.stop)

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -955,7 +955,6 @@ class Figure(mfigure.Figure):
             elif y > grid.shape[1] - 1:
                 return True
             # Check if we reached a plot or an internal edge
-            print(grid.shape, x, y)
             if grid[x, y] != target and grid[x, y] > 0:
                 return False
             elif grid[x, y] != target and grid[x, y] == 0:

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -936,7 +936,7 @@ class Figure(mfigure.Figure):
             # Top row
             if x == 0:
                 border_axes["top"].append(axi)
-            # Rottom row
+            # Bottom row
             elif x == nrows - 1:
                 border_axes["bottom"].append(axi)
             # There could be an internal axis that is facing

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -928,7 +928,7 @@ class Figure(mfigure.Figure):
         # spanning axes will fit into one of the boxes. Check
         # this with unittest to see how empty axes are handles
         for axi in all_axes:
-            # Infer coordinate from grdispec
+            # Infer coordinate from gridspec
             x, y = np.unravel_index(axi.number - 1, (nrows, ncols))
             grid[x, y] = True
         for axi in all_axes:

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -951,14 +951,16 @@ class Figure(mfigure.Figure):
                 return True
             elif x > grid.shape[0] - 1:
                 return True
+
             if y < 0:
                 return True
             elif y > grid.shape[1] - 1:
                 return True
+
             # Check if we reached a plot or an internal edge
             if grid[x, y] != target and grid[x, y] > 0:
                 return False
-            elif grid[x, y] != target and grid[x, y] == 0:
+            if grid[x, y] == 0:
                 return True
             dx, dy = direction
             new_pos = (x + dx, y + dy)
@@ -978,7 +980,6 @@ class Figure(mfigure.Figure):
             # not be borders -- we are conservative in this
             # regard
             for direction, d in directions.items():
-                found_border = False
                 xs = range(rowspan[0], rowspan[1] + 1)
                 ys = range(colspan[0], colspan[1] + 1)
                 for x, y in product(xs, ys):

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -260,6 +260,14 @@ def test_sharing_labels_top_right():
 
 
 def test_sharing_labels_top_right_odd_layout():
+
+    # Helper function to check if the labels
+    # on an axis direction is visible
+    def check_state(numbers: list, state: bool, which: str):
+        for number in numbers:
+            for label in getattr(ax[number], f"get_{which}ticklabels")():
+                assert label.get_visible() == state
+
     layout = [
         [1, 2, 0],
         [1, 2, 5],
@@ -271,11 +279,6 @@ def test_sharing_labels_top_right_odd_layout():
         xticklabelloc="t",
         yticklabelloc="r",
     )
-
-    def check_state(numbers: list, state: bool, which: str):
-        for number in numbers:
-            for label in getattr(ax[number], f"get_{which}ticklabels")():
-                assert label.get_visible() == state
 
     # these correspond to the indices of the axis
     # in the axes array (so the grid number minus 1)
@@ -291,15 +294,15 @@ def test_sharing_labels_top_right_odd_layout():
         [4, 0, 5],
     ]
 
-    fig, ax = uplt.subplots(layout)
+    fig, ax = uplt.subplots(layout, hspace=0.2, wspace=0.2, share=1)
     ax.format(
         xticklabelloc="t",
         yticklabelloc="r",
     )
     # these correspond to the indices of the axis
     # in the axes array (so the grid number minus 1)
-    check_state([0, 3], False, which="y")
+    check_state([0, 3], True, which="y")
     check_state([1, 2, 4], True, which="y")
     check_state([0, 1, 2], True, which="x")
-    check_state([3, 4], False, which="x")
+    check_state([3, 4], True, which="x")
     uplt.close(fig)

--- a/ultraplot/tests/test_format.py
+++ b/ultraplot/tests/test_format.py
@@ -58,7 +58,7 @@ def test_patch_format():
     """
     Test application of patch args on initialization.
     """
-    fig = uplt.figure(suptitle="Super title")
+    fig = uplt.figure(suptitle="Super title", share=0)
     fig.subplot(
         121, proj="cyl", labels=True, land=True, latlines=20, abcloc="l", abc="[A]"
     )
@@ -82,7 +82,7 @@ def test_multi_formatting():
     Support formatting in multiple projections.
     """
     # Mix Cartesian with a projection
-    fig, axs = uplt.subplots(ncols=2, proj=("cart", "cyl"))
+    fig, axs = uplt.subplots(ncols=2, proj=("cart", "cyl"), share=0)
     axs[0].pcolormesh(np.random.rand(5, 5))
 
     # Warning is raised based on projection. Cart does not have lonlim, latllim or labels

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -580,7 +580,7 @@ def test_sharing_levels():
             assert_views_are_sharing(axi)
             # When we share the labels but not the limits,
             # we expect all ticks to be on
-            if level < 3:
+            if level == 0:
                 assert s == 4
             else:
                 assert s == 2

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -253,6 +253,12 @@ def test_sharing_cartopy():
     n = 3
     settings = dict(land=True, ocean=True, labels="both")
     fig, ax = uplt.subplots(ncols=n, nrows=n, share="all", proj="cyl")
+    # Add data and ensure the tests still hold
+    # Adding a colorbar will change the underlying gridpsec, the
+    # labels should still be correctly treated.
+    data = np.random.rand(10, 10)
+    h = ax.imshow(data)[0]
+    fig.colorbar(h, loc="r")
     ax.format(**settings)
     fig.canvas.draw()  # need a draw to trigger ax.draw for  sharing
 

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -611,7 +611,7 @@ def test_cartesian_and_geo():
         ax[0].pcolormesh(np.random.rand(10, 10))
         ax[1].scatter(*np.random.rand(2, 100))
         ax[0]._apply_axis_sharing()
-        assert mocked.call_count == 1
+        assert mocked.call_count == 2
     return fig
 
 

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -254,7 +254,7 @@ def test_sharing_cartopy():
     settings = dict(land=True, ocean=True, labels="both")
     fig, ax = uplt.subplots(ncols=n, nrows=n, share="all", proj="cyl")
     # Add data and ensure the tests still hold
-    # Adding a colorbar will change the underlying gridpsec, the
+    # Adding a colorbar will change the underlying gridspec, the
     # labels should still be correctly treated.
     data = np.random.rand(10, 10)
     h = ax.imshow(data)[0]


### PR DESCRIPTION
The colorbar (apparently) fundamentally changes the gridspec in a non-trivial way, see #234. This causes an issue with the introduced `GeoAxes` sharing feature where the borders were determined based on the position in the gridpec. We can sidestep this issue by using the gridspec of the figure to reconstruct the position.

Current implementation now produces

![image](https://github.com/user-attachments/assets/3bcab31d-5570-42fa-8573-f79a99530002)
