### PR TITLE
Pin docutils for docs builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ filterwarnings = [
 mpl-default-style = { axes.prop_cycle = "cycler('color', ['#4c72b0ff', '#55a868ff', '#c44e52ff', '#8172b2ff', '#ccb974ff', '#64b5cdff'])" }
 [project.optional-dependencies]
 docs = [
+    "docutils<0.22",
     "jupyter",
     "jupytext",
     "lxml-html-clean",


### PR DESCRIPTION
  The docs build currently fails because m2r2 expects `docutils.core.ErrorString`, which was removed in docutils 0.22. This pins docutils to <0.22 in the docs extra to keep Read the Docs working until we replace or update the m2r2 dependency.