### PR TITLE
Tests: pin outside-label panel baseline to explicit share mode

### DIFF
--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -689,11 +689,12 @@ def test_non_rectangular_outside_labels_top():
     uplt.close(fig)
 
 
-@pytest.mark.mpl_image_compare(tolerance=4)
+@pytest.mark.mpl_image_compare
 def test_outside_labels_with_panels():
     fig, ax = uplt.subplots(
         ncols=2,
         nrows=2,
+        share=True,
     )
     # Create extreme case where we add a lot of panels
     # This should push the left labels further left


### PR DESCRIPTION
This PR isolates a comparison-stability fix used by multiple branches: `test_outside_labels_with_panels` now sets `share=True` explicitly so the image baseline is independent of changing default share policy. This keeps the test focused on outside-label/panel behavior and avoids cross-branch CI comparison drift.