### PR TITLE
Add error when plotting cftime

### DIFF
--- a/ultraplot/internals/inputs.py
+++ b/ultraplot/internals/inputs.py
@@ -160,10 +160,9 @@ def _to_numpy_array(data, strip_units=False):
             result = np.atleast_1d(data.magnitude) * data.units
     else:
         result = np.atleast_1d(data)  # natively preserves masked arrays
-
     # If the array contains cftime objects, ensure nc-time-axis is available.
     if result.size:
-        first_elem = result.flat[0]
+        first_elem = result.flatten()[0]
         if hasattr(
             first_elem, "__class__"
         ) and first_elem.__class__.__module__.startswith("cftime"):


### PR DESCRIPTION
Plotting on non-gregorian time scales raises an error. Matplotlib by default does not allow for this. Luckily there is a fix. By installing `nc-time-axis` some formatters are registered that allows for this. We can either implement this natively or add an install requirement

Currently I just implemented an error when one is plotting in a non-gregorian calendar (issue raised in #288).