### PR TITLE
Add citation metadata (CITATION.cff, .zenodo.json) to support scholarly use

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
     {
       "name": "Becker, Matthew",
       "orcid": "0000-0001-7774-2246",
-      "affiliation": "Argonne National Laboratory: Lemont, US"
+      "affiliation": "Argonne National Laboratory, Lemont, IL USA"
     }
   ],
   "license": "MIT",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -9,7 +9,7 @@
       "affiliation": "University of Amsterdam, Polder Center, Institute for Advanced Study Amsterdam"
     },
     {
-      "name": "Becker, Matthew",
+      "name": "Becker, Matthew R.",
       "orcid": "0000-0001-7774-2246",
       "affiliation": "Argonne National Laboratory, Lemont, IL USA"
     }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,39 @@
+{
+  "title": "UltraPlot: A succinct wrapper for Matplotlib",
+  "upload_type": "software",
+  "description": "UltraPlot provides a compact and extensible API on top of Matplotlib, inspired by ProPlot. It simplifies the creation of scientific plots with consistent layout, colorbars, and shared axes.",
+  "creators": [
+    {
+      "name": "van Elteren, Casper",
+      "orcid": "0000-0001-9862-8936",
+      "affiliation": "University of Amsterdam, Polder Center, Institute for Advanced Study Amsterdam"
+    },
+    {
+      "name": "Becker, Matthew",
+      "orcid": "0000-0001-7774-2246",
+      "affiliation": "Argonne National Laboratory: Lemont, US"
+    }
+  ],
+  "license": "MIT",
+  "keywords": [
+    "matplotlib",
+    "scientific visualization",
+    "plotting",
+    "wrapper",
+    "python"
+  ],
+  "related_identifiers": [
+    {
+      "relation": "isDerivedFrom",
+      "identifier": "https://github.com/lukelbd/proplot",
+      "scheme": "url"
+    },
+    {
+      "relation": "isDerivedFrom",
+      "identifier": "https://matplotlib.org/",
+      "scheme": "url"
+    }
+  ],
+  "version": "1.57",
+  "publication_date": "2025-01-01" // need to fix
+}

--- a/CITATON.cff
+++ b/CITATON.cff
@@ -6,7 +6,7 @@ authors:
     given-names: "Casper"
     orcid: "https://orcid.org/0000-0001-9862-8936"
   - family-names: "Becker"
-    given-names: "Matthew"
+    given-names: "Matthew R."
     orcid: "https://orcid.org/0000-0001-7774-2246"
 date-released: "2025-01-01"
 version: "1.57"

--- a/CITATON.cff
+++ b/CITATON.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+message: "If you use UltraPlot in your work, please cite it using the following metadata."
+title: "UltraPlot"
+authors:
+  - family-names: "van Elteren"
+    given-names: "Casper"
+    orcid: "https://orcid.org/0000-0001-9862-8936"
+  - family-names: "Becker"
+    given-names: "Matthew"
+    orcid: "https://orcid.org/0000-0001-7774-2246"
+date-released: "2025-01-01"
+version: "1.57"
+doi: "10.5281/zenodo.XXXXXXX"  # need to add
+repository-code: "https://github.com/Ultraplot/UltraPlot"
+license: "MIT"
+keywords:
+  - plotting
+  - matplotlib
+  - scientific visualization
+  - wrapper
+references:
+  - type: software
+    name: "ProPlot"
+    authors:
+      - family-names: "Davis"
+        given-names: "Luke"
+    url: "https://github.com/lukelbd/proplot"
+  - type: software
+    name: "Matplotlib"
+    authors:
+      - family-names: "Hunter"
+        given-names: "John D."
+    url: "https://matplotlib.org/"

--- a/README.rst
+++ b/README.rst
@@ -116,16 +116,17 @@ To install a development version of UltraPlot, you can use
 or clone the repository and run ``pip install -e .``
 inside the ``ultraplot`` folder.
 
-```bibtex
-@software{vanElteren2025,
-  author       = {Casper van Elteren and Matthew Becker},
-  title        = {UltraPlot: A succinct wrapper for Matplotlib},
-  year         = {2025},
-  version      = {1.5.7},
-  publisher    = {GitHub},
-  url          = {https://github.com/Ultraplot/UltraPlot}
-}
-```
+If you use UltraPlot in your research, please cite it using the following BibTeX entry::
+
+    @software{vanElteren2025,
+      author       = {Casper van Elteren and Matthew Becker},
+      title        = {UltraPlot: A succinct wrapper for Matplotlib},
+      year         = {2025},
+      version      = {1.5.7},
+      publisher    = {GitHub},
+      url          = {https://github.com/Ultraplot/UltraPlot}
+    }
+
 
 
 .. |build-status| image::  https://github.com/ultraplot/ultraplot/actions/workflows/build-ultraplot.yml/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ inside the ``ultraplot`` folder.
 If you use UltraPlot in your research, please cite it using the following BibTeX entry::
 
     @software{vanElteren2025,
-      author       = {Casper van Elteren and Matthew Becker},
+      author       = {Casper van Elteren and Matthew R. Becker},
       title        = {UltraPlot: A succinct wrapper for Matplotlib},
       year         = {2025},
       version      = {1.5.7},

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,17 @@ To install a development version of UltraPlot, you can use
 or clone the repository and run ``pip install -e .``
 inside the ``ultraplot`` folder.
 
+```bibtex
+@software{vanElteren2025,
+  author       = {Casper van Elteren and Matthew Becker},
+  title        = {UltraPlot: A succinct wrapper for Matplotlib},
+  year         = {2025},
+  version      = {1.5.7},
+  publisher    = {GitHub},
+  url          = {https://github.com/Ultraplot/UltraPlot}
+}
+```
+
 
 .. |build-status| image::  https://github.com/ultraplot/ultraplot/actions/workflows/build-ultraplot.yml/badge.svg
 


### PR DESCRIPTION
This PR formally introduces citation metadata for the UltraPlot project.

UltraPlot is a continuation of the original [ProPlot](https://github.com/lukelbd/proplot) library, which has not seen active development since 2022. While ProPlot laid the foundation for many of the ideas in UltraPlot, this project has been significantly restructured, modernized, and extended, and is being actively maintained.

To acknowledge this transition and to support reproducible and citable scientific software, we now include:

- A `CITATION.cff` file for automatic citation support on GitHub and with Zotero.
- A `.zenodo.json` file for future DOI integration via Zenodo.
- A BibTeX citation in the README for easy copy-paste into academic manuscripts.

We are committed to maintaining this project as a reliable and actively supported plotting library, especially for scientific users. We encourage users to cite *UltraPlot* if it contributes to their research. The citation metadata also acknowledges prior work from ProPlot and Matplotlib, on which UltraPlot is based.

### Example Citation (BibTeX)

```bibtex
@software{vanElteren2025,
  author       = {Casper van Elteren and Matthew Becker},
  title        = {UltraPlot: A succinct wrapper for Matplotlib},
  year         = {2025},
  version      = {1.5.7},
  publisher    = {GitHub},
  url          = {https://github.com/Ultraplot/UltraPlot}
}
```


We believe clear authorship and citation support are essential to long-term sustainability in scientific software.


Please check if I added your affiliation correctly @beckermr. Will need to update the zenodo links if the format is accepted as is.