### PR TITLE
Update Documentation for `abc` Parameter in Subplots and Format Command

### DIFF
--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -48,7 +48,7 @@
 # UltraPlot can quickly add labels to subplots using the `abc` parameter. This parameter
 # can be a template (with a letter "a" or "A") used to format the subplot labels, such as "A.", which assigns
 # an alphabetic label based on the axis number. Alternatively, you can pass a list to
-# the `abc` parameter, which will use the corresponding list elements as labels for
+# the `abc` parameter, where the list elements are mapped as labels for the subplots one by one.
 # the subplots. If you add subplots one-by-one with :func:`~ultraplot.figure.Figure.add_subplot`,
 # you can manually specify the number with the `number` keyword. By default, the subplot
 # number is incremented by ``1`` each time you call :func:`~ultraplot.figure.Figure.add_subplot`.

--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -46,7 +46,7 @@
 # ------------
 #
 # UltraPlot can quickly add labels to subplots using the `abc` parameter. This parameter
-# can be used as a template to format the subplot labels, such as "A.", which assigns
+# can be a template (with a letter "a" or "A") used to format the subplot labels, such as "A.", which assigns
 # an alphabetic label based on the axis number. Alternatively, you can pass a list to
 # the `abc` parameter, which will use the corresponding list elements as labels for
 # the subplots. If you add subplots one-by-one with :func:`~ultraplot.figure.Figure.add_subplot`,

--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -45,18 +45,19 @@
 # A-b-c labels
 # ------------
 #
-# UltraPlot can quickly add "a-b-c" labels using the
-# :func:`~ultraplot.axes.Axes.number` assigned to each subplot.
-# If you add subplots one-by-one with :func:`~ultraplot.figure.Figure.add_subplot`, you can
-# manually specify the number with the `number` keyword. By default, the subplot number
-# is incremented by ``1`` each time you call :func:`~ultraplot.figure.Figure.add_subplot`.
+# UltraPlot can quickly add labels to subplots using the `abc` parameter. This parameter
+# can be used as a template to format the subplot labels, such as "A.", which assigns
+# an alphabetic label based on the axis number. Alternatively, you can pass a list to
+# the `abc` parameter, which will use the corresponding list elements as labels for
+# the subplots. If you add subplots one-by-one with :func:`~ultraplot.figure.Figure.add_subplot`,
+# you can manually specify the number with the `number` keyword. By default, the subplot
+# number is incremented by ``1`` each time you call :func:`~ultraplot.figure.Figure.add_subplot`.
 # If you draw all of your subplots at once with :func:`~ultraplot.figure.Figure.add_subplots`,
-# the numbers depend on the input arguments. If you
-# :ref:`passed an array <ug_intro>`, the subplot numbers correspond to the numbers
-# in the array. But if you used the `ncols` and `nrows` keyword arguments, the
-# number order is row-major by default and can be switched to column-major by
-# passing ``order='F'`` (note the number order also determines the list order in the
-# :class:`~ultraplot.gridspec.SubplotGrid` returned by :func:`~ultraplot.figure.Figure.add_subplots`).
+# the numbers depend on the input arguments. If you :ref:`passed an array <ug_intro>`,
+# the subplot numbers correspond to the numbers in the array. But if you used the `ncols`
+# and `nrows` keyword arguments, the number order is row-major by default and can be switched
+# to column-major by passing ``order='F'`` (note the number order also determines the list order
+# in the :class:`~ultraplot.gridspec.SubplotGrid` returned by :func:`~ultraplot.figure.Figure.add_subplots`).
 #
 # To turn on "a-b-c" labels, set :rcraw:`abc` to ``True`` or pass ``abc=True``
 # to :func:`~ultraplot.axes.Axes.format` (see :ref:`the format command <ug_format>`

--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -49,7 +49,7 @@
 # can be a template (with a letter "a" or "A") used to format the subplot labels, such as "A.", which assigns
 # an alphabetic label based on the axis number. Alternatively, you can pass a list to
 # the `abc` parameter, where the list elements are mapped as labels for the subplots one by one.
-# the subplots. If you add subplots one-by-one with :func:`~ultraplot.figure.Figure.add_subplot`,
+# If you add subplots one-by-one with :func:`~ultraplot.figure.Figure.add_subplot`,
 # you can manually specify the number with the `number` keyword. By default, the subplot
 # number is incremented by ``1`` each time you call :func:`~ultraplot.figure.Figure.add_subplot`.
 # If you draw all of your subplots at once with :func:`~ultraplot.figure.Figure.add_subplots`,

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -308,7 +308,7 @@ abc : bool or str or sequence, default: :rc:`abc`
     ``'a'`` is used. The ``a`` or ``A`` is replaced with the alphabetic character
     matching the `~Axes.number`. If `~Axes.number` is greater than 26, the
     characters loop around to a, ..., z, aa, ..., zz, aaa, ..., zzz, etc.
-    Can also be a sequence of strings, in which case the "a-b-c" label will be selected sequentially from the list. For example `axs.format(abc = ["hello", "world"])` for a two-panel figure, and `axes[3:5].format(abc = ["hello", "world"])` for a two-panel subset of a larger figure.
+    Can also be a sequence of strings, in which case the "a-b-c" label will be selected sequentially from the list. For example `axs.format(abc = ["X", "Y"])` for a two-panel figure, and `axes[3:5].format(abc = ["X", "Y"])` for a two-panel subset of a larger figure.
 abcloc, titleloc : str, default: :rc:`abc.loc`, :rc:`title.loc`
     Strings indicating the location for the a-b-c label and main title.
     The following locations are valid:

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -308,8 +308,7 @@ abc : bool or str or sequence, default: :rc:`abc`
     ``'a'`` is used. The ``a`` or ``A`` is replaced with the alphabetic character
     matching the `~Axes.number`. If `~Axes.number` is greater than 26, the
     characters loop around to a, ..., z, aa, ..., zz, aaa, ..., zzz, etc.
-    Can also be a sequence of strings, in which case the "a-b-c" label
-    will simply be selected from the sequence according to `~Axes.number`.
+    Can also be a sequence of strings, in which case the "a-b-c" label will be selected sequentially from the list. For example `axs.format(abc = ["hello", "world"])` for a two-panel figure, and `axes[3:5].format(abc = ["hello", "world"])` for a two-panel subset of a larger figure.
 abcloc, titleloc : str, default: :rc:`abc.loc`, :rc:`title.loc`
     Strings indicating the location for the a-b-c label and main title.
     The following locations are valid:


### PR DESCRIPTION
#### Summary
This PR updates the documentation in `ultraplot/docs/subplots.py` to clarify the functionality of the `abc` parameter for formatting subplot labels and its usage in the `format` command. The changes aim to provide a comprehensive explanation of how users can utilize the `abc` parameter across different contexts.

#### Changes
- Revised the wording to explain that the `abc` parameter can:
  - Be used as a template to format subplot labels, such as "A.", which assigns alphabetic labels based on the axis number.
  - Accept a list, where the elements of the list are used as labels for the subplots.
- Updated the documentation to highlight that the `abc` parameter can also be enabled via the `format` command by setting `abc=True`.

#### Motivation
The previous documentation mentioned "a-b-c" labels but did not clearly describe the flexibility of the `abc` parameter or its integration with the `format` command. This update ensures users understand how to leverage this feature for customized labeling in both subplot creation and formatting.

Addresses #305 