### PR TITLE
Surpress warnings on docs

### DIFF
--- a/ultraplot/config.py
+++ b/ultraplot/config.py
@@ -45,7 +45,6 @@ from .internals import (
 # when when substituting dummy unavailable glyph due to fallback disabled.
 logging.getLogger("matplotlib.mathtext").setLevel(logging.ERROR)
 
-
 __all__ = [
     "Configurator",
     "rc",


### PR DESCRIPTION
This PR surpresses the warnings on the docs for a cleaner look.