### PR TITLE
Guard abc/title width calc when text detached

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3063,13 +3063,13 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         ha = aobj.get_ha()
 
         # Get dimensions of non-empty elements
-        if atext and aobj.get_figure(root=True) is not None:
+        if atext and aobj.get_figure() is not None:
             awidth = (
                 aobj.get_window_extent(renderer)
                 .transformed(self.transAxes.inverted())
                 .width
             )
-        if ttext and tobj.get_figure(root=True) is not None:
+        if ttext and tobj.get_figure() is not None:
             twidth = (
                 tobj.get_window_extent(renderer)
                 .transformed(self.transAxes.inverted())


### PR DESCRIPTION
The fix prevents a tight-layout crash by skipping title/abc width measurements when the underlying text artist is detached from a figure, since `get_window_extent` tries to read `fig.dpi` and raises when `fig` is `None`; with this guard, layout proceeds normally when the artist is attached and avoids the `AttributeError` when it isn’t.