### PR TITLE
Set warning level for mpl to error

### DIFF
--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -2,6 +2,8 @@ import os, shutil, pytest, re, numpy as np, ultraplot as uplt
 from pathlib import Path
 import warnings, logging
 
+logging.getLogger("matplotlib").setLevel(logging.ERROR)
+
 SEED = 51423
 
 


### PR DESCRIPTION
Reduces the logging on GHA to get a clear few on what is going on.