### PR TITLE
Change rectangle to non-square for geolegend

### DIFF
--- a/ultraplot/legend.py
+++ b/ultraplot/legend.py
@@ -138,11 +138,13 @@ _GEOMETRY_SHAPE_PATHS = {
     "pentagon": mpath.Path.unit_regular_polygon(5),
     "hexagon": mpath.Path.unit_regular_polygon(6),
     "star": mpath.Path.unit_regular_star(5),
+    "rectangle": mpath.Path([[0, 0], [2, 0], [2, 1], [0, 1], [0, 0]],
+                            closed=True, readonly=True)
 }
 _GEOMETRY_SHAPE_ALIASES = {
     "box": "square",
-    "rect": "square",
-    "rectangle": "square",
+    "rect": "rectangle",
+    "rec": "rectangle",
     "tri": "triangle",
     "pent": "pentagon",
     "hex": "hexagon",

--- a/ultraplot/legend.py
+++ b/ultraplot/legend.py
@@ -138,8 +138,9 @@ _GEOMETRY_SHAPE_PATHS = {
     "pentagon": mpath.Path.unit_regular_polygon(5),
     "hexagon": mpath.Path.unit_regular_polygon(6),
     "star": mpath.Path.unit_regular_star(5),
-    "rectangle": mpath.Path([[0, 0], [2, 0], [2, 1], [0, 1], [0, 0]],
-                            closed=True, readonly=True)
+    "rectangle": mpath.Path(
+        [[0, 0], [2, 0], [2, 1], [0, 1], [0, 0]], closed=True, readonly=True
+    ),
 }
 _GEOMETRY_SHAPE_ALIASES = {
     "box": "square",


### PR DESCRIPTION
Addresses #729 .

Change `rec`, `rect`, `rectangle` to non-square rectangles for `geolegend`. 

Now the following codes,  produces the following image.

```python
fig,ax=pplt.subplot()
ax.axis('off')
# ax.geolegend(['diamond', 'rect', 'box'], fc='r', ec='r', loc='uc')
ax.geolegend(['rec', 'rect','rectangle', 'box', 'square'], 
    facecolor='r', edgecolor='r', loc='c', ncols=1)
```

<img width="312" height="289" alt="image" src="https://github.com/user-attachments/assets/e1861c4b-c1a7-4eb0-81c6-7f7217491635" />
