### PR TITLE
Suppress sharing warnings when no sharing is possible

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1347,22 +1347,24 @@ class Axes(_ExternalModeMixin, maxes.Axes):
 
         # External axes sharing, sometimes overrides panel axes sharing
         # Share x axes within compatible groups
-        axes_x = self._get_share_axes("x")
-        for group in self.figure._partition_share_axes(axes_x, "x"):
-            if not group:
-                continue
-            parent, *children = group
-            for child in children:
-                child._sharex_setup(parent)
+        if self.figure._sharex > 0:
+            axes_x = self._get_share_axes("x")
+            for group in self.figure._partition_share_axes(axes_x, "x"):
+                if not group:
+                    continue
+                parent, *children = group
+                for child in children:
+                    child._sharex_setup(parent)
 
         # Share y axes within compatible groups
-        axes_y = self._get_share_axes("y")
-        for group in self.figure._partition_share_axes(axes_y, "y"):
-            if not group:
-                continue
-            parent, *children = group
-            for child in children:
-                child._sharey_setup(parent)
+        if self.figure._sharey > 0:
+            axes_y = self._get_share_axes("y")
+            for group in self.figure._partition_share_axes(axes_y, "y"):
+                if not group:
+                    continue
+                parent, *children = group
+                for child in children:
+                    child._sharey_setup(parent)
 
         # Global sharing, use the reference subplot where compatible
         ref = self.figure._subplot_dict.get(self.figure._refnum, None)

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -1325,6 +1325,15 @@ class Figure(mfigure.Figure):
 
         # Process each group independently
         for _, group_axes in groups.items():
+            # Nothing to share if the group is too small or sharing is disabled —
+            # avoids unsupported-type warnings (e.g. PolarAxes) for those cases.
+            if len(group_axes) < 2:
+                continue
+            if all(
+                self._effective_share_level(axi, axis, sides) < 3 for axi in group_axes
+            ):
+                continue
+
             # Build baseline from MAIN axes only (exclude panels)
             baseline, skip_group = self._compute_baseline_tick_state(
                 group_axes, axis, label_keys

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -1325,9 +1325,19 @@ class Figure(mfigure.Figure):
 
         # Process each group independently
         for _, group_axes in groups.items():
-            # Nothing to share if the group is too small or sharing is disabled —
-            # avoids unsupported-type warnings (e.g. PolarAxes) for those cases.
-            if len(group_axes) < 2:
+            # Singleton groups can still need border masking reapplied for
+            # supported axes (e.g. GeoAxes split by guides), but unsupported
+            # singleton groups like a single PolarAxes should not warn.
+            main_axes = [
+                axi for axi in group_axes if not getattr(axi, "_panel_side", None)
+            ]
+            supported_main_axes = any(
+                isinstance(
+                    axi, (paxes.CartesianAxes, paxes._CartopyAxes, paxes._BasemapAxes)
+                )
+                for axi in main_axes
+            )
+            if len(group_axes) < 2 and not supported_main_axes:
                 continue
             if all(
                 self._effective_share_level(axi, axis, sides) < 3 for axi in group_axes

--- a/ultraplot/tests/test_figure.py
+++ b/ultraplot/tests/test_figure.py
@@ -354,6 +354,56 @@ def test_explicit_share_warns_for_mixed_cartesian_polar():
     assert len(incompatible) == 1
 
 
+def test_share_zero_polar_emits_no_warnings(recwarn):
+    fig, axs = uplt.subplots(proj="polar", ncols=2, nrows=3, share=0)
+    fig.canvas.draw()
+
+    ultra = [
+        w
+        for w in recwarn
+        if issubclass(w.category, uplt.internals.warnings.UltraPlotWarning)
+    ]
+    assert ultra == [], [str(w.message) for w in ultra]
+
+
+def test_share_zero_mixed_cartesian_polar_emits_no_warnings(recwarn):
+    fig, axs = uplt.subplots(ncols=2, proj=("cart", "polar"), share=0)
+    fig.canvas.draw()
+
+    ultra = [
+        w
+        for w in recwarn
+        if issubclass(w.category, uplt.internals.warnings.UltraPlotWarning)
+    ]
+    assert ultra == [], [str(w.message) for w in ultra]
+
+
+def test_share_default_single_polar_emits_no_warnings(recwarn):
+    """A single polar axis has nothing to share — must not warn at default share."""
+    fig, ax = uplt.subplots(proj="polar")
+    fig.canvas.draw()
+
+    ultra = [
+        w
+        for w in recwarn
+        if issubclass(w.category, uplt.internals.warnings.UltraPlotWarning)
+    ]
+    assert ultra == [], [str(w.message) for w in ultra]
+
+
+def test_share_default_single_polar_subplot_singular_emits_no_warnings(recwarn):
+    """``uplt.subplot(proj='polar')`` (singular) has nothing to share either."""
+    fig, ax = uplt.subplot(proj="polar")
+    fig.canvas.draw()
+
+    ultra = [
+        w
+        for w in recwarn
+        if issubclass(w.category, uplt.internals.warnings.UltraPlotWarning)
+    ]
+    assert ultra == [], [str(w.message) for w in ultra]
+
+
 def test_auto_share_local_yscale_change_splits_group():
     fig, axs = uplt.subplots(ncols=2, share="auto")
     fig.canvas.draw()


### PR DESCRIPTION
# Suppress sharing warnings when no sharing is possible

## Problem

`UltraPlotWarning`s about axis sharing fired in cases where the user did not request sharing or where sharing was not possible at all:

- `uplt.subplots(proj='polar', ncols=2, nrows=3, share=0)` — the user explicitly disabled sharing, but construction and every subsequent `draw` emitted `Skipping incompatible y-axis sharing for PolarAxes and PolarAxes: different axis families.` and `Tick label sharing not implemented for <class 'ultraplot.axes.polar.PolarAxes'> subplots.`
- `uplt.subplot(proj='polar')` / `uplt.subplots(proj='polar')` — a single polar axis has nothing to share with, but `Tick label sharing not implemented for <PolarAxes> subplots.` still fired four times per draw.

## Fix

Two unrelated paths needed gating:

- **`Axes._apply_auto_share`** (`ultraplot/axes/base.py`) called `Figure._partition_share_axes` for x and y unconditionally. Wrapped the external-share blocks in `if self.figure._sharex > 0:` / `if self.figure._sharey > 0:`, mirroring the existing panel-share guards just above.

- **`Figure._share_ticklabels`** (`ultraplot/figure.py`) ran `_compute_baseline_tick_state` (which emits the `Tick label sharing not implemented` warning for unsupported axes types) before checking whether the group could actually share. Skip the group up front when it has fewer than two axes or when no axes have effective share level >= 3.

Explicit `share='all'` (or any level >= 1) on multiple polar / mixed cart-polar grids still warns as before — that case is informative.

## Tests

Added regression tests in `ultraplot/tests/test_figure.py`:

- `test_share_zero_polar_emits_no_warnings` — `share=0` on an all-polar grid.
- `test_share_zero_mixed_cartesian_polar_emits_no_warnings` — `share=0` on a mixed cart/polar grid.
- `test_share_default_single_polar_emits_no_warnings` — default share on a single-axis polar figure via `uplt.subplots`.
- `test_share_default_single_polar_subplot_singular_emits_no_warnings` — same via `uplt.subplot` (singular).

Existing `test_explicit_share_warns_for_mixed_cartesian_polar` continues to pass, confirming the explicit-share warning path is preserved. All 23 share-related tests pass; broader `test_figure.py` / `test_subplots.py` / `test_projections.py` (139 tests) also pass.
