### PR TITLE
CI: stabilize compare-baseline exits and determinism

### DIFF
--- a/.github/workflows/build-ultraplot.yml
+++ b/.github/workflows/build-ultraplot.yml
@@ -33,6 +33,7 @@ jobs:
       TEST_MODE: ${{ inputs.test-mode }}
       TEST_NODEIDS: ${{ inputs.test-nodeids }}
       PYTEST_WORKERS: 4
+      PYTHONHASHSEED: "0"
     steps:
       - name: Set up swap space
         uses: pierotofy/set-swap-space@master
@@ -78,6 +79,7 @@ jobs:
       TEST_MODE: ${{ inputs.test-mode }}
       TEST_NODEIDS: ${{ inputs.test-nodeids }}
       PYTEST_WORKERS: 4
+      PYTHONHASHSEED: "0"
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
This PR isolates the compare-baseline workflow fixes from feature work so they can be merged independently. It hardens selected-nodeid filtering to avoid shell edge cases, uses explicit pytest+junit status normalization, neutralizes login-shell .bash_logout teardown side effects that were causing false non-zero exits, and pins PYTHONHASHSEED=0 for deterministic image comparisons across matrix jobs. No plotting logic or feature code is changed.