### PR TITLE
Fix order of label transfer

### DIFF
--- a/ultraplot/internals/labels.py
+++ b/ultraplot/internals/labels.py
@@ -10,7 +10,9 @@ from matplotlib.font_manager import FontProperties
 from . import ic  # noqa: F401
 
 
-def merge_font_properties(dest_fp, src_fp):
+def merge_font_properties(
+    dest_fp: FontProperties, src_fp: FontProperties
+) -> FontProperties:
     # Prefer dest_fp's values if set, otherwise use src_fp's
     return FontProperties(
         family=dest_fp.get_family() or src_fp.get_family(),

--- a/ultraplot/internals/labels.py
+++ b/ultraplot/internals/labels.py
@@ -4,8 +4,22 @@ Utilities related to matplotlib text labels.
 """
 import matplotlib.patheffects as mpatheffects
 import matplotlib.text as mtext
+from matplotlib.font_manager import FontProperties
+
 
 from . import ic  # noqa: F401
+
+
+def merge_font_properties(dest_fp, src_fp):
+    # Prefer dest_fp's values if set, otherwise use src_fp's
+    return FontProperties(
+        family=dest_fp.get_family() or src_fp.get_family(),
+        style=dest_fp.get_style() or src_fp.get_style(),
+        variant=dest_fp.get_variant() or src_fp.get_variant(),
+        weight=dest_fp.get_weight() or src_fp.get_weight(),
+        stretch=dest_fp.get_stretch() or src_fp.get_stretch(),
+        size=dest_fp.get_size() or src_fp.get_size(),
+    )
 
 
 def _transfer_label(src, dest):
@@ -15,8 +29,11 @@ def _transfer_label(src, dest):
     """
     text = src.get_text()
     dest.set_color(src.get_color())  # not a font property
-    dest.set_fontproperties(src.get_fontproperties())  # size, weight, etc.
-    if not text.strip():  # WARNING: must test strip() (see _align_axis_labels())
+    src_fp = src.get_font_properties()
+    dest_fp = dest.get_font_properties()
+    merged_fp = merge_font_properties(dest_fp, src_fp)  # dest takes precedence
+    dest.set_fontproperties(merged_fp)
+    if not text.strip():
         return
     dest.set_text(text)
     src.set_text("")

--- a/ultraplot/internals/labels.py
+++ b/ultraplot/internals/labels.py
@@ -22,7 +22,7 @@ def merge_font_properties(dest_fp, src_fp):
     )
 
 
-def _transfer_label(src, dest):
+def _transfer_label(src: mtext.Text, dest: mtext.Text) -> None:
     """
     Transfer the input text object properties and content to the destination
     text object. Then clear the input object text.
@@ -31,8 +31,17 @@ def _transfer_label(src, dest):
     dest.set_color(src.get_color())  # not a font property
     src_fp = src.get_font_properties()
     dest_fp = dest.get_font_properties()
-    merged_fp = merge_font_properties(dest_fp, src_fp)  # dest takes precedence
-    dest.set_fontproperties(merged_fp)
+
+    # Track if we've already transferred to this dest
+    if not hasattr(dest, "_label_transferred"):
+        # First transfer: copy all from src
+        dest.set_fontproperties(src_fp)
+        dest._label_transferred = True
+    else:
+        # Subsequent transfers: preserve dest's manual changes
+        merged_fp = merge_font_properties(dest_fp, src_fp)  # dest takes precedence
+        dest.set_fontproperties(merged_fp)
+
     if not text.strip():
         return
     dest.set_text(text)

--- a/ultraplot/tests/test_format.py
+++ b/ultraplot/tests/test_format.py
@@ -140,6 +140,34 @@ def test_inner_title_zorder():
     return fig
 
 
+def test_transfer_label_preserves_dest_font_properties():
+    """
+    Test that repeated _transfer_label calls do not overwrite dest's updated font properties.
+    """
+    import matplotlib.pyplot as plt
+    from ultraplot.internals.labels import _transfer_label
+
+    fig, ax = plt.subplots()
+    src = ax.text(0.1, 0.5, "Source", fontsize=10, fontweight="bold", color="red")
+    dest = ax.text(0.9, 0.5, "Dest", fontsize=12, fontweight="normal", color="blue")
+
+    # First transfer: dest gets src's font properties
+    _transfer_label(src, dest)
+    assert dest.get_fontsize() == 10
+    assert dest.get_fontweight() == "bold"
+    assert dest.get_text() == "Source"
+
+    # Change dest's font size
+    dest.set_fontsize(20)
+
+    # Second transfer: dest's font size should be preserved
+    src.set_text("New Source")
+    _transfer_label(src, dest)
+    assert dest.get_fontsize() == 20  # Should not be overwritten by src
+    assert dest.get_fontweight() == "bold"  # Still from src originally
+    assert dest.get_text() == "New Source"
+
+
 @pytest.mark.mpl_image_compare
 def test_font_adjustments():
     """


### PR DESCRIPTION
Closes #352 

The `_transfer_label(src, dest)` function is responsible for transferring text and font properties from a source text object (`src`) to a destination text object (`dest`). Currently, the function sets all font properties of `dest` to match those of `src` every time it is called:

```python
font_properties = src.get_font_properties()
dest.set_fontproperties(font_properties)
```

This approach causes an issue when `_transfer_label` is called multiple times on the same `dest` object. Any customizations or updates made to `dest`'s font properties after the first transfer are lost, as they are overwritten by `src`'s properties on subsequent calls.

#### Example Scenario

1. `_transfer_label(src, dest)` is called — `dest` now has `src`'s font properties.
2. The user or another function updates `dest`'s font size or family.
3. `_transfer_label(src, dest)` is called again — the update is lost, as `src`'s font properties overwrite `dest`'s.

### Solution

To address this, the PR introduces a merge strategy for font properties:
- When transferring, the function now merges `src` and `dest` font properties.
- For each property, if `dest` has a value set, it is preserved; otherwise, the value from `src` is used.
- This ensures that any customizations to `dest` are retained across multiple calls to `_transfer_label`.

### Summary of Changes

- Added a `merge_font_properties` helper function.
- Updated `_transfer_label` to use merged font properties, preserving `dest`'s customizations.

### Impact

This change prevents accidental loss of user or programmatic updates to text object font properties, making the label transfer process more robust and predictable.