### PR TITLE
Fix duplicate import in colors.py

### DIFF
--- a/ultraplot/colors.py
+++ b/ultraplot/colors.py
@@ -27,7 +27,6 @@ from xml.etree import ElementTree
 import matplotlib as mpl
 import matplotlib.cm as mcm
 import matplotlib.colors as mcolors
-import matplotlib.colors as mcolors
 import numpy as np
 import numpy.ma as ma
 


### PR DESCRIPTION
Removed one duplicate line of import of matplotlib.colors.