### PR TITLE
Internal: cache inspect.signature used by pop_params

### DIFF
--- a/ultraplot/internals/__init__.py
+++ b/ultraplot/internals/__init__.py
@@ -189,6 +189,7 @@ def _get_signature(func):
         # Some callable objects may be unhashable for lru_cache keys.
         return inspect.signature(func)
 
+
 _LAZY_ATTRS = {
     "benchmarks": ("benchmarks", None),
     "context": ("context", None),


### PR DESCRIPTION
Randomly checked through some functions and stumbled upon a speed-up. The `_pop_params`is used by a lot of functions and it uses inspect signature a lot. By caching that function we can gain a 13x speed up.

  - Before: ~1.88s for 200k _pop_params calls
  - After: ~0.138s for 200k calls


