### PR TITLE
Fix GeoAxes grid label formatting through SubplotGrid and Figure format dispatch

### DIFF
--- a/ultraplot/config.py
+++ b/ultraplot/config.py
@@ -1314,15 +1314,19 @@ class Configurator(MutableMapping, dict):
         Return the tick label properties, optionally filtering the output dictionary
         based on the context.
         """
-        # NOTE: 'tick.label' properties are now synonyms of 'grid.label' properties
+        # Geographic gridline labels use the ultraplot-only grid.label* settings,
+        # while native matplotlib tick labels use x/y tick rcParams.
         sprefix = axis or ""
         cprefix = sprefix if _version_mpl >= "3.4" else ""  # new settings
         context = not rebuild and (native or self._context_mode == 2)
+        color_key = f"{cprefix}tick.labelcolor" if native else "grid.labelcolor"
+        size_key = f"{sprefix}tick.labelsize" if native else "grid.labelsize"
+        weight_key = "tick.labelweight" if native else "grid.labelweight"
         kwtext = self.fill(
             {
-                "color": f"{cprefix}tick.labelcolor",  # native setting sometimes avail
-                "size": f"{sprefix}tick.labelsize",  # native setting always avail
-                "weight": "tick.labelweight",  # native setting never avail
+                "color": color_key,  # native setting sometimes avail
+                "size": size_key,
+                "weight": weight_key,  # native setting never avail
                 "family": "font.family",  # apply manually
             },
             context=context,

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -3623,7 +3623,19 @@ class Figure(mfigure.Figure):
         # Initiate context block
         axs = axs or self._subplot_dict.values()
         skip_axes = kwargs.pop("skip_axes", False)  # internal keyword arg
+        # Preserve explicit projection-specific format keywords that also happen to
+        # be valid rc aliases (e.g. GeoAxes/PolarAxes `labelsize`). Otherwise
+        # `_pop_rc()` removes them before the per-axes format dispatch below.
+        original_kwargs = kwargs.copy()
+        axis_param_names = set()
+        for ax in axs:
+            for cls, sig in paxes.Axes._format_signatures.items():
+                if isinstance(ax, cls):
+                    axis_param_names.update(sig.parameters)
+        axis_param_names.discard("self")
         rc_kw, rc_mode = _pop_rc(kwargs)
+        for key in axis_param_names & original_kwargs.keys():
+            kwargs.setdefault(key, original_kwargs[key])
         with rc.context(rc_kw, mode=rc_mode):
             # Update background patch
             kw = rc.fill({"facecolor": "figure.facecolor"}, context=True)

--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -2114,7 +2114,19 @@ class SubplotGrid(MutableSequence, list):
         else:
             shared_title_loc = None
             shared_title_pad = None
+        # Preserve explicit projection-specific format keywords that also happen to
+        # be valid rc aliases (e.g. GeoAxes/PloarAxes `labelsize`). Otherwise
+        # `_pop_rc()` removes them before Figure.format() can delegate to axes.
+        original_kwargs = kwargs.copy()
+        axis_param_names = set()
+        for ax in axes:
+            for cls, sig in paxes.Axes._format_signatures.items():
+                if isinstance(ax, cls):
+                    axis_param_names.update(sig.parameters)
+        axis_param_names.discard("self")
         rc_kw, rc_mode = _pop_rc(kwargs)
+        for key in axis_param_names & original_kwargs.keys():
+            kwargs.setdefault(key, original_kwargs[key])
         with rc.context(rc_kw, mode=rc_mode):
             implicit_share_xlabels = (
                 is_subset

--- a/ultraplot/tests/test_geographic.py
+++ b/ultraplot/tests/test_geographic.py
@@ -188,6 +188,35 @@ def test_geoticks_label_shorthand_lb_no_warning(recwarn):
     uplt.close(fig)
 
 
+def test_geo_labelsize_updates_gridliner_labels():
+    fig, ax = uplt.subplots(proj="cyl")
+    ax = ax[0]
+    ax.format(labels=True, lonlines=30, latlines=30, labelsize=30)
+    fig.canvas.draw()
+
+    labels = (
+        ax.gridlines_major.bottom_label_artists + ax.gridlines_major.left_label_artists
+    )
+    assert labels
+    assert {label.get_fontsize() for label in labels} == {30}
+    uplt.close(fig)
+
+
+def test_subplotgrid_geo_labelsize_updates_gridliner_labels():
+    fig, ax = uplt.subplots(proj="cyl")
+    ax.format(labels=True, lonlines=30, latlines=30, labelsize=30)
+    fig.canvas.draw()
+
+    geo = ax[0]
+    labels = (
+        geo.gridlines_major.bottom_label_artists
+        + geo.gridlines_major.left_label_artists
+    )
+    assert labels
+    assert {label.get_fontsize() for label in labels} == {30}
+    uplt.close(fig)
+
+
 def test_toggle_ticks_supports_bool_and_sequence_specs():
     fig, ax = uplt.subplots(proj="cyl")
     geo = ax[0]


### PR DESCRIPTION
Closes #723 
This fixes a long-standing issue where geographic grid label styling options like labelsize worked when formatting a single GeoAxes directly, but were silently ignored when the same axes was formatted through SubplotGrid.format() or Figure.format(). The higher-level formatting paths were treating names like labelsize as rc-style aliases and removing them before dispatching to the projection-specific GeoAxes.format() method.

The underlying behavior goes back to the ProPlot inheritance chain. GeoAxes.format(labelsize=..., labelweight=...) was introduced there in October 2021, while the figure-level formatting dispatch was already using _pop_rc(kwargs). That meant the collision between explicit geo formatting keywords and rc aliases had been latent for a long time. This change preserves explicit projection-specific formatting arguments during figure and subplot-grid dispatch so that geographic label styling behaves the same whether users call ax.format(...) or axs.format(...).
