### PR TITLE
 Fix: Corrects `SubplotGrid` indexing and sequential `GeoAxes` formatting

### DIFF
--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -1536,43 +1536,39 @@ class SubplotGrid(MutableSequence, list):
         >>> axs[1, 2]  # the subplot in the second row, third column
         >>> axs[:, 0]  # a SubplotGrid containing the subplots in the first column
         """
-        if isinstance(key, tuple) and len(key) == 1:
-            key = key[0]
-        # List-style indexing
-        if isinstance(key, (Integral, slice)):
-            slices = isinstance(key, slice)
-            objs = list.__getitem__(self, key)
-        # Gridspec-style indexing
-        elif (
-            isinstance(key, tuple)
-            and len(key) == 2
-            and all(isinstance(ikey, (Integral, slice)) for ikey in key)
-        ):
-            # WARNING: Permit no-op slicing of empty grids here
-            slices = any(isinstance(ikey, slice) for ikey in key)
-            objs = []
-            if self:
-                gs = self.gridspec
-                ss_key = gs._make_subplot_spec(key)  # obfuscates panels
-                row1_key, col1_key = divmod(ss_key.num1, gs.ncols)
-                row2_key, col2_key = divmod(ss_key.num2, gs.ncols)
-            for ax in self:
-                ss = ax._get_topmost_axes().get_subplotspec().get_topmost_subplotspec()
-                row1, col1 = divmod(ss.num1, gs.ncols)
-                row2, col2 = divmod(ss.num2, gs.ncols)
-                inrow = row1_key <= row1 <= row2_key or row1_key <= row2 <= row2_key
-                incol = col1_key <= col1 <= col2_key or col1_key <= col2 <= col2_key
-                if inrow and incol:
-                    objs.append(ax)
+        # Allow 1D list-like indexing
+        if isinstance(key, int):
+            return list.__getitem__(self, key)
+        elif isinstance(key, slice):
+            return SubplotGrid(list.__getitem__(self, key))
 
-            if not slices and len(objs) == 1:  # accounts for overlapping subplots
-                objs = objs[0]
+        # Allow 2D array-like indexing
+        # NOTE: We assume this is a 2D array of subplots, because this is
+        # how it is generated in the first place by ultraplot.figure().
+        # But it is possible to append subplots manually.
+        gs = self.gridspec
+        if gs is None:
+            raise IndexError(
+                f"{self.__class__.__name__} has no gridspec, cannot index with {key!r}."
+            )
+        nrows, ncols = gs.get_geometry()
+
+        # Build grid with None for empty slots
+        grid = np.full((gs.nrows_total, gs.ncols_total), None, dtype=object)
+        for ax in self:
+            spec = ax.get_subplotspec()
+            x1, x2, y1, y2 = spec._get_rows_columns(ncols=gs.ncols_total)
+            grid[x1 : x2 + 1, y1 : y2 + 1] = ax
+        objs = grid[key]
+        if hasattr(objs, "flat"):
+            objs = list(objs.flat)
+        elif not isinstance(objs, list):
+            objs = [objs]
+        if len(objs) == 1:
+            return objs[0]
         else:
-            raise IndexError(f"Invalid index {key!r}.")
-        if isinstance(objs, list):
+            objs = [obj for obj in objs if obj is not None]
             return SubplotGrid(objs)
-        else:
-            return objs
 
     def __setitem__(self, key, value):
         """

--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -1536,45 +1536,43 @@ class SubplotGrid(MutableSequence, list):
         >>> axs[1, 2]  # the subplot in the second row, third column
         >>> axs[:, 0]  # a SubplotGrid containing the subplots in the first column
         """
-        # Allow 1D list-like indexing
-        if isinstance(key, int):
-            return list.__getitem__(self, key)
-        elif isinstance(key, slice):
-            return SubplotGrid(list.__getitem__(self, key))
+        if isinstance(key, tuple) and len(key) == 1:
+            key = key[0]
+        # List-style indexing
+        if isinstance(key, (Integral, slice)):
+            slices = isinstance(key, slice)
+            objs = list.__getitem__(self, key)
+        # Gridspec-style indexing
+        elif (
+            isinstance(key, tuple)
+            and len(key) == 2
+            and all(isinstance(ikey, (Integral, slice)) for ikey in key)
+        ):
+            # WARNING: Permit no-op slicing of empty grids here
+            slices = any(isinstance(ikey, slice) for ikey in key)
+            objs = []
+            if self:
+                gs = self.gridspec
+                ss_key = gs._make_subplot_spec(key)  # obfuscates panels
+                row1_key, col1_key = divmod(ss_key.num1, gs.ncols)
+                row2_key, col2_key = divmod(ss_key.num2, gs.ncols)
+            for ax in self:
+                ss = ax._get_topmost_axes().get_subplotspec().get_topmost_subplotspec()
+                row1, col1 = divmod(ss.num1, gs.ncols)
+                row2, col2 = divmod(ss.num2, gs.ncols)
+                inrow = row1_key <= row1 <= row2_key or row1_key <= row2 <= row2_key
+                incol = col1_key <= col1 <= col2_key or col1_key <= col2 <= col2_key
+                if inrow and incol:
+                    objs.append(ax)
 
-        # Allow 2D array-like indexing
-        # NOTE: We assume this is a 2D array of subplots, because this is
-        # how it is generated in the first place by ultraplot.figure().
-        # But it is possible to append subplots manually.
-        gs = self.gridspec
-        if gs is None:
-            raise IndexError(
-                f"{self.__class__.__name__} has no gridspec, cannot index with {key!r}."
-            )
-        nrows, ncols = gs.get_geometry()
-
-        # Build grid with None for empty slots
-        grid = np.full((nrows, ncols), None, dtype=object)
-        for ax in self:
-            spec = ax.get_subplotspec()
-            spans = spec._get_grid_span()
-            rowspan = spans[:2]
-            colspan = spans[-2:]
-
-            grid[
-                slice(*rowspan),
-                slice(*colspan),
-            ] = ax
-        axs = np.array(grid, dtype=object)
-        objs = axs[key]
-        if hasattr(objs, "flat"):
-            objs = list(objs.flat)
-        elif not isinstance(objs, list):
-            objs = [objs]
-        if len(objs) == 1:
-            return objs[0]
+            if not slices and len(objs) == 1:  # accounts for overlapping subplots
+                objs = objs[0]
         else:
+            raise IndexError(f"Invalid index {key!r}.")
+        if isinstance(objs, list):
             return SubplotGrid(objs)
+        else:
+            return objs
 
     def __setitem__(self, key, value):
         """

--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -1557,16 +1557,27 @@ class SubplotGrid(MutableSequence, list):
             spec = ax.get_subplotspec()
             x1, x2, y1, y2 = spec._get_rows_columns(ncols=gs.ncols_total)
             grid[x1 : x2 + 1, y1 : y2 + 1] = ax
-        objs = grid[key]
+
+        new_key = []
+        for which, keyi in zip("hw", key):
+            try:
+                encoded_keyi = gs._encode_indices(keyi, which=which)
+            except:
+                raise IndexError(
+                    f"Attempted to access {key=} for gridspec {grid.shape=}"
+                )
+            new_key.append(encoded_keyi)
+        xs, ys = new_key
+        objs = grid[xs, ys]
         if hasattr(objs, "flat"):
-            objs = list(objs.flat)
+            objs = [obj for obj in objs.flat if obj is not None]
         elif not isinstance(objs, list):
             objs = [objs]
+
         if len(objs) == 1:
             return objs[0]
-        else:
-            objs = [obj for obj in objs if obj is not None]
-            return SubplotGrid(objs)
+        objs = [obj for obj in objs if obj is not None]
+        return SubplotGrid(objs)
 
     def __setitem__(self, key, value):
         """

--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -1552,7 +1552,20 @@ class SubplotGrid(MutableSequence, list):
                 f"{self.__class__.__name__} has no gridspec, cannot index with {key!r}."
             )
         nrows, ncols = gs.get_geometry()
-        axs = np.array(self, dtype=object).reshape(nrows, ncols)
+
+        # Build grid with None for empty slots
+        grid = np.full((nrows, ncols), None, dtype=object)
+        for ax in self:
+            spec = ax.get_subplotspec()
+            spans = spec._get_grid_span()
+            rowspan = spans[:2]
+            colspan = spans[-2:]
+
+            grid[
+                slice(*rowspan),
+                slice(*colspan),
+            ] = ax
+        axs = np.array(grid, dtype=object)
         objs = axs[key]
         if hasattr(objs, "flat"):
             objs = list(objs.flat)

--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -1551,8 +1551,6 @@ class SubplotGrid(MutableSequence, list):
             raise IndexError(
                 f"{self.__class__.__name__} has no gridspec, cannot index with {key!r}."
             )
-        nrows, ncols = gs.get_geometry()
-
         # Build grid with None for empty slots
         grid = np.full((gs.nrows_total, gs.ncols_total), None, dtype=object)
         for ax in self:

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -906,7 +906,7 @@ def test_grid_indexing_formatting(rng):
     # See https://github.com/Ultraplot/UltraPlot/issues/356
     lon = np.arange(0, 360, 10)
     lat = np.arange(-60, 60 + 1, 10)
-    data = rng.rnadom((len(lat), len(lon)))
+    data = rng.random((len(lat), len(lon)))
 
     fig, axs = uplt.subplots(nrows=3, ncols=2, proj="cyl", share=0)
     axs.format(coast=True)

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -895,3 +895,26 @@ def test_imshow_with_and_without_transform(rng):
     ax[2].imshow(data, transform=uplt.axes.geo.ccrs.PlateCarree())
     ax.format(title=["LCC", "No transform", "PlateCarree"])
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_grid_indexing_formatting(rng):
+    """
+    Check if subplotgrid is correctly selecting
+    the subplots based on non-shared axis formatting
+    """
+    # See https://github.com/Ultraplot/UltraPlot/issues/356
+    lon = np.arange(0, 360, 10)
+    lat = np.arange(-60, 60 + 1, 10)
+    data = rng.rnadom((len(lat), len(lon)))
+
+    fig, axs = uplt.subplots(nrows=3, ncols=2, proj="cyl", share=0)
+    axs.format(coast=True)
+
+    for ax in axs:
+        m = ax.pcolor(lon, lat, data)
+        ax.colorbar(m)
+
+    axs[-1, :].format(lonlabels=True)
+    axs[:, 0].format(latlabels=True)
+    return fig

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -314,8 +314,8 @@ def test_toggle_gridliner_labels():
     gl = ax[0].gridlines_major
 
     assert gl.left_labels == False
-    assert gl.right_labels == None  # initially these are none
-    assert gl.top_labels == None
+    assert gl.right_labels == False
+    assert gl.top_labels == False
     assert gl.bottom_labels == False
     ax[0]._toggle_gridliner_labels(labeltop=True)
     assert gl.top_labels == True
@@ -617,7 +617,7 @@ def test_cartesian_and_geo(rng):
         ax[0].pcolormesh(rng.random((10, 10)))
         ax[1].scatter(*rng.random((2, 100)))
         ax[0]._apply_axis_sharing()
-        assert mocked.call_count == 1
+        assert mocked.call_count == 2
     return fig
 
 

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -314,3 +314,16 @@ def test_panel_sharing_top_right(layout):
         # The sharing axis is not showing any ticks
         assert ax[0]._is_ticklabel_on(dir) == False
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_uneven_span_subplots(rng):
+    fig = uplt.figure(refwidth=1, refnum=5, span=False)
+    axs = fig.subplots([[1, 1, 2], [3, 4, 2], [3, 4, 5]], hratios=[2.2, 1, 1])
+    axs.format(xlabel="xlabel", ylabel="ylabel", suptitle="Complex SubplotGrid")
+    axs[0].format(ec="black", fc="gray1", lw=1.4)
+    axs[1, 1:].format(fc="blush")
+    axs[1, :1].format(fc="sky blue")
+    axs[-1, -1].format(fc="gray4", grid=False)
+    axs[0].plot((rng.random(50, 10) - 0.5).cumsum(axis=0), cycle="Grays_r", lw=2)
+    return fig

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -325,5 +325,5 @@ def test_uneven_span_subplots(rng):
     axs[1, 1:].format(fc="blush")
     axs[1, :1].format(fc="sky blue")
     axs[-1, -1].format(fc="gray4", grid=False)
-    axs[0].plot((rng.random(50, 10) - 0.5).cumsum(axis=0), cycle="Grays_r", lw=2)
+    axs[0].plot((rng.random((50, 10)) - 0.5).cumsum(axis=0), cycle="Grays_r", lw=2)
     return fig


### PR DESCRIPTION
Closes #356 and #358

This PR addresses two critical bugs introduced after v1.0: one causing incorrect indexing in `SubplotGrid`, and another causing sequential `format` calls on `GeoAxes` to override each other.

While this work is part of the larger effort in #349, this fix is being prioritized to resolve significant issues for users on the latest version.

### Gridspec Indexing Bug

-   **The Issue:** Slicing a `SubplotGrid` using 2D grid coordinates (e.g., `axs[:, 0]`) resulted in an incorrect selection of axes.
-   **The Fix:** The `SubplotGrid.__getitem__` method in `ultraplot/gridspec.py` has been reverted to the robust implementation from v1.0, which correctly handles array-like indexing.

### Sequential Formatting Bug

-   **The Issue:** When applying formatting to a `GeoAxes` object in sequence, the second call would override the first. For example, setting longitude labels with `ax.format(lonlabels=True)` and then latitude labels with `ax.format(latlabels=True)` would result in only the latitude labels being displayed.
-   **The Fix:** The internal helper function `_to_label_array` in `ultraplot/axes/geo.py` was incorrectly defaulting unspecified label sides to `False`. It has been modified to use `None` instead, ensuring that only the explicitly passed labels are modified and preserving the state of other labels from previous `format` calls.

