### PR TITLE
 Add cftime support for non-standard calendars

### DIFF
--- a/ultraplot/tests/test_tickers.py
+++ b/ultraplot/tests/test_tickers.py
@@ -1,0 +1,42 @@
+import pytest
+import numpy as np
+import xarray as xr
+import ultraplot as uplt
+
+
+@pytest.mark.mpl_image_compare
+def test_datetime_calendars_comparison():
+    # Time axis centered at mid-month
+    # Standard calendar
+    time1 = xr.date_range("2000-01", periods=120, freq="MS")
+    time2 = xr.date_range("2000-02", periods=120, freq="MS")
+    time = time1 + 0.5 * (time2 - time1)
+    # Non-standard calendar (uses cftime)
+    time1 = xr.date_range("2000-01", periods=120, freq="MS", calendar="noleap")
+    time2 = xr.date_range("2000-02", periods=120, freq="MS", calendar="noleap")
+    time_noleap = time1 + 0.5 * (time2 - time1)
+
+    da = xr.DataArray(
+        data=np.sin(np.arange(0.0, 2 * np.pi, np.pi / 60.0)),
+        dims=("time",),
+        coords={
+            "time": time,
+        },
+        attrs={"long_name": "low freq signal", "units": "normalized"},
+    )
+
+    da_noleap = xr.DataArray(
+        data=np.sin(2.0 * np.arange(0.0, 2 * np.pi, np.pi / 60.0)),
+        dims=("time",),
+        coords={
+            "time": time_noleap,
+        },
+        attrs={"long_name": "high freq signal", "units": "normalized"},
+    )
+
+    fig, axs = uplt.subplots(ncols=2)
+    axs.format(title=("Standard calendar", "Non-standard calendar"))
+    axs[0].plot(da)
+    axs[1].plot(da_noleap)
+
+    return fig


### PR DESCRIPTION
This PR introduces support for plotting data with non-standard calendars using `cftime`.

Key changes:
- Added `CFTimeConverter` to enable `matplotlib` to handle `cftime.datetime` objects.
- Implemented `AutoDatetimeLocator` and `AutoDatetimeFormatter` for automatic, "nice" tick generation on `cftime` axes, mimicking `matplotlib`'s behavior for standard `datetime` objects.
- Added a regression test using `pytest-mpl` to ensure visual consistency of plots with non-standard calendars.

This resolves issues where plots with non-standard calendars had incorrect or poorly formatted time axes.

Continuation of #289 

<img width="1169" height="656" alt="image" src="https://github.com/user-attachments/assets/e8eded87-d9dd-4927-8a0c-d3e8a4d90032" />
