### PR TITLE
Update Cartopy references

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -24,7 +24,7 @@ or clone the repository and run ``pip install -e .`` inside
 the ``ultraplot`` folder.
 
 ultraplot's only hard dependency is `matplotlib <https://matplotlib.org/>`__.
-The *soft* dependencies are `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`__,
+The *soft* dependencies are `cartopy <https://cartopy.readthedocs.io/stable/>`__,
 `basemap <https://matplotlib.org/basemap/index.html>`__,
 `xarray <http://xarray.pydata.org>`__, and `pandas <https://pandas.pydata.org>`__.
 See the documentation for details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,7 +229,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
-    "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
+    "cartopy": ("https://cartopy.readthedocs.io/stable/", None),
     "basemap": ("https://matplotlib.org/basemap/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pint": ("https://pint.readthedocs.io/en/stable/", None),

--- a/docs/external-links.rst
+++ b/docs/external-links.rst
@@ -22,7 +22,7 @@ dependencies of UltraPlot, or are distributed with UltraPlot:
 * `pint <https://github.com/hgrecco/pint>`__ - A package for tracking and
   converting between physical units during mathematical operations and when
   plotting in matplotlib axes.
-* `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`__ - A package for
+* `cartopy <https://cartopy.readthedocs.io/stable/>`__ - A package for
   plotting geographic and geophysical data in matplotlib. Includes a suite of
   different map projections.
 * `basemap <https://github.com/matplotlib/basemap>`__ - The original cartographic

--- a/docs/projections.py
+++ b/docs/projections.py
@@ -17,7 +17,7 @@
 #
 # .. _polar: https://matplotlib.org/3.1.0/gallery/pie_and_polar_charts/polar_demo.html
 #
-# .. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
+# .. _cartopy: https://cartopy.readthedocs.io/stable/
 #
 # .. _basemap: https://matplotlib.org/basemap/index.html
 #
@@ -205,7 +205,7 @@ axs.format(
 #      to :func:`~ultraplot.axes.GeoAxes.format`.
 #    * By default, UltraPlot gives circular boundaries to polar cartopy and basemap
 #      projections like :class:`~cartopy.crs.NorthPolarStereo` (see `this example
-#      <https://scitools.org.uk/cartopy/docs/latest/gallery/lines_and_polygons/always_circular_stereo.html>`__
+#      <https://cartopy.readthedocs.io/stable/gallery/lines_and_polygons/always_circular_stereo.html>`__
 #      from the cartopy website). To disable this feature, set :rcraw:`geo.round` to
 #      ``False`` or pass ``round=False` to :func:`~ultraplot.axes.GeoAxes.format`. Please note
 #      that older versions of cartopy cannot add gridlines to maps bounded by circles.
@@ -510,7 +510,7 @@ uplt.rc.reset()
 # Included projections
 # --------------------
 #
-# The available `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`__
+# The available `cartopy <https://cartopy.readthedocs.io/stable/>`__
 # and `basemap <https://matplotlib.org/basemap/index.html>`__ projections are
 # plotted below. The full table of projection names with links to the relevant
 # `PROJ <https://proj.org>`__ documentation is found :ref:`here <proj_table>`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,4 +1,4 @@
-.. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
+.. _cartopy: https://cartopy.readthedocs.io/stable/
 
 .. _basemap: https://matplotlib.org/basemap/index.html
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -1,4 +1,4 @@
-.. _cartopy: https://scitools.org.uk/cartopy/docs/latest/
+.. _cartopy: https://cartopy.readthedocs.io/stable/
 
 .. _basemap: https://matplotlib.org/basemap/index.html
 

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -1151,7 +1151,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         """
         This function is intended for the Basemap backend
         and mirrors the label placement behavior of Cartopy.
-        See: https://scitools.org.uk/cartopy/docs/v0.16/_modules/cartopy/mpl/gridliner.html#Gridliner
+        See: https://cartopy.readthedocs.io/stable/reference/generated/cartopy.mpl.gridliner.Gridliner.html
         """
         sides = dict()
         for which, formatter in zip("xy", gl):
@@ -1341,7 +1341,7 @@ class _CartopyAxes(GeoAxes, _GeoAxes):
         Return a circle `~matplotlib.path.Path` used as the outline for polar
         stereographic, azimuthal equidistant, Lambert conformal, and gnomonic
         projections. This was developed from `this cartopy example \
-    <https://scitools.org.uk/cartopy/docs/v0.15/examples/always_circular_stereo.html>`__.
+    <https://cartopy.readthedocs.io/v0.25.0.post2/gallery/lines_and_polygons/always_circular_stereo.html>`__.
         """
         theta = np.linspace(0, 2 * np.pi, N)
         center, radius = [0.5, 0.5], 0.5


### PR DESCRIPTION
The Cartopy docs have a new home on ReadTheDocs.  There is an intention to retire the whole www.scitools.org.uk site at some point so the version-specific links will also break.