### PR TITLE
Fix missing s on input parsing for boxpercentiles

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -2087,7 +2087,7 @@ class PlotAxes(base.Axes):
         ):  # ugly kludge to check for shading
             if all(_ is None for _ in (bardata, barstds, barpctiles)):
                 barstds, barpctiles = default_barstds, default_barpctiles
-            if all(_ is None for _ in (boxdata, boxstds, boxpctile)):
+            if all(_ is None for _ in (boxdata, boxstds, boxpctiles)):
                 boxstds, boxpctiles = default_boxstds, default_boxpctiles
         showbars = any(
             _ is not None and _ is not False for _ in (barstds, barpctiles, bardata)

--- a/ultraplot/tests/test_statistical_plotting.py
+++ b/ultraplot/tests/test_statistical_plotting.py
@@ -71,3 +71,25 @@ def test_panel_dist(rng):
         px.hist(x, bins, color=color, fill=True, ec="k")
         px.format(grid=False, ylocator=[], title=title, titleloc="l")
     return fig
+
+
+@pytest.mark.mpl_image_compare
+def test_input_violin_box_options():
+    """
+    Test various box options in violin plots.
+    """
+    data = np.array([0, 1, 2, 3]).reshape(-1, 1)
+
+    fig, axes = uplt.subplots(ncols=4)
+    axes[0].bar(data, median=True, boxpctiles=True, bars=False)
+    axes[0].format(title="boxpctiles")
+
+    axes[1].bar(data, median=True, boxpctile=True, bars=False)
+    axes[1].format(title="boxpctile")
+
+    axes[2].bar(data, median=True, boxstd=True, bars=False)
+    axes[2].format(title="boxstd")
+
+    axes[3].bar(data, median=True, boxstds=True, bars=False)
+    axes[3].format(title="boxstds")
+    return fig


### PR DESCRIPTION
Closes #399 

There was a missing s on the input for the plural of the parameters.