### PR TITLE
Fix double-counted margins for shared spanning labels at space=0

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -2558,6 +2558,10 @@ class Figure(mfigure.Figure):
             props = ("ha", "va", "rotation", "rotation_mode")
             suplab = suplabs[ax] = self.text(0, 0, "")
             suplab.update({prop: getattr(axlab, "get_" + prop)() for prop in props})
+        # Spanning labels are positioned manually while regular axis labels are
+        # replaced by space placeholders to reserve bbox space. Exclude these
+        # figure-level labels from tight layout to avoid double counting.
+        suplab.set_in_layout(False)
 
         # Copy text from the central label to the spanning label
         # NOTE: Must use spaces rather than newlines, otherwise tight layout

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -277,6 +277,29 @@ def test_subset_share_xlabels_override():
     uplt.close(fig)
 
 
+def test_spanning_labels_excluded_from_tight_layout_bbox():
+    """
+    Spanning x/y labels should not be counted twice by tight layout.
+
+    Regression test: with ``space=0``, including the figure-level spanning labels
+    in layout caused oversized left/bottom margins.
+    """
+    fig, ax = uplt.subplots(space=0, refwidth="10em")
+    ax.format(xticks="null", yticks="null", xlabel="x axis", ylabel="y axis")
+    fig.canvas.draw()
+
+    assert fig._supxlabel_dict
+    assert fig._supylabel_dict
+    assert all(not lab.get_in_layout() for lab in fig._supxlabel_dict.values())
+    assert all(not lab.get_in_layout() for lab in fig._supylabel_dict.values())
+
+    left, bottom, _, _ = ax.get_position().bounds
+    assert left < 0.25
+    assert bottom < 0.25
+
+    uplt.close(fig)
+
+
 def test_subset_share_xlabels_implicit():
     fig, ax = uplt.subplots(ncols=2, nrows=2, share="labels", span=False)
     ax[0, 0].format(xlabel="Top-left X")


### PR DESCRIPTION
This fix addresses a layout regression where figures with `space=0` and shared/spanning axis labels (`xlabel`/`ylabel`) reserved too much margin on the left and bottom edges. The root cause was that spanning figure-level labels were being included in tight-layout calculations while placeholder axis labels were also used to reserve space, effectively counting label extents twice. The patch marks spanning labels as out-of-layout (`in_layout=False`) so tight layout only accounts for the intended placeholder label extents. A regression test was added to verify spanning labels are excluded from layout accounting and that margins remain compact for `space=0` cases.
