### PR TITLE
Add linewidth support to legend inputs

### DIFF
--- a/ultraplot/legend.py
+++ b/ultraplot/legend.py
@@ -1308,6 +1308,7 @@ class _LegendInputs:
     pad: Any
     space: Any
     frameon: bool
+    linewidth: Any
     ncol: Any
     order: str
     label: Any
@@ -1834,6 +1835,7 @@ class UltraLegend:
             pad=pad,
             space=space,
             frameon=frameon,
+            linewidth=kwargs.get("linewidth", None), 
             ncol=ncol,
             order=order,
             label=label,

--- a/ultraplot/legend.py
+++ b/ultraplot/legend.py
@@ -1835,7 +1835,7 @@ class UltraLegend:
             pad=pad,
             space=space,
             frameon=frameon,
-            linewidth=kwargs.get("linewidth", None), 
+            linewidth=kwargs.get("linewidth", None),
             ncol=ncol,
             order=order,
             label=label,


### PR DESCRIPTION
Summary

Adds support for "linewidth" in legend inputs.

Changes

- Passes "linewidth" from kwargs into "_LegendInputs"
- Allows users to control legend frame linewidth

Notes

- Minimal change, no breaking behavior