### PR TITLE
Add two files and one folder from doc building to git ignoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ docs/_build
 docs/_static/ultraplotrc
 docs/_static/rctable.rst
 docs/_static/*
+docs/gallery/
+docs/sg_execution_times.rst
+docs/whats_new.rst
 
 # Development subfolders
 dev


### PR DESCRIPTION
After building docs, there are two files and one folder left that shouldn't be committed. Add them to `.gitignore`.

```
On branch main
Your branch is ahead of 'origin/main' by 8 commits.
  (use "git push" to publish your local commits)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        docs/gallery/
        docs/sg_execution_times.rst
        docs/whats_new.rst

nothing added to commit but untracked files present (use "git add" to track)
```