### PR TITLE
There's a typo about zerotrim in doc.

### DIFF
--- a/ultraplot/ticker.py
+++ b/ultraplot/ticker.py
@@ -64,7 +64,7 @@ precision : int, default: {6, 2}
     when `zerotrim` is ``True`` and ``2`` otherwise.
 """
 _zerotrim_docstring = """
-zerotrim : bool, default: :rc:`format.zerotrim`
+zerotrim : bool, default: :rc:`formatter.zerotrim`
     Whether to trim trailing decimal zeros.
 """
 _auto_docstring = """


### PR DESCRIPTION
It should be `formatter.zerotrim` not `format.zerotrim`.