### PR TITLE
Fix rc init when matplotlib is imported first

### DIFF
--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -734,6 +734,7 @@ font_scalings["med-large"] = 1.1  # add scaling
 if not hasattr(RcParams, "validate"):  # not mission critical so skip
     warnings._warn_ultraplot("Failed to update matplotlib rcParams validators.")
 else:
+
     def _validator_accepts(validator, value):
         try:
             validator(value)

--- a/ultraplot/tests/test_config.py
+++ b/ultraplot/tests/test_config.py
@@ -222,8 +222,7 @@ def _run_in_subprocess(code):
     code = (
         "import pathlib\n"
         "import sys\n"
-        "sys.path.insert(0, str(pathlib.Path.cwd()))\n"
-        + code
+        "sys.path.insert(0, str(pathlib.Path.cwd()))\n" + code
     )
     env = os.environ.copy()
     env["MPLBACKEND"] = "Agg"


### PR DESCRIPTION
This fixes issue #568 where importing matplotlib.pyplot before ultraplot could make rc initialization fail with axes.titlesize set to med-large validation errors. The root cause was font-size validator patching that relied on validator object identity, which is not stable across Matplotlib builds; this patch adds behavior-based detection so relevant size validators are consistently routed through UltraPlot custom fontsize validation. It also expands subprocess regression coverage in test_config.py to enforce the problematic import order and verify both general rc mutation and med-large assignments across multiple font-size keys.