### PR TITLE
fix: dedupe boxplot ticks on shared axes

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -6279,6 +6279,14 @@ class PlotAxes(base.Axes):
             # Use vert parameter
             artists = self._call_native("boxplot", y, vert=vert, **kw)
 
+        if kw.get("manage_ticks", True):
+            getter = self.get_xticks if vert else self.get_yticks
+            setter = self.set_xticks if vert else self.set_yticks
+            ticks = getter()
+            unique_ticks = list(dict.fromkeys(ticks))
+            if len(unique_ticks) != len(ticks):
+                setter(unique_ticks)
+
         artists = artists or {}  # necessary?
         artists = {
             key: cbook.silent_list(type(objs[0]).__name__, objs) if objs else objs

--- a/ultraplot/tests/test_statistical_plotting.py
+++ b/ultraplot/tests/test_statistical_plotting.py
@@ -482,3 +482,19 @@ def test_ridgeline_continuous_auto_height(rng):
     artists = ax.ridgeline([data[0]], positions=[0])
     assert len(artists) == 1
     uplt.close(fig)
+
+
+def test_boxplot_shared_x_does_not_duplicate_ticks(rng):
+    data = [rng.random(size=j * 50) for j in range(1, 11)]
+    fig, axs = uplt.subplots(nrows=2, ncols=2, sharex=2, sharey=False)
+
+    for ax in axs:
+        ax.boxplot(data, showfliers=False, lw=0.5)
+
+    fig.canvas.draw()
+
+    for ax in axs:
+        ticks = [int(t) for t in ax.get_xticks()]
+        assert ticks == list(range(10))
+
+    uplt.close(fig)


### PR DESCRIPTION
## Bug
Fixes #628 — with shared x-axes, repeated `boxplot()` calls can leave duplicated tick positions/labels (e.g. `0..9` rendered twice), which causes doubled/bold tick labels.

## Fix
- After the native `boxplot` call, deduplicate managed axis tick positions while preserving order.
- Apply this only when `manage_ticks` is active, so explicit tick management still behaves as requested.

## Tests
- Added regression test: `test_boxplot_shared_x_does_not_duplicate_ticks`
- Ran:
  - `pytest ultraplot/tests/test_statistical_plotting.py -k boxplot_shared_x_does_not_duplicate_ticks`

Happy to adjust if you prefer a different location for the dedupe logic.

Greetings, saschabuehrle
