### PR TITLE
Hotfix: unsharing causes excessive draw in jupyter

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2626,9 +2626,19 @@ class Axes(maxes.Axes):
                     setattr(sibling, f"_share{which}", None)
                 this_ax = getattr(self, f"{which}axis")
                 sib_ax = getattr(sibling, f"{which}axis")
-                # Reset formatters
-                this_ax.major = copy.deepcopy(this_ax.major)
-                this_ax.minor = copy.deepcopy(this_ax.minor)
+                # Reset formatters by creating new Ticker objects.
+                # A deepcopy can trigger redraws.
+                new_major = maxis.Ticker()
+                if this_ax.major:
+                    new_major.locator = copy.copy(this_ax.major.locator)
+                    new_major.formatter = copy.copy(this_ax.major.formatter)
+                this_ax.major = new_major
+
+                new_minor = maxis.Ticker()
+                if this_ax.minor:
+                    new_minor.locator = copy.copy(this_ax.minor.locator)
+                    new_minor.formatter = copy.copy(this_ax.minor.formatter)
+                this_ax.minor = new_minor
 
     def _sharex_setup(self, sharex, **kwargs):
         """


### PR DESCRIPTION
Closes #407 

Remove the deepcopy on the formatters to prevent triggering redraw but ensuring that the formatters are different objects.

Note: I removed the lines now all together as the test were failing, and apparently the lines were not necessary anyway (i.e. they are already in dependent). 