### PR TITLE
Fix GeoAxes _toggle_ticks label parsing

### DIFF
--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -179,6 +179,38 @@ def test_geoticks_input_handling(recwarn):
     ax.format(lonticklen="1em")
 
 
+def test_geoticks_label_shorthand_lb_no_warning(recwarn):
+    fig, ax = uplt.subplots(proj="cyl")
+    ax.format(land=True, lonlines=30, latlines=30, labels="lb")
+    assert len(recwarn) == 0
+    assert ax[0].xaxis.get_ticks_position() == "bottom"
+    assert ax[0].yaxis.get_ticks_position() == "left"
+    uplt.close(fig)
+
+
+def test_toggle_ticks_supports_bool_and_sequence_specs():
+    fig, ax = uplt.subplots(proj="cyl")
+    geo = ax[0]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", uplt.warnings.UltraPlotWarning)
+        geo._toggle_ticks(True, "x")
+        assert geo.xaxis.get_ticks_position() == "bottom"
+        geo._toggle_ticks((True, True), "x")
+        assert geo.xaxis.get_ticks_position() in ("both", "default")
+        geo._toggle_ticks(("left", "bottom"), "x")
+        assert geo.xaxis.get_ticks_position() == "bottom"
+
+        geo._toggle_ticks(True, "y")
+        assert geo.yaxis.get_ticks_position() == "left"
+        geo._toggle_ticks((True, True), "y")
+        assert geo.yaxis.get_ticks_position() in ("both", "default")
+        geo._toggle_ticks(("left", "bottom"), "y")
+        assert geo.yaxis.get_ticks_position() == "left"
+
+    assert not caught
+    uplt.close(fig)
+
+
 @pytest.mark.parametrize(
     ("layout", "lonlabels", "latlabels"),
     [


### PR DESCRIPTION
This fixes the GeoAxes tick-toggle parsing mismatch reported in #578.

