### PR TITLE
Fix issue where fair was set to default for diverging colormaps

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2709,7 +2709,8 @@ class PlotAxes(base.Axes):
         norm = _not_none(norm, "div" if "diverging" in trues else "linear")
         # If using a diverging norm, fair=True, and vcenter not set, default to midpoint
         if norm in ("div", "diverging") or "diverging" in trues:
-            fair = norm_kw.get("fair", True)  # defaults to True
+            is_fair = True if vmin is None and vmax is None else False
+            fair = norm_kw.get("fair", is_fair)  # defaults to True
             vcenter = norm_kw.get("vcenter", 0)
             if fair and vcenter is None and vmin is not None and vmax is not None:
                 vcenter = 0.5 * (vmin + vmax)

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2709,13 +2709,13 @@ class PlotAxes(base.Axes):
         norm = _not_none(norm, "div" if "diverging" in trues else "linear")
         # If using a diverging norm, fair=True, and vcenter not set, default to midpoint
         if norm in ("div", "diverging") or "diverging" in trues:
-            # When vmin or vmax is given we cannot be sure the colormap is fair
-            is_fair = True if vmin is None and vmax is None else False
-            fair = norm_kw.get("fair", is_fair)
+            # By default we assume
+            # diverging maps are "fair", i.e. equal left
+            #  and right ranges
+            fair = norm_kw.get("fair", True)
             vcenter = norm_kw.get("vcenter", 0)
-            if fair == False:
-                if vmin is not None and vmax is not None:
-                    vcenter = vmin + (vmax - vmin) / 2
+            if fair and vmin and vmax:
+                vcenter = vmin = (vmax - vmin) / 2
             norm_kw["vcenter"] = vcenter
         if isinstance(norm, mcolors.Normalize):
             norm.vmin, norm.vmax = vmin, vmax

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2713,8 +2713,9 @@ class PlotAxes(base.Axes):
             is_fair = True if vmin is None and vmax is None else False
             fair = norm_kw.get("fair", is_fair)
             vcenter = norm_kw.get("vcenter", 0)
-            if vmin is not None and vmax is not None:
-                vcenter = vmin + (vmax - vmin) / 2
+            if fair == False:
+                if vmin is not None and vmax is not None:
+                    vcenter = vmin + (vmax - vmin) / 2
             norm_kw["vcenter"] = vcenter
         if isinstance(norm, mcolors.Normalize):
             norm.vmin, norm.vmax = vmin, vmax

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2715,7 +2715,7 @@ class PlotAxes(base.Axes):
             fair = norm_kw.get("fair", True)
             vcenter = norm_kw.get("vcenter", 0)
             if fair and vmin and vmax:
-                vcenter = vmin = (vmax - vmin) / 2
+                vcenter = vmin + (vmax - vmin) / 2
             norm_kw["vcenter"] = vcenter
         if isinstance(norm, mcolors.Normalize):
             norm.vmin, norm.vmax = vmin, vmax

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2715,8 +2715,6 @@ class PlotAxes(base.Axes):
             vcenter = norm_kw.get("vcenter", 0)
             if vmin is not None and vmax is not None:
                 vcenter = vmax - (vmax - vmin) / 2
-            if fair and vcenter is None and vmin is not None and vmax is not None:
-                vcenter = 0.5 * (vmin + vmax)
             norm_kw["vcenter"] = vcenter
         if isinstance(norm, mcolors.Normalize):
             norm.vmin, norm.vmax = vmin, vmax

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2714,7 +2714,7 @@ class PlotAxes(base.Axes):
             fair = norm_kw.get("fair", is_fair)
             vcenter = norm_kw.get("vcenter", 0)
             if vmin is not None and vmax is not None:
-                vcenter = vmax - (vmax - vmin) / 2
+                vcenter = vmin + (vmax - vmin) / 2
             norm_kw["vcenter"] = vcenter
         if isinstance(norm, mcolors.Normalize):
             norm.vmin, norm.vmax = vmin, vmax

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2709,9 +2709,12 @@ class PlotAxes(base.Axes):
         norm = _not_none(norm, "div" if "diverging" in trues else "linear")
         # If using a diverging norm, fair=True, and vcenter not set, default to midpoint
         if norm in ("div", "diverging") or "diverging" in trues:
+            # When vmin or vmax is given we cannot be sure the colormap is fair
             is_fair = True if vmin is None and vmax is None else False
-            fair = norm_kw.get("fair", is_fair)  # defaults to True
+            fair = norm_kw.get("fair", is_fair)
             vcenter = norm_kw.get("vcenter", 0)
+            if vmin is not None and vmax is not None:
+                vcenter = vmax - (vmax - vmin) / 2
             if fair and vcenter is None and vmin is not None and vmax is not None:
                 vcenter = 0.5 * (vmin + vmax)
             norm_kw["vcenter"] = vcenter

--- a/ultraplot/tests/test_color.py
+++ b/ultraplot/tests/test_color.py
@@ -2,36 +2,39 @@ import ultraplot as uplt, numpy as np, pytest
 
 
 @pytest.mark.mpl_image_compare
-def test_vcenter_values():
+def test_vcenter_values(rng):
     """
     Test that vcenter values are correctly set in colorbars.
     """
-    rng = np.random.default_rng(seed=10)
     mvals = rng.normal(size=(32, 32))
     cmap = "spectral"
-    # The middle and right plot should look the same
-    # The colors should spread out where the extremes are visible
+    vmin, vmax = -0.2, 2.0
+
+    titles = ["No vmin/vmax", "With vmin/vmax", "Clipped with vmin/vmax"]
     fig, axs = uplt.subplots(ncols=3, share=0)
-    for i, ax in enumerate(axs):
-        specs = {}
-        if i > 0:
-            vmin = -0.2
-            vmax = 2.0
-            specs = dict(vmin=vmin, vmax=vmax)
-            if i == 2:
-                mvals = np.clip(mvals, vmin, vmax)
+    for i, (ax, title) in enumerate(zip(axs, titles)):
+        # Configure plot-specific settings
+        specs = {"vmin": vmin, "vmax": vmax} if i > 0 else {}
+        clipped_mvals = np.clip(mvals, vmin, vmax) if i == 2 else mvals
+
         m = ax.pcolormesh(
-            mvals,
+            clipped_mvals,
             cmap=cmap,
             discrete=False,
             **specs,
         )
+        if i >= 1:
+            assert np.isclose(m.norm.vcenter, (vmin + vmax) / 2)
+            assert np.isclose(m.norm.vmax, vmax)
+            assert np.isclose(m.norm.vmin, vmin)
+        # Format the axes
         ax.format(
             grid=False,
             xticklabels=[],
             xticks=[],
             yticklabels=[],
             yticks=[],
+            title=title,
         )
         ax.colorbar(m, loc="r", label=f"{i}")
     return fig


### PR DESCRIPTION
Diverging colormaps are by default set to fair. This PR introduces logic that fair is ignored if vmin and or vmax is given. 

Addresses #313 