### PR TITLE
Fix outer legend hiding y-tick labels with sharey='labs' (#694)

### DIFF
--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -1487,10 +1487,18 @@ class Figure(mfigure.Figure):
         if getattr(axi, "_panel_side", None) and getattr(axi, f"_share{axis}", None):
             return 3
 
-        # Adjacent panels on any relevant side
+        # Adjacent panels on any relevant side. Ignore hidden filled panels
+        # (e.g. those created for outer legends/colorbars via ``loc='r'``);
+        # they do not participate in axis sharing and must not promote the
+        # parent axes' tick-label sharing level (see issue #694).
         panel_dict = getattr(axi, "_panel_dict", {})
         for side in sides:
-            side_panels = panel_dict.get(side) or []
+            side_panels = [
+                p
+                for p in (panel_dict.get(side) or [])
+                if not getattr(p, "_panel_hidden", False)
+                and getattr(p, "_panel_share", False)
+            ]
             if side_panels and getattr(side_panels[0], f"_share{axis}", False):
                 return 3
 

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -948,3 +948,41 @@ def test_grid_geo_and_cartesian():
     assert axs[2] in outer_axes["right"]
     assert axs[3] in outer_axes["right"]
     return fig
+
+
+@pytest.mark.parametrize("share_level", ["labs", "lims"])
+def test_outer_legend_keeps_ticklabels_with_label_sharing(share_level: str) -> None:
+    """
+    Regression test for issue #694. With ``sharey`` set to a "label" or
+    "limits" level (i.e. < 3), tick labels must remain on every visible
+    subplot even after an outer legend (``loc='r'``) is added next to one
+    of them. Previously the legend's hidden filled panel promoted the
+    parent's effective share level to 3 and hid its left tick labels.
+    """
+    fig, axs = uplt.subplots(ncols=3, sharey=share_level)
+    axs[-1].set_visible(False)
+    for ax in axs[:-1]:
+        ax.plot([0, 1], [0, 1], label="line")
+    axs[-2].legend(loc="r")
+    fig.canvas.draw()
+
+    for ax in axs[:-1]:
+        assert ax.yaxis.get_tick_params()["labelleft"] is True
+
+
+def test_outer_legend_preserves_share_true_ticklabel_hiding() -> None:
+    """
+    Counterpart to ``test_outer_legend_keeps_ticklabels_with_label_sharing``:
+    when ``sharey=True`` (level 3) the inner subplots' tick labels must
+    still be hidden even after an outer legend is attached. Guards against
+    over-correcting the issue #694 fix.
+    """
+    fig, axs = uplt.subplots(ncols=3, sharey=True)
+    for ax in axs:
+        ax.plot([0, 1], [0, 1], label="line")
+    axs[1].legend(loc="r")
+    fig.canvas.draw()
+
+    assert axs[0].yaxis.get_tick_params()["labelleft"] is True
+    assert axs[1].yaxis.get_tick_params()["labelleft"] is False
+    assert axs[2].yaxis.get_tick_params()["labelleft"] is False


### PR DESCRIPTION
Closes #694.

## Summary

`_effective_share_level` (in `figure.py`) was promoting an axes' effective share level to 3 whenever any adjacent panel had a shared axis — including the *hidden filled panel* that an outer legend (`loc='r'`) creates. That promotion fired `_share_ticklabels`, whose border-mask then turned `labelleft` off on the inner subplot because the inner subplot is not on the figure's left border.

The fix filters the "adjacent panels" clause to ignore panels with `_panel_hidden=True` or `_panel_share=False`, matching the same predicate `_apply_auto_share` already uses (`shared(paxs)`). With that, `sharey='labs'` no longer loses its tick labels when an outer legend is added next to a subplot.

## Tests

Two new flat tests in `ultraplot/tests/test_subplots.py`:

- `test_outer_legend_keeps_ticklabels_with_label_sharing[labs|lims]` — the issue #694 reproducer.
- `test_outer_legend_preserves_share_true_ticklabel_hiding` — guard so the fix doesn't accidentally re-enable interior tick labels when `sharey=True` (level 3).

All 455 pre-existing `test_subplots`/`test_figure`/`test_axes`/`test_colorbar` tests still pass.

## Note for follow-up — proper architectural fix needed

This PR is intentionally minimal. It papers over a deeper duplication: tick-label visibility is currently decided in **two parallel systems** — `cartesian.py:_apply_axis_sharing_for_axis` (per-axes) and `figure.py:_share_ticklabels` (figure-level) — that race during draw. The "panel participates in sharing" concept is encoded with **four slightly different filters** across `_apply_auto_share`, the span helpers, the cartesian tick-sharing path, and (until this PR) `_effective_share_level`. The bug lived in exactly that gap.

A proper follow-up should:

1. Introduce a single `_panel_participates_in_sharing(p)` predicate used by every site that filters panel lists.
2. Centralise the "promote to level 3" logic in one place rather than three (`cartesian.py:505`, `cartesian.py:820/847`, `figure.py:_effective_share_level`).
3. Pick a single owner of tick-label visibility per draw and remove the overlapping logic from the other path.

This aligns with the existing plan to extract layout/sharing logic out of `Figure`. I'll open a separate tracking issue for it.