### PR TITLE
Fix sharing

### DIFF
--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -529,6 +529,8 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             if is_panel:
                 label_visibility[label_param] = is_parent_tick_on
             elif is_border or getattr(self.figure, f"_share{axis_name}") < 3:
+                # turn on sharing when on border
+                # or sharing is below 3
                 label_visibility[label_param] = (
                     is_this_tick_on or sharing_ticks[label_param_trans]
                 )

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -2,6 +2,7 @@
 """
 The standard Cartesian axes used for most ultraplot figures.
 """
+from cProfile import label
 import copy
 import inspect
 
@@ -434,8 +435,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             labels._transfer_label(axis.label, shared_axis_obj.label)
             axis.label.set_visible(False)
 
-        # Handle tick label sharing (level > 2)
-        if level > 2:
+        if level >= 1:
             label_visibility = self._determine_tick_label_visibility(
                 axis,
                 shared_axis,
@@ -528,8 +528,10 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             is_parent_tick_on = sharing_ticks[label_param_trans]
             if is_panel:
                 label_visibility[label_param] = is_parent_tick_on
-            elif is_border:
-                label_visibility[label_param] = is_this_tick_on
+            elif is_border or getattr(self.figure, f"_share{axis_name}") < 3:
+                label_visibility[label_param] = (
+                    is_this_tick_on or sharing_ticks[label_param_trans]
+                )
         return label_visibility
 
     def _add_alt(self, sx, **kwargs):

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -1058,7 +1058,7 @@ class Figure(mfigure.Figure):
         """
         We take the average here as the sharex and sharey should be the same value. In case this changes in the future we can track down the error easily
         """
-        return 0.5 * (self.figure._sharex + self.figure._sharey)
+        return min(self.figure._sharex, self.figure._sharey)
 
     def _add_axes_panel(self, ax, side=None, **kwargs):
         """

--- a/ultraplot/tests/test_sharing.py
+++ b/ultraplot/tests/test_sharing.py
@@ -1,0 +1,86 @@
+import pytest, ultraplot as uplt
+
+"""
+Sharing levels for subplots determine the visbility of the axis labels and tick labels.
+
+Axis labels are pushed to the border subplots when the sharing level is greater than 1.
+
+Ticks are visible only on the border plots when the sharing levels is greater than 2.
+
+Or more verbosely:
+    sharey = 0: no sharing, all labels and ticks visible
+    sharey = 1: share axis, all labels and ticks visible
+    sharey = 2: share limits
+    sharey = 3 or True, share both ticks and labels
+A similar story holds for sharex.
+"""
+
+
+@pytest.mark.parametrize("share_level", [0, "labels", "labs", 1, True])
+@pytest.mark.mpl_image_compare
+def test_sharing_levels_y(share_level):
+    """
+    Test sharing levels for y-axis: left and right ticks/labels.
+    """
+    fig, axs = uplt.subplots(None, 2, 3, sharey=share_level)
+    axs.format(ylabel="Y")
+    axs.format(title=f"sharey = {share_level}")
+    fig.canvas.draw()  # needed for checks
+
+    if fig._sharey < 3:
+        border_axes = set(axs)
+    else:
+        # Reduce border_axes to a set of axes for left and right
+        border_axes = set()
+        for direction in ["left", "right"]:
+            axes = fig._get_border_axes().get(direction, [])
+            if isinstance(axes, (list, tuple, set)):
+                border_axes.update(axes)
+            else:
+                border_axes.add(axes)
+    for axi in axs:
+        tick_params = axi.yaxis.get_tick_params()
+        for direction in ["left", "right"]:
+            label_key = f"label{direction}"
+            visible = tick_params.get(label_key, False)
+            is_border = axi in fig._get_border_axes().get(direction, [])
+            if direction == "left" and (fig._sharey < 3 or is_border):
+                assert visible
+            else:
+                assert not visible
+    return fig
+
+
+@pytest.mark.parametrize("share_level", [0, "labels", "labs", 1, True])
+@pytest.mark.mpl_image_compare
+def test_sharing_levels_x(share_level):
+    """
+    Test sharing levels for x-axis: top and bottom ticks/labels.
+    """
+    fig, axs = uplt.subplots(None, 2, 3, sharex=share_level)
+    axs.format(xlabel="X")
+    axs.format(title=f"sharex = {share_level}")
+    fig.canvas.draw()  # needed for checks
+
+    if fig._sharex < 3:
+        border_axes = set(axs)
+    else:
+        # Reduce border_axes to a set of axes for top and bottom
+        border_axes = set()
+        for direction in ["top", "bottom"]:
+            axes = fig._get_border_axes().get(direction, [])
+            if isinstance(axes, (list, tuple, set)):
+                border_axes.update(axes)
+            else:
+                border_axes.add(axes)
+    for axi in axs:
+        tick_params = axi.xaxis.get_tick_params()
+        for direction in ["top", "bottom"]:
+            label_key = f"label{direction}"
+            visible = tick_params.get(label_key, False)
+            is_border = axi in fig._get_border_axes().get(direction, [])
+            if direction == "bottom" and (fig._sharex < 3 or is_border):
+                assert visible
+            else:
+                assert not visible
+    return fig


### PR DESCRIPTION
Closes #348 

We recently introduced axis sharing to allow for top right axis sharing but inadvertently caused a bug for axis sharing levels 1. This PR should correct this issue.

##What's changed?
- Added a check `_determine_axis_visibility` to propagate the visibility if the sharing level is below 3.