### PR TITLE
Add opt-in pixel snapping for subplot layout

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -869,6 +869,7 @@ class Figure(mfigure.Figure):
 
     @override
     def draw(self, renderer):
+        self._snap_axes_to_pixel_grid(renderer)
         # implement the tick sharing here
         # should be shareable --> either all cartesian or all geographic
         # but no mixing (panels can be mixed)
@@ -879,6 +880,53 @@ class Figure(mfigure.Figure):
         self._share_ticklabels(axis="y")
         self._apply_share_label_groups()
         super().draw(renderer)
+
+    def _snap_axes_to_pixel_grid(self, renderer) -> None:
+        """
+        Snap visible axes bounds to the renderer pixel grid.
+        """
+        if not rc.find("subplots.pixelsnap", context=True):
+            return
+
+        width = getattr(renderer, "width", None)
+        height = getattr(renderer, "height", None)
+        if not width or not height:
+            return
+
+        width = float(width)
+        height = float(height)
+        if width <= 0 or height <= 0:
+            return
+
+        invw = 1.0 / width
+        invh = 1.0 / height
+        minw = invw
+        minh = invh
+
+        for ax in self._iter_axes(hidden=False, children=False, panels=True):
+            bbox = ax.get_position(original=False)
+            old = np.array([bbox.x0, bbox.y0, bbox.x1, bbox.y1], dtype=float)
+            new = np.array(
+                [
+                    round(old[0] * width) * invw,
+                    round(old[1] * height) * invh,
+                    round(old[2] * width) * invw,
+                    round(old[3] * height) * invh,
+                ],
+                dtype=float,
+            )
+
+            if new[2] <= new[0]:
+                new[2] = new[0] + minw
+            if new[3] <= new[1]:
+                new[3] = new[1] + minh
+
+            if np.allclose(new, old, rtol=0.0, atol=1e-12):
+                continue
+            ax.set_position(
+                [new[0], new[1], new[2] - new[0], new[3] - new[1]],
+                which="both",
+            )
 
     def _share_ticklabels(self, *, axis: str) -> None:
         """

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -2099,6 +2099,11 @@ _rc_ultraplot_table = {
         _validate_bool,
         "Whether to auto-adjust the subplot spaces and figure margins.",
     ),
+    "subplots.pixelsnap": (
+        False,
+        _validate_bool,
+        "Whether to snap subplot bounds to the renderer pixel grid during draw.",
+    ),
     # Super title settings
     "suptitle.color": (BLACK, _validate_color, "Figure title color."),
     "suptitle.pad": (

--- a/ultraplot/tests/conftest.py
+++ b/ultraplot/tests/conftest.py
@@ -37,6 +37,8 @@ def close_figures_after_test(request):
     # Start from a clean rc state.
     uplt.rc._context.clear()
     uplt.rc.reset(local=False, user=False, default=True)
+    if request.node.get_closest_marker("mpl_image_compare"):
+        uplt.rc["subplots.pixelsnap"] = True
 
     yield
     uplt.close("all")

--- a/ultraplot/tests/test_figure.py
+++ b/ultraplot/tests/test_figure.py
@@ -297,3 +297,21 @@ def test_suptitle_kw_position_reverted(ha, expectation):
     assert np.isclose(x, expectation, atol=0.1), f"Expected x={expectation}, got {x=}"
 
     uplt.close("all")
+
+
+def test_subplots_pixelsnap_aligns_axes_bounds():
+    with uplt.rc.context({"subplots.pixelsnap": True}):
+        fig, axs = uplt.subplots(ncols=2, nrows=2)
+        axs.plot([0, 1], [0, 1])
+        fig.canvas.draw()
+
+        renderer = fig._get_renderer()
+        width = float(renderer.width)
+        height = float(renderer.height)
+
+        for ax in axs:
+            bbox = ax.get_position(original=False)
+            coords = np.array(
+                [bbox.x0 * width, bbox.y0 * height, bbox.x1 * width, bbox.y1 * height]
+            )
+            assert np.allclose(coords, np.round(coords), atol=1e-8)


### PR DESCRIPTION
This is an attempt to fix the CI; In order to lockdown the small drifts that occur when tests fails, we can snap the corners of the axis to the nearest pixel.