### PR TITLE
Fix font lazy load

### DIFF
--- a/ultraplot/__init__.py
+++ b/ultraplot/__init__.py
@@ -67,6 +67,9 @@ def _setup():
             register_cycles,
             register_fonts,
         )
+        from .internals import (
+            fonts as _fonts,  # noqa: F401 - ensure mathtext override is active
+        )
         from .internals import rcsetup, warnings
         from .internals.benchmarks import _benchmark
 


### PR DESCRIPTION
This PR loads font at the proper stage so it is not skipped and created before a MathParser us isued.

Closes #497 
