### PR TITLE
Fix cartopy tri default transform for Triangulation inputs

### DIFF
--- a/ultraplot/internals/inputs.py
+++ b/ultraplot/internals/inputs.py
@@ -16,6 +16,10 @@ try:
     from cartopy.crs import PlateCarree
 except ModuleNotFoundError:
     PlateCarree = object
+try:
+    from matplotlib.tri import Triangulation
+except ModuleNotFoundError:
+    Triangulation = object
 
 
 # Constants
@@ -300,8 +304,16 @@ def _parse_triangulation_with_preprocess(*keys, keywords=None, allow_extra=True)
         # Manually set the name to the original function's name
         triangulation_wrapper.__name__ = func.__name__
 
+        def _tri_cartopy_default(args, kwargs):
+            # If the first parsed argument is already a Triangulation then it may
+            # be in projected coordinates, so skip implicit PlateCarree defaults.
+            return not (args and isinstance(args[0], Triangulation))
+
         final_wrapper = _preprocess_or_redirect(
-            *keys, keywords=keywords, allow_extra=allow_extra
+            *keys,
+            keywords=keywords,
+            allow_extra=allow_extra,
+            cartopy_default_transform=_tri_cartopy_default,
         )(triangulation_wrapper)
 
         # Finally make sure all other metadata is correct
@@ -311,7 +323,9 @@ def _parse_triangulation_with_preprocess(*keys, keywords=None, allow_extra=True)
     return _decorator
 
 
-def _preprocess_or_redirect(*keys, keywords=None, allow_extra=True):
+def _preprocess_or_redirect(
+    *keys, keywords=None, allow_extra=True, cartopy_default_transform=True
+):
     """
     Redirect internal plotting calls to native matplotlib methods. Also convert
     keyword args to positional and pass arguments through 'data' dictionary.
@@ -335,18 +349,6 @@ def _preprocess_or_redirect(*keys, keywords=None, allow_extra=True):
                 func_native = getattr(super(PlotAxes, self), name)
                 return func_native(*args, **kwargs)
             else:
-                # Impose default coordinate system
-                from ..constructor import Proj
-
-                if self._name == "basemap" and name in BASEMAP_FUNCS:
-                    if kwargs.get("latlon", None) is None:
-                        kwargs["latlon"] = True
-                if self._name == "cartopy" and name in CARTOPY_FUNCS:
-                    if kwargs.get("transform", None) is None:
-                        kwargs["transform"] = PlateCarree()
-                    else:
-                        kwargs["transform"] = Proj(kwargs["transform"])
-
                 # Process data args
                 # NOTE: Raises error if there are more args than keys
                 args, kwargs = _kwargs_to_args(
@@ -357,6 +359,25 @@ def _preprocess_or_redirect(*keys, keywords=None, allow_extra=True):
                     args = _from_data(data, *args)
                     for key in set(keywords) & set(kwargs):
                         kwargs[key] = _from_data(data, kwargs[key])
+
+                # Impose default coordinate system using parsed inputs. This keeps
+                # behavior consistent across positional/keyword/data pathways.
+                from ..constructor import Proj
+
+                if self._name == "basemap" and name in BASEMAP_FUNCS:
+                    if kwargs.get("latlon", None) is None:
+                        kwargs["latlon"] = True
+                if self._name == "cartopy" and name in CARTOPY_FUNCS:
+                    if kwargs.get("transform", None) is None:
+                        use_default_transform = cartopy_default_transform
+                        if callable(use_default_transform):
+                            use_default_transform = bool(
+                                use_default_transform(args, kwargs)
+                            )
+                        if use_default_transform:
+                            kwargs["transform"] = PlateCarree()
+                    else:
+                        kwargs["transform"] = Proj(kwargs["transform"])
 
                 # Auto-setup matplotlib with the input unit registry
                 _load_objects()

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -931,10 +931,10 @@ def test_rasterize_feature():
 
 def test_check_tricontourf():
     """
-    Ensure that tricontour functions are getting
-    the transform for GeoAxes.
+    Ensure transform defaults are applied only when appropriate for tri-plots.
     """
     import cartopy.crs as ccrs
+    from matplotlib.tri import Triangulation
 
     lon0 = 90
     lon = np.linspace(-180, 180, 10)
@@ -947,6 +947,7 @@ def test_check_tricontourf():
     data[mask_box] = 1.5
 
     lon, lat, data = map(np.ravel, (lon2d, lat2d, data))
+    triangulation = Triangulation(lon, lat)
 
     fig, ax = uplt.subplots(proj="cyl", proj_kw={"lon0": lon0})
     original_func = ax[0]._call_native
@@ -956,10 +957,18 @@ def test_check_tricontourf():
         autospec=True,
         side_effect=original_func,
     ) as mocked:
-        for func in "tricontour tricontourf".split():
-            getattr(ax[0], func)(lon, lat, data)
+        ax[0].tricontourf(lon, lat, data)
         assert "transform" in mocked.call_args.kwargs
         assert isinstance(mocked.call_args.kwargs["transform"], ccrs.PlateCarree)
+
+    with mock.patch.object(
+        ax[0],
+        "_call_native",
+        autospec=True,
+        side_effect=original_func,
+    ) as mocked:
+        ax[0].tricontourf(triangulation, data)
+        assert "transform" not in mocked.call_args.kwargs
     uplt.close(fig)
 
 


### PR DESCRIPTION
Closes #594 
I introduced a messy injector with the decorators that would auto assume that PlateCaree was used as a tricontourmesh for GeoAxes. This ensure that we do not set this projection for triangular meshes.