### PR TITLE
Implement stacked bar regression test

### DIFF
--- a/ultraplot/tests/test_1dplots.py
+++ b/ultraplot/tests/test_1dplots.py
@@ -116,13 +116,19 @@ def test_column_iteration(rng):
     return fig
 
 
-@pytest.mark.skip("TODO")
 @pytest.mark.mpl_image_compare
-def test_bar_stack():
+def test_bar_stack(rng):
     """
     Test bar and area stacking.
     """
-    # TODO: Add test here
+    fig, axs = uplt.subplots(ncols=2, nrows=2)
+    x = np.arange(5)
+    y = rng.random((5, 3))
+    axs[0].bar(x, y, stack=False)
+    axs[1].bar(x, y, stack=True)
+    axs[2].area(x, y, stack=False)
+    axs[3].area(x, y, stack=True)
+    return fig
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
## Summary

Replaces the skipped `test_bar_stack()` placeholder with a working regression test. The test creates a 2x2 subplot grid covering unstacked bars, stacked bars, unstacked area, and stacked area.

## Why this matters

The skipped test was dead weight in the test suite. Stacking behavior is a core feature that should have regression coverage. This test catches regressions in both `bar()` and `area()` stacking logic.

## Changes

- `ultraplot/tests/test_1dplots.py`: Removed `@pytest.mark.skip("TODO")`, added `rng` fixture parameter, implemented test body with 4 subplot panels covering bar/area stacking variants.

## Testing

- Generated baseline image locally with `--mpl-generate-path` - renders correctly with all 4 panels showing expected stacking behavior.
- CI will auto-generate the baseline from main and compare against the PR's output.

Fixes #642

This contribution was developed with AI assistance (Claude Code).