### PR TITLE
Fix suptitle top spacing for center/top vertical alignment

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -2322,18 +2322,23 @@ class Figure(mfigure.Figure):
         ha = self._suptitle.get_ha()
         va = self._suptitle.get_va()
 
-        # Use original centering algorithm for positioning (regardless of alignment)
+        # Use original centering algorithm for horizontal positioning.
         x, _ = self._get_align_coord(
             "top",
             axs,
             includepanels=self._includepanels,
             align=ha,
         )
-        y = self._get_offset_coord("top", axs, renderer, pad=pad, extra=labs)
+        y_target = self._get_offset_coord("top", axs, renderer, pad=pad, extra=labs)
 
-        # Set final position and alignment on the suptitle
+        # Place suptitle so its *bbox bottom* sits at the target offset.
+        # This preserves spacing for all vertical alignments (e.g. va='top').
         self._suptitle.set_ha(ha)
         self._suptitle.set_va(va)
+        self._suptitle.set_position((x, 0))
+        bbox = self._suptitle.get_window_extent(renderer)
+        y_bbox = self.transFigure.inverted().transform((0, bbox.ymin))[1]
+        y = y_target - y_bbox
         self._suptitle.set_position((x, y))
 
     def _update_axis_label(self, side, axs):

--- a/ultraplot/tests/test_figure.py
+++ b/ultraplot/tests/test_figure.py
@@ -299,6 +299,33 @@ def test_suptitle_kw_position_reverted(ha, expectation):
     uplt.close("all")
 
 
+@pytest.mark.parametrize("va", ["bottom", "center", "top"])
+def test_suptitle_vertical_alignment_preserves_top_spacing(va):
+    """
+    Suptitle vertical alignment should not reduce the spacing above top content.
+    """
+    fig, axs = uplt.subplots(ncols=2)
+    fig.format(
+        suptitle="Long figure title\nsecond line",
+        suptitle_kw={"va": va},
+        toplabels=("left", "right"),
+    )
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+
+    axs_top = fig._get_align_axes("top")
+    labs = tuple(t for t in fig._suplabel_dict["top"].values() if t.get_text())
+    pad = (fig._suptitle_pad / 72) / fig.get_size_inches()[1]
+    y_expected = fig._get_offset_coord("top", axs_top, renderer, pad=pad, extra=labs)
+
+    bbox = fig._suptitle.get_window_extent(renderer)
+    y_actual = fig.transFigure.inverted().transform((0, bbox.ymin))[1]
+    y_tol = 1.5 / (fig.dpi * fig.get_size_inches()[1])  # ~1.5 px tolerance
+    assert y_actual >= y_expected - y_tol
+
+    uplt.close("all")
+
+
 def test_subplots_pixelsnap_aligns_axes_bounds():
     with uplt.rc.context({"subplots.pixelsnap": True}):
         fig, axs = uplt.subplots(ncols=2, nrows=2)


### PR DESCRIPTION
This fixes a suptitle layout regression where `suptitle_kw` vertical alignments (`va='center'` or `va='top'`) could let the suptitle overlap top content. The alignment code now computes the target top offset from surrounding content and then positions the suptitle so its bbox bottom lands at that offset, preserving spacing regardless of alignment. It also adds a regression test covering `va in {'bottom','center','top'}` to enforce consistent top spacing. Closes #573.
