### PR TITLE
Handle non homogeneous arrays 

### DIFF
--- a/ultraplot/internals/inputs.py
+++ b/ultraplot/internals/inputs.py
@@ -150,13 +150,17 @@ def _to_numpy_array(data, strip_units=False):
         data = data.data  # support pint quantities that get unit-stripped later
     elif isinstance(data, (DataFrame, Series, Index)):
         data = data.values
+
     if Quantity is not ndarray and isinstance(data, Quantity):
         if strip_units:
             return np.atleast_1d(data.magnitude)
         else:
             return np.atleast_1d(data.magnitude) * data.units
-    else:
+    try:
         return np.atleast_1d(data)  # natively preserves masked arrays
+    except:
+        # handle  non-homogeneous data
+        return np.array(data, dtype=object)
 
 
 def _to_masked_array(data, *, copy=False):

--- a/ultraplot/internals/inputs.py
+++ b/ultraplot/internals/inputs.py
@@ -158,7 +158,7 @@ def _to_numpy_array(data, strip_units=False):
             return np.atleast_1d(data.magnitude) * data.units
     try:
         return np.atleast_1d(data)  # natively preserves masked arrays
-    except:
+    except (TypeError, ValueError):
         # handle  non-homogeneous data
         return np.array(data, dtype=object)
 

--- a/ultraplot/tests/test_inputs.py
+++ b/ultraplot/tests/test_inputs.py
@@ -6,7 +6,7 @@ import ultraplot as uplt, pytest, numpy as np
     [
         ([1, 2, 3], int),
         ([[1, 2], [1, 2, 3]], object),
-        (["hello", 1], np.dtype("<U21")),  # will convert 1 to string
+        (["hello", 1], "unicode"),  # will convert 1 to string
         ([["hello"], 1], object),  # non-homogeneous  # mixed types
     ],
 )

--- a/ultraplot/tests/test_inputs.py
+++ b/ultraplot/tests/test_inputs.py
@@ -1,0 +1,23 @@
+import ultraplot as uplt, pytest, numpy as np
+
+
+class BrokenObject:
+    def __str__(self):
+        raise Exception("I am broken.")
+
+
+@pytest.mark.parametrize(
+    "data, dtype",
+    [
+        ([1, 2, 3], int),
+        ([[1, 2], [1, 2, 3]], object),
+        (["hello", 1], np.dtype("<U21")),  # will convert 1 to string
+        ([["hello"], 1], object),  # non-homogeneous  # mixed types
+    ],
+)
+def test_to_numpy_array(data, dtype):
+    """
+    Test that to_numpy_array works with various data types.
+    """
+    arr = uplt.internals.inputs._to_numpy_array(data)
+    assert arr.dtype == dtype, f"Expected dtype {dtype}, got {arr.dtype}"

--- a/ultraplot/tests/test_inputs.py
+++ b/ultraplot/tests/test_inputs.py
@@ -6,7 +6,7 @@ import ultraplot as uplt, pytest, numpy as np
     [
         ([1, 2, 3], int),
         ([[1, 2], [1, 2, 3]], object),
-        (["hello", 1], "unicode"),  # will convert 1 to string
+        (["hello", 1], np.dtype("<U21")),  # will convert 1 to string
         ([["hello"], 1], object),  # non-homogeneous  # mixed types
     ],
 )

--- a/ultraplot/tests/test_inputs.py
+++ b/ultraplot/tests/test_inputs.py
@@ -1,11 +1,6 @@
 import ultraplot as uplt, pytest, numpy as np
 
 
-class BrokenObject:
-    def __str__(self):
-        raise Exception("I am broken.")
-
-
 @pytest.mark.parametrize(
     "data, dtype",
     [

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -446,4 +446,4 @@ def test_inhomogeneous_violin(rng):
     assert len(violins) == 2
     for violin in violins:
         assert violin.get_paths()  # Ensure paths are created
-    uplt.close(fig)
+    return fig

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -436,12 +436,12 @@ def test_color_parsing_for_none():
 
 
 @pytest.mark.mpl_image_compare
-def test_inhomogeneous_violin():
+def test_inhomogeneous_violin(rng):
     """
     Test that inhomogeneous violin plots work correctly.
     """
     fig, ax = uplt.subplots()
-    data = [np.random.normal(size=100), np.random.normal(size=200)]
+    data = [rng.normal(size=100), np.random.normal(size=200)]
     violins = ax.violinplot(data, vert=True, labels=["A", "B"])
     assert len(violins) == 2
     for violin in violins:

--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -433,3 +433,17 @@ def test_color_parsing_for_none():
     for artist in ax[0].collections:
         assert artist.get_facecolor().shape[0] == 0
     uplt.close(fig)
+
+
+@pytest.mark.mpl_image_compare
+def test_inhomogeneous_violin():
+    """
+    Test that inhomogeneous violin plots work correctly.
+    """
+    fig, ax = uplt.subplots()
+    data = [np.random.normal(size=100), np.random.normal(size=200)]
+    violins = ax.violinplot(data, vert=True, labels=["A", "B"])
+    assert len(violins) == 2
+    for violin in violins:
+        assert violin.get_paths()  # Ensure paths are created
+    uplt.close(fig)


### PR DESCRIPTION
This PR will attempt to parse the data inputs as a `dtype=object` if the input has different dimensions as was the case in #317. This would allow for more flexible parsing in violin and boxplots.