### PR TITLE
feat: add 'plot.sticky' RC flag to toggle sticky edges

### DIFF
--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -3497,6 +3497,8 @@ class PlotAxes(base.Axes):
         Fix sticky edges for the input artists using the minimum and maximum of the
         input coordinates. This is used to copy `bar` behavior to `area` and `lines`.
         """
+        if not rc["plot.sticky"]:
+            return
         for array in args:
             min_, max_ = inputs._safe_range(array)
             if min_ is None or max_ is None:

--- a/ultraplot/internals/rcsetup.py
+++ b/ultraplot/internals/rcsetup.py
@@ -1050,6 +1050,12 @@ _rc_ultraplot_table = {
         _validate_float,
         "Vertical margin around ribbon diagrams (axes-relative units).",
     ),
+    # Plot settings
+    "plot.sticky": (
+        True,
+        _validate_bool,
+        "Whether to use sticky edges for line and area plots by default.",
+    ),
     "ribbon.rowheightratio": (
         2.2,
         _validate_float,


### PR DESCRIPTION
Fixes #631

Added a new 'plot.sticky' configuration setting (default True) that allows globally disabling sticky edges for line and area plots via the rc file or rc context.