### PR TITLE
Fix uncertainty legend glyphs for errorbar-based mean plots

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2127,14 +2127,11 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         # Helper function. Translate handles in the input tuple group. Extracts
         # legend handles from contour sets and extracts labeled elements from
         # matplotlib containers (important for histogram plots).
-        ignore = (mcontainer.ErrorbarContainer,)
         containers = (cbook.silent_list, mcontainer.Container)
 
         def _legend_tuple(*objs):  # noqa: E306
             handles = []
             for obj in objs:
-                if isinstance(obj, ignore) and not _legend_label(obj):
-                    continue
                 if hasattr(obj, "update_scalarmappable"):  # for e.g. pcolor
                     obj.update_scalarmappable()
                 if isinstance(obj, mcontour.ContourSet):  # extract single element
@@ -2143,7 +2140,9 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                     if hs:  # non-empty
                         obj = hs[len(hs) // 2]
                         obj.set_label(label)
-                if isinstance(obj, containers):  # extract labeled elements
+                if isinstance(obj, mcontainer.ErrorbarContainer):
+                    handles.append(obj)
+                elif isinstance(obj, containers):  # extract labeled elements
                     hs = (obj, *guides._iter_iterables(obj))
                     hs = tuple(filter(_legend_label, hs))
                     if hs:

--- a/ultraplot/tests/test_legend.py
+++ b/ultraplot/tests/test_legend.py
@@ -1,12 +1,16 @@
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib import collections as mcollections
 from matplotlib import colors as mcolors
+from matplotlib import container as mcontainer
 from matplotlib import legend_handler as mhandler
+from matplotlib import lines as mlines
 from matplotlib import patches as mpatches
 
 import ultraplot as uplt
 from ultraplot.axes import Axes as UAxes
+from ultraplot.internals import guides
 
 
 @pytest.mark.mpl_image_compare
@@ -181,6 +185,28 @@ def test_tuple_handles(rng):
             handler_map={tuple: legend_handler.HandlerTuple(pad=0, ndivide=3)},
         )
     return fig
+
+
+@pytest.mark.parametrize("kwarg", ["barstd", "boxstd"])
+def test_mean_errorbar_handles_are_preserved_in_legends(kwarg, rng):
+    fig, axs = uplt.subplots()
+    ax = axs[0]
+    data = rng.random((10, 4)).cumsum(axis=0)
+
+    handles = ax.plot(data, means=True, label="label", **{kwarg: 1})
+    handles, labels = ax._parse_legend_group(handles, None)
+
+    assert labels == ["label"]
+    assert len(handles) == 1
+    assert isinstance(handles[0], tuple)
+    assert any(isinstance(obj, mcontainer.ErrorbarContainer) for obj in handles[0])
+
+    leg = ax.legend(handles)
+    legend_children = list(guides._iter_children(leg._legend_handle_box))
+    assert any(isinstance(obj, mcollections.LineCollection) for obj in legend_children)
+    assert any(isinstance(obj, mlines.Line2D) for obj in legend_children)
+
+    uplt.close(fig)
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
Closes #705

Removed `ErrorbarContainer` from  filter list to allow legends to show the compound mean and errobars.

