### PR TITLE
Increase timeout on GHA

### DIFF
--- a/.github/workflows/build-ultraplot.yml
+++ b/.github/workflows/build-ultraplot.yml
@@ -17,7 +17,7 @@ jobs:
   build-ultraplot:
     name: Test Python ${{ inputs.python-version }} with ${{ inputs.matplotlib-version }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
GHA are timing out. This PR bumps the timeout limit from 15 to 25 minutes.