### PR TITLE
Fix/preserve dpi draw without rendering

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -898,6 +898,18 @@ class Figure(mfigure.Figure):
         self._apply_share_label_groups()
         super().draw(renderer)
 
+    @override
+    def draw_without_rendering(self):
+        """
+        Draw without output while preserving figure dpi state.
+        """
+        dpi = self.dpi
+        try:
+            return super().draw_without_rendering()
+        finally:
+            if self.dpi != dpi:
+                mfigure.Figure.set_dpi(self, dpi)
+
     def _is_auto_share_mode(self, which: str) -> bool:
         """Return whether a given axis uses auto-share mode."""
         if which not in ("x", "y"):

--- a/ultraplot/tests/test_figure.py
+++ b/ultraplot/tests/test_figure.py
@@ -78,6 +78,21 @@ def test_get_renderer_basic():
     assert hasattr(renderer, "draw_path")
 
 
+def test_draw_without_rendering_preserves_dpi():
+    """
+    draw_without_rendering should not mutate figure dpi/bbox.
+    """
+    fig, ax = uplt.subplots(figsize=(4, 3), dpi=101)
+    dpi_before = fig.dpi
+    bbox_before = np.array([fig.bbox.width, fig.bbox.height])
+
+    fig.draw_without_rendering()
+
+    assert np.isclose(fig.dpi, dpi_before)
+    assert np.allclose([fig.bbox.width, fig.bbox.height], bbox_before)
+    uplt.close(fig)
+
+
 def test_figure_sharing_toggle():
     """
     Check if axis sharing and unsharing works


### PR DESCRIPTION
Fixes an issue where matplotlib figures reset the dpi to something else than set by UltraPlots config. Addresses https://github.com/moss-xyz/matplotlib-map-utils/pull/17/changes#diff-7a6e4a98de7d026a6930f77a022e894c3949c06f8542e1597e1a577ce8c83f1c