### PR TITLE
Fix inhomogeneous violin test

### DIFF
--- a/ultraplot/tests/test_plot.py
+++ b/ultraplot/tests/test_plot.py
@@ -441,7 +441,7 @@ def test_inhomogeneous_violin(rng):
     Test that inhomogeneous violin plots work correctly.
     """
     fig, ax = uplt.subplots()
-    data = [rng.normal(size=100), np.random.normal(size=200)]
+    data = [rng.normal(size=100), rng.normal(size=200)]
     violins = ax.violinplot(data, vert=True, labels=["A", "B"])
     assert len(violins) == 2
     for violin in violins:


### PR DESCRIPTION
I think the current failure on main is because one of the violin plots uses `np.random` without a fixed seed.