### PR TITLE
Support Python 3.10 TOML loading

### DIFF
--- a/tools/release/publish_zenodo.py
+++ b/tools/release/publish_zenodo.py
@@ -6,9 +6,13 @@ import json
 import mimetypes
 import os
 import sys
-import tomllib
 from pathlib import Path
 from urllib import error, parse, request
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 try:
     import yaml

--- a/ultraplot/tests/test_release_metadata.py
+++ b/ultraplot/tests/test_release_metadata.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 import re
 import subprocess
-import tomllib
 from pathlib import Path
 
 import pytest
@@ -87,8 +86,7 @@ def test_zenodo_release_metadata_is_built_from_repository_sources():
     """
     publish_zenodo = _load_publish_zenodo()
     citation = yaml.safe_load(CITATION_CFF.read_text(encoding="utf-8"))
-    with PYPROJECT.open("rb") as handle:
-        pyproject = tomllib.load(handle)
+    pyproject = publish_zenodo.load_pyproject(PYPROJECT)
     metadata = publish_zenodo.build_metadata(citation, pyproject)
     assert metadata["title"] == citation["title"]
     assert metadata["upload_type"] == "software"


### PR DESCRIPTION
Follow-up hotfix for #625. The Zenodo release helper and its release-metadata test were importing tomllib unconditionally, which breaks under Python 3.10. This reuses the repo's existing tomllib/tomli fallback pattern in the release helper and routes the test through the helper so the release path stays compatible with the supported Python floor.