### PR TITLE
Deprecate basemap

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -826,7 +826,7 @@ class Figure(mfigure.Figure):
         # Basemap is currently being developed again so are removing the deprecation warning
         if backend == "basemap":
             warnings._warn_ultraplot(
-                f"{backend=} will be deprecated in next major release (v1.6)"
+                f"{backend=} will be deprecated in next major release (v2.0). See https://github.com/Ultraplot/ultraplot/pull/243"
             )
         return backend
 


### PR DESCRIPTION
This PR will introduce a deprecation warning for basemap. The rationale behind deprecation is as follows: basemap was deprecated in the past, but it seemed like development was picking  up steam again. It has been a few months since I submitted a few PRs that would update basemap with modern tooling (in particular numpy, see https://github.com/matplotlib/basemap/issues/604, https://github.com/matplotlib/basemap/pull/623, https://github.com/matplotlib/basemap/pull/622). Not sure what the status is currently but little activity has been seen on that repo for a while. Furthermore, cartopy has more powerful features with good matplotlib support. Lastly, it would streamline our development as we only have to focus on a singular backend and `geo.py` needs a refactor in my opinion. 

I open this PR up for community members to chip in, but I don't see a good reason to not do this.