### PR TITLE
fix late binding and proper reversal for funcs

### DIFF
--- a/ultraplot/colors.py
+++ b/ultraplot/colors.py
@@ -1271,14 +1271,17 @@ class ContinuousColormap(mcolors.LinearSegmentedColormap, _Colormap):
         --------
         matplotlib.colors.LinearSegmentedColormap.reversed
         """
-        # Reverse segments
-        segmentdata = {}
-        for key, data in self._segmentdata.items():
-            if callable(data):
-                segmentdata[key] = lambda x, func=data: func(1.0 - x)
-            else:
-                segmentdata[key] = tuple((1.0 - x, y1, y0) for x, y0, y1 in data)
 
+        # Reverse segments
+        def _reverse_data(data):
+            if callable(data):
+                return lambda x, func=data: func(1 - x)
+            else:
+                return [(1.0 - x, y1, y0) for x, y0, y1 in reversed(data)]
+
+        segmentdata = {
+            key: _reverse_data(data) for key, data in self._segmentdata.items()
+        }
         # Reverse gammas
         if name is None:
             name = self._make_name(suffix="r")

--- a/ultraplot/colors.py
+++ b/ultraplot/colors.py
@@ -1272,14 +1272,12 @@ class ContinuousColormap(mcolors.LinearSegmentedColormap, _Colormap):
         matplotlib.colors.LinearSegmentedColormap.reversed
         """
         # Reverse segments
-        segmentdata = {
-            key: (
-                (lambda x, func=data: func(x))
-                if callable(data)
-                else [(1.0 - x, y1, y0) for x, y0, y1 in reversed(data)]
-            )
-            for key, data in self._segmentdata.items()
-        }
+        segmentdata = {}
+        for key, data in self._segmentdata.items():
+            if callable(data):
+                segmentdata[key] = lambda x, func=data: func(1.0 - x)
+            else:
+                segmentdata[key] = tuple((1.0 - x, y1, y0) for x, y0, y1 in data)
 
         # Reverse gammas
         if name is None:
@@ -3156,7 +3154,7 @@ class ColormapDatabase(mcm.ColormapRegistry):
 
             # Try mirroring the non-lowered key
             if reverse:
-                original_key = original_key.strip("_r")
+                original_key = original_key.rstrip("_r")
             half = len(original_key) // 2
             mirrored_key = original_key[half:] + original_key[:half]
             if self._has_item(mirrored_key):

--- a/ultraplot/colors.py
+++ b/ultraplot/colors.py
@@ -3138,7 +3138,7 @@ class ColormapDatabase(mcm.ColormapRegistry):
         # Handle reversal
         reverse = key.endswith("_r")
         if reverse:
-            key = key.rstrip("_r")
+            key = key.removesuffix("_r")
 
         # Check if the key exists in builtin colormaps
         if self._has_item(key):
@@ -3157,7 +3157,7 @@ class ColormapDatabase(mcm.ColormapRegistry):
 
             # Try mirroring the non-lowered key
             if reverse:
-                original_key = original_key.rstrip("_r")
+                original_key = original_key.removesuffix("_r")
             half = len(original_key) // 2
             mirrored_key = original_key[half:] + original_key[:half]
             if self._has_item(mirrored_key):
@@ -3183,11 +3183,11 @@ class ColormapDatabase(mcm.ColormapRegistry):
         key = self._translate_key(key, mirror=True)
         shift = key.endswith("_s") and not self._has_item(key)
         if shift:
-            key = key.rstrip("_s")
+            key = key.removesuffix("_s")
         reverse = key.endswith("_r") and not self._has_item(key)
 
         if reverse:
-            key = key.rstrip("_r")
+            key = key.removesuffix("_r")
         # Retrieve colormap
         if self._has_item(key):
             value = self._cmaps[key].copy()

--- a/ultraplot/tests/test_colormap.py
+++ b/ultraplot/tests/test_colormap.py
@@ -1,0 +1,12 @@
+import ultraplot as uplt, pytest, numpy as np
+
+
+def test_colormap_reversal():
+    # Rainbow uses a callable which went wrong see
+    # https://github.com/Ultraplot/UltraPlot/issues/294#issuecomment-3016653770
+    cmap = uplt.Colormap("rainbow")
+    cmap_r = cmap.reversed()
+    for i in range(256):
+        assert np.allclose(
+            cmap(i), cmap_r(255 - i)
+        ), f"Reversed colormap mismatch at index {i}"


### PR DESCRIPTION
A secondary issue came up in #294 where a callable is not properly inverse. 

This PR fixes a bug in the reversal of colormap segment data where callable segments were incorrectly captured due to Python’s late binding behavior in closures. Specifically, lambdas inside the dictionary comprehension referenced the loop variable data, which caused all callables to use the last data value. This is resolved by binding data as a default argument in the lambda. Explicit segment lists are unaffected and still reversed correctly.