### PR TITLE
Update return requirements pytest 8.4.0

### DIFF
--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -615,7 +615,7 @@ def test_bar_alpha():
     y = [2]
     ax.bar(x, y, alphas=[0.2])
     ax.bar(x, y, alphas=0.2)
-    return fig
+    uplt.close(fig)
 
 
 @pytest.mark.mpl_image_compare

--- a/ultraplot/tests/test_format.py
+++ b/ultraplot/tests/test_format.py
@@ -405,7 +405,7 @@ def test_scaler():
     fig, ax = uplt.subplots(ncols=2, share=0)
     ax[0].set_yscale("mercator")
     ax[1].set_yscale("asinh")
-    return fig
+    uplt.close(fig)
 
 
 @pytest.mark.mpl_image_compare

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -238,7 +238,7 @@ def test_lon0_shifts():
         n = len(str_loc)
         assert str_loc == format[:n]
     assert locs[0] != 0  # we should not be a 0 anymore
-    return fig
+    uplt.close(fig)
 
 
 def test_sharing_cartopy():
@@ -296,7 +296,7 @@ def test_sharing_cartopy():
         state = are_labels_on(axi)
         expectation = expectations[axi.number - 1]
         assert all([i == j for i, j in zip(state, expectation)])
-    return fig
+    uplt.close(fig)
 
 
 def test_toggle_gridliner_labels():

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -226,7 +226,7 @@ def test_quiver_discrete_colors():
     C = np.random.rand(3, 4)
     ax.quiver(X - 2, Y, U, V, C)
     ax.quiver(X - 3, Y, U, V, color="red", infer_rgb=True)
-    return fig
+    uplt.close(fig)
 
 
 def test_setting_log_with_rc():
@@ -281,7 +281,7 @@ def test_setting_log_with_rc():
             axi = getattr(ax, f"{target}axis")
             check_ticks(axi, target=False)
 
-    return fig
+    uplt.close(fig)
 
 
 def test_shading_pcolor():
@@ -324,7 +324,7 @@ def test_shading_pcolor():
         else:
             assert x.shape[0] == z.shape[0]
             assert x.shape[1] == z.shape[1]
-    return fig
+    uplt.close(fig)
 
 
 def test_cycle_with_singular_column():


### PR DESCRIPTION
Pytest has a stricter requirement on tests returning objects without being marked as such. This fixes the tests that do this.