### PR TITLE
Fix: panel axis upgraded when sharing axes.

### DIFF
--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -2079,6 +2079,20 @@ class SubplotGrid(MutableSequence, list):
         ultraplot.figure.Figure.format
         ultraplot.config.Configurator.context
         """
+
+        def _supports_implicit_label_share(target):
+            compatible_sides = {
+                "x": {"top", "bottom"},
+                "y": {"left", "right"},
+            }
+            for ax in axes:
+                side = getattr(ax, "_panel_side", None)
+                if side is None:
+                    continue
+                if side not in compatible_sides[target]:
+                    return False
+            return True
+
         # Implicit label sharing for subset format calls
         share_xlabels = kwargs.get("share_xlabels", None)
         share_ylabels = kwargs.get("share_ylabels", None)
@@ -2102,6 +2116,18 @@ class SubplotGrid(MutableSequence, list):
             shared_title_pad = None
         rc_kw, rc_mode = _pop_rc(kwargs)
         with rc.context(rc_kw, mode=rc_mode):
+            implicit_share_xlabels = (
+                is_subset
+                and share_xlabels is None
+                and xlabel is not None
+                and _supports_implicit_label_share("x")
+            )
+            implicit_share_ylabels = (
+                is_subset
+                and share_ylabels is None
+                and ylabel is not None
+                and _supports_implicit_label_share("y")
+            )
             if len(self) > 1:
                 if share_xlabels is False:
                     self.figure._clear_share_label_groups(self, target="x")
@@ -2111,9 +2137,9 @@ class SubplotGrid(MutableSequence, list):
                     self.figure._clear_share_label_groups(self, target="x")
                 if not is_subset and share_ylabels is None and ylabel is not None:
                     self.figure._clear_share_label_groups(self, target="y")
-                if is_subset and share_xlabels is None and xlabel is not None:
+                if implicit_share_xlabels:
                     self.figure._register_share_label_group(self, target="x")
-                if is_subset and share_ylabels is None and ylabel is not None:
+                if implicit_share_ylabels:
                     self.figure._register_share_label_group(self, target="y")
             self.figure.format(axs=self, **kwargs)
             if shared_subset_title:
@@ -2126,9 +2152,9 @@ class SubplotGrid(MutableSequence, list):
                 )
             # Refresh groups after labels are set
             if len(self) > 1:
-                if is_subset and share_xlabels is None and xlabel is not None:
+                if implicit_share_xlabels:
                     self.figure._register_share_label_group(self, target="x")
-                if is_subset and share_ylabels is None and ylabel is not None:
+                if implicit_share_ylabels:
                     self.figure._register_share_label_group(self, target="y")
 
     def share_labels(self, *, axis="x"):

--- a/ultraplot/tests/test_subplots.py
+++ b/ultraplot/tests/test_subplots.py
@@ -284,6 +284,30 @@ def test_subset_share_xlabels_override():
     uplt.close(fig)
 
 
+def test_panel_subset_keeps_orthogonal_axis_labels_local():
+    fig, axs = uplt.subplots(ncols=2, sharey=0)
+    bottom = axs.panel_axes("bottom")
+    right = axs.panel_axes("right")
+
+    axs.format(xlabel="main x", ylabel="main y")
+    bottom.format(ylabel="bottom y")
+    right.format(xlabel="right x")
+    fig.canvas.draw()
+
+    assert not fig._supylabel_dict
+    assert not fig._supxlabel_dict
+    for ax in axs:
+        assert ax.get_ylabel() == "main y"
+    for pax in bottom:
+        assert pax.get_ylabel() == "bottom y"
+        assert pax.yaxis.label.get_visible()
+    for pax in right:
+        assert pax.get_xlabel() == "right x"
+        assert pax.xaxis.label.get_visible()
+
+    uplt.close(fig)
+
+
 def test_spanning_labels_excluded_from_tight_layout_bbox():
     """
     Spanning x/y labels should not be counted twice by tight layout.


### PR DESCRIPTION
Closes #702 
Fix panel subset label sharing so orthogonal panel axes keep local labels instead of entering implicit shared-label groups.