### PR TITLE
Allow colorbars to attach to inset axes

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -726,11 +726,12 @@ class _TransformedBoundsLocator:
 class _SideColorbarLocator:
     """Position a side colorbar beyond its parent axes decorations."""
 
-    def __init__(self, parent, side, bounds, pad):
+    def __init__(self, parent, side, bounds, pad, previous=()):
         self._parent = parent
         self._side = side
         self._bounds = bounds
         self._pad = pad
+        self._previous = tuple(previous)
 
     def __call__(self, ax, renderer):
         parent = self._parent
@@ -751,6 +752,13 @@ class _SideColorbarLocator:
         bboxes = [parent.bbox]
         if tight_bbox is not None:
             bboxes.append(tight_bbox)
+        if renderer is not None:
+            bboxes.extend(
+                bbox
+                for previous in self._previous
+                if previous.get_visible()
+                and (bbox := previous.get_tightbbox(renderer)) is not None
+            )
         tight_bbox = mtransforms.Bbox.union(bboxes)
         if side == "left":
             axes_bbox = mtransforms.Bbox.from_bounds(
@@ -2136,8 +2144,16 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             self, orientation, length, width, pad
         )
         bounds = _get_side_colorbar_bounds(side, align, length, width, xpad, ypad)
-        locator = _SideColorbarLocator(self, side, bounds, pad_points)
+        previous = (
+            child
+            for child in self.child_axes
+            if getattr(child, "_inset_colorbar_side", None) == side
+        )
+        locator = _SideColorbarLocator(
+            self, side, bounds, pad_points, previous=previous
+        )
         ax = self._add_colorbar_child_axes(bounds, locator=locator)
+        ax._inset_colorbar_side = side
         ax._inset_colorbar_frame = None
 
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -688,6 +688,67 @@ class _TransformedBoundsLocator:
         return bbox
 
 
+class _SideColorbarLocator:
+    """Position a side colorbar beyond its parent axes decorations."""
+
+    def __init__(self, parent, side, bounds, pad):
+        self._parent = parent
+        self._side = side
+        self._bounds = bounds
+        self._pad = pad
+
+    def __call__(self, ax, renderer):
+        parent = self._parent
+        side = self._side
+        x, y, width, height = self._bounds
+        pad = (
+            renderer.points_to_pixels(self._pad)
+            if renderer is not None
+            else self._pad * ax.figure.dpi / 72
+        )
+        axes_bbox = mtransforms.TransformedBbox(
+            mtransforms.Bbox.from_bounds(x, y, width, height), parent.transAxes
+        )
+        tight_bbox = None
+        if renderer is not None:
+            axis = parent.yaxis if side in ("left", "right") else parent.xaxis
+            tight_bbox = axis.get_tightbbox(renderer)
+        bboxes = [parent.bbox]
+        if tight_bbox is not None:
+            bboxes.append(tight_bbox)
+        tight_bbox = mtransforms.Bbox.union(bboxes)
+        if side == "left":
+            axes_bbox = mtransforms.Bbox.from_bounds(
+                tight_bbox.x0 - pad - axes_bbox.width,
+                axes_bbox.y0,
+                axes_bbox.width,
+                axes_bbox.height,
+            )
+        elif side == "right":
+            axes_bbox = mtransforms.Bbox.from_bounds(
+                tight_bbox.x1 + pad,
+                axes_bbox.y0,
+                axes_bbox.width,
+                axes_bbox.height,
+            )
+        elif side == "top":
+            axes_bbox = mtransforms.Bbox.from_bounds(
+                axes_bbox.x0,
+                tight_bbox.y1 + pad,
+                axes_bbox.width,
+                axes_bbox.height,
+            )
+        else:
+            axes_bbox = mtransforms.Bbox.from_bounds(
+                axes_bbox.x0,
+                tight_bbox.y0 - pad - axes_bbox.height,
+                axes_bbox.width,
+                axes_bbox.height,
+            )
+        transfig = getattr(ax.figure, "transSubfigure", ax.figure.transFigure)
+        return mtransforms.TransformedBbox(axes_bbox, transfig.inverted())
+
+
 class _ExternalModeMixin:
     """
     Mixin providing explicit external-mode control and a context manager.
@@ -1973,12 +2034,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             )
 
         # Create axes and frame
-        cls = mproj.get_projection_class("ultraplot_cartesian")
-        locator = self._make_inset_locator(bounds_inset, self.transAxes)
-        ax = cls(self.figure, locator(self, None).bounds, zorder=5)
-        ax.patch.set_facecolor("none")
-        ax.set_axes_locator(locator)
-        self.add_child_axes(ax)
+        ax = self._add_colorbar_child_axes(bounds_inset)
         kw_frame, kwargs = self._parse_frame("colorbar", **kwargs)
         frame_artist = None
         if frame_enabled:
@@ -1997,20 +2053,30 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             "width_raw": width_raw,
             "pad_raw": pad_raw,
         }
-        ax._inset_colorbar_parent = self
         ax._inset_colorbar_frame = frame_artist
 
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})
         return ax, kwargs
 
+    def _add_colorbar_child_axes(self, bounds, locator=None):
+        """Add and return a colorbar axes positioned relative to this axes."""
+        cls = mproj.get_projection_class("ultraplot_cartesian")
+        initial_locator = self._make_inset_locator(bounds, self.transAxes)
+        ax = cls(self.figure, initial_locator(self, None).bounds, zorder=5)
+        ax.patch.set_facecolor("none")
+        ax.set_axes_locator(locator or initial_locator)
+        self.add_child_axes(ax)
+        ax._inset_colorbar_parent = self
+        return ax
+
     def _parse_colorbar_inset_side(
         self,
         loc=None,
+        align=None,
         width=None,
         length=None,
         shrink=None,
-        frame=None,
-        frameon=None,
+        space=None,
         pad=None,
         tickloc=None,
         ticklocation=None,
@@ -2020,11 +2086,11 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         """
         Return the axes and adjusted keyword args for a side colorbar on an inset axes.
         """
-        frame_enabled = _not_none(frame=frame, frameon=frameon, default=False)
-        length = _not_none(length=length, shrink=shrink, default=1)
+        length = _not_none(length=length, shrink=shrink, default=rc["colorbar.length"])
         width = _not_none(width, rc["colorbar.width"])
-        pad = _not_none(pad, rc["colorbar.insetpad"])
+        pad = _not_none(space, pad, rc["subplots.panelpad"])
         side = _translate_loc(loc, "panel")
+        align = _not_none(align, "center")
         orientation = _not_none(
             orientation, "vertical" if side in ("left", "right") else "horizontal"
         )
@@ -2045,57 +2111,27 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             length = units(
                 length, "em", "ax", axes=self, width=orientation == "horizontal"
             )
-        width = units(width, "em", "ax", axes=self, width=orientation == "vertical")
+        if not isinstance(width, str):
+            width *= 0.5
+        width = units(width, "in", "ax", axes=self, width=orientation == "vertical")
         xpad = units(pad, "em", "ax", axes=self, width=True)
         ypad = units(pad, "em", "ax", axes=self, width=False)
 
-        if side == "right":
-            bounds = [1 + xpad, 0.5 * (1 - length), width, length]
-            bounds_frame = [
-                1 + 0.5 * xpad,
-                bounds[1] - ypad,
-                width + xpad,
-                length + 2 * ypad,
-            ]
-        elif side == "left":
-            bounds = [-xpad - width, 0.5 * (1 - length), width, length]
-            bounds_frame = [
-                bounds[0] - 0.5 * xpad,
-                bounds[1] - ypad,
-                width + xpad,
-                length + 2 * ypad,
-            ]
-        elif side == "top":
-            bounds = [0.5 * (1 - length), 1 + ypad, length, width]
-            bounds_frame = [
-                bounds[0] - xpad,
-                1 + 0.5 * ypad,
-                length + 2 * xpad,
-                width + ypad,
-            ]
-        else:
-            bounds = [0.5 * (1 - length), -ypad - width, length, width]
-            bounds_frame = [
-                bounds[0] - xpad,
-                bounds[1] - 0.5 * ypad,
-                length + 2 * xpad,
-                width + ypad,
-            ]
+        aligned = _align_bbox(align, length).x0
 
-        cls = mproj.get_projection_class("ultraplot_cartesian")
-        locator = self._make_inset_locator(bounds, self.transAxes)
-        ax = cls(self.figure, locator(self, None).bounds, zorder=5)
-        ax.patch.set_facecolor("none")
-        ax.set_axes_locator(locator)
-        self.add_child_axes(ax)
-        kw_frame, kwargs = self._parse_frame("colorbar", **kwargs)
-        frame_artist = None
-        if frame_enabled:
-            frame_artist = self._add_guide_frame(
-                *bounds_frame, fontsize=rc["xtick.labelsize"], **kw_frame
-            )
-        ax._inset_colorbar_parent = self
-        ax._inset_colorbar_frame = frame_artist
+        if side == "right":
+            bounds = [1 + xpad, aligned, width, length]
+        elif side == "left":
+            bounds = [-xpad - width, aligned, width, length]
+        elif side == "top":
+            bounds = [aligned, 1 + ypad, length, width]
+        else:
+            bounds = [aligned, -ypad - width, length, width]
+
+        pad_points = units(pad, "em", "pt", axes=self, width=True)
+        locator = _SideColorbarLocator(self, side, bounds, pad_points)
+        ax = self._add_colorbar_child_axes(bounds, locator=locator)
+        ax._inset_colorbar_frame = None
 
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})
         return ax, kwargs

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -671,6 +671,41 @@ def _align_bbox(align, length):
     return mtransforms.Bbox(bounds)
 
 
+def _get_side_colorbar_ticklocation(side, orientation, tickloc, ticklocation):
+    """Return the outward-facing tick location for a side colorbar."""
+    if orientation == "horizontal":
+        default = "bottom" if side == "bottom" else "top"
+    else:
+        default = "left" if side == "left" else "right"
+    return _not_none(tickloc, ticklocation, default)
+
+
+def _convert_side_colorbar_units(axes, orientation, length, width, pad):
+    """Convert side colorbar dimensions to axes-relative units."""
+    horizontal = orientation == "horizontal"
+    if isinstance(length, str):
+        length = units(length, "em", "ax", axes=axes, width=horizontal)
+    if not isinstance(width, str):
+        width *= 0.5
+    width = units(width, "in", "ax", axes=axes, width=not horizontal)
+    xpad = units(pad, "em", "ax", axes=axes, width=True)
+    ypad = units(pad, "em", "ax", axes=axes, width=False)
+    pad_points = units(pad, "em", "pt", axes=axes, width=True)
+    return length, width, xpad, ypad, pad_points
+
+
+def _get_side_colorbar_bounds(side, align, length, width, xpad, ypad):
+    """Return axes-relative bounds for a side colorbar."""
+    aligned = _align_bbox(align, length).x0
+    if side == "right":
+        return [1 + xpad, aligned, width, length]
+    if side == "left":
+        return [-xpad - width, aligned, width, length]
+    if side == "top":
+        return [aligned, 1 + ypad, length, width]
+    return [aligned, -ypad - width, length, width]
+
+
 class _TransformedBoundsLocator:
     """
     Axes locator for `~Axes.inset_axes` and other axes.
@@ -2094,41 +2129,13 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         orientation = _not_none(
             orientation, "vertical" if side in ("left", "right") else "horizontal"
         )
-        if orientation == "horizontal":
-            ticklocation = _not_none(
-                tickloc,
-                ticklocation,
-                "bottom" if side == "bottom" else "top",
-            )
-        else:
-            ticklocation = _not_none(
-                tickloc,
-                ticklocation,
-                "left" if side == "left" else "right",
-            )
-
-        if isinstance(length, str):
-            length = units(
-                length, "em", "ax", axes=self, width=orientation == "horizontal"
-            )
-        if not isinstance(width, str):
-            width *= 0.5
-        width = units(width, "in", "ax", axes=self, width=orientation == "vertical")
-        xpad = units(pad, "em", "ax", axes=self, width=True)
-        ypad = units(pad, "em", "ax", axes=self, width=False)
-
-        aligned = _align_bbox(align, length).x0
-
-        if side == "right":
-            bounds = [1 + xpad, aligned, width, length]
-        elif side == "left":
-            bounds = [-xpad - width, aligned, width, length]
-        elif side == "top":
-            bounds = [aligned, 1 + ypad, length, width]
-        else:
-            bounds = [aligned, -ypad - width, length, width]
-
-        pad_points = units(pad, "em", "pt", axes=self, width=True)
+        ticklocation = _get_side_colorbar_ticklocation(
+            side, orientation, tickloc, ticklocation
+        )
+        length, width, xpad, ypad, pad_points = _convert_side_colorbar_units(
+            self, orientation, length, width, pad
+        )
+        bounds = _get_side_colorbar_bounds(side, align, length, width, xpad, ypad)
         locator = _SideColorbarLocator(self, side, bounds, pad_points)
         ax = self._add_colorbar_child_axes(bounds, locator=locator)
         ax._inset_colorbar_frame = None

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -671,9 +671,13 @@ def _align_bbox(align, length):
     return mtransforms.Bbox(bounds)
 
 
-def _get_side_colorbar_ticklocation(side, orientation, tickloc, ticklocation):
+def _get_side_colorbar_ticklocation(
+    side, orientation, tickloc, ticklocation, *, orientation_explicit=False
+):
     """Return the outward-facing tick location for a side colorbar."""
-    if orientation == "horizontal":
+    if orientation == "horizontal" and orientation_explicit:
+        default = "bottom"
+    elif orientation == "horizontal":
         default = "top" if side == "top" else "bottom"
     else:
         default = "right" if side == "right" else "left"
@@ -1966,11 +1970,16 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         side = _not_none(side, "left" if orientation == "vertical" else "bottom")
         align = _not_none(align, "center")
         length = _not_none(length=length, default=rc["colorbar.length"])
+        orientation_explicit = orientation is not None
         orientation = _not_none(
             orientation, "horizontal" if side in ("bottom", "top") else "vertical"
         )
         ticklocation = _get_side_colorbar_ticklocation(
-            side, orientation, tickloc, ticklocation
+            side,
+            orientation,
+            tickloc,
+            ticklocation,
+            orientation_explicit=orientation_explicit,
         )
         bounds = _get_filled_colorbar_bounds(side, align, length)
         ax = self._add_colorbar_child_axes(bounds, track_parent=False)
@@ -2116,11 +2125,16 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         pad = _not_none(space, pad, rc["subplots.panelpad"])
         side = _translate_loc(loc, "panel")
         align = _not_none(align, "center")
+        orientation_explicit = orientation is not None
         orientation = _not_none(
             orientation, "vertical" if side in ("left", "right") else "horizontal"
         )
         ticklocation = _get_side_colorbar_ticklocation(
-            side, orientation, tickloc, ticklocation
+            side,
+            orientation,
+            tickloc,
+            ticklocation,
+            orientation_explicit=orientation_explicit,
         )
         length, width, xpad, ypad, pad_points = _convert_side_colorbar_units(
             self, orientation, length, width, pad

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -696,7 +696,7 @@ def _convert_side_colorbar_units(axes, orientation, length, width, pad):
 
 def _get_side_colorbar_bounds(side, align, length, width, xpad, ypad):
     """Return axes-relative bounds for a side colorbar."""
-    aligned = _align_bbox(align, length).x0
+    aligned = _get_colorbar_aligned_position(side, align, length)
     if side == "right":
         return [1 + xpad, aligned, width, length]
     if side == "left":
@@ -708,10 +708,19 @@ def _get_side_colorbar_bounds(side, align, length, width, xpad, ypad):
 
 def _get_filled_colorbar_bounds(side, align, length):
     """Return panel-relative bounds for a side colorbar."""
-    aligned = _align_bbox(align, length).x0
+    aligned = _get_colorbar_aligned_position(side, align, length)
     if side in ("top", "bottom"):
         return [aligned, 0, length, 1]
     return [0, aligned, 1, length]
+
+
+def _get_colorbar_aligned_position(side, align, length):
+    """Validate colorbar alignment and return its long-axis start position."""
+    horizontal = side in ("top", "bottom")
+    valid = ("left", "center", "right") if horizontal else ("bottom", "center", "top")
+    if align not in valid:
+        raise ValueError(f"Invalid align={align!r} for colorbar loc={side!r}.")
+    return _align_bbox(align, length).x0
 
 
 class _TransformedBoundsLocator:
@@ -2117,16 +2126,19 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             self, orientation, length, width, pad
         )
         bounds = _get_side_colorbar_bounds(side, align, length, width, xpad, ypad)
+        align_bbox = _align_bbox(align, length)
         previous = (
             child
             for child in self.child_axes
             if getattr(child, "_inset_colorbar_side", None) == side
+            and align_bbox.overlaps(child._inset_colorbar_align_bbox)
         )
         locator = _SideColorbarLocator(
             self, side, bounds, pad_points, previous=previous
         )
         ax = self._add_colorbar_child_axes(bounds, locator=locator)
         ax._inset_colorbar_side = side
+        ax._inset_colorbar_align_bbox = align_bbox
         ax._inset_colorbar_frame = None
 
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -2003,6 +2003,103 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})
         return ax, kwargs
 
+    def _parse_colorbar_inset_side(
+        self,
+        loc=None,
+        width=None,
+        length=None,
+        shrink=None,
+        frame=None,
+        frameon=None,
+        pad=None,
+        tickloc=None,
+        ticklocation=None,
+        orientation=None,
+        **kwargs,
+    ):
+        """
+        Return the axes and adjusted keyword args for a side colorbar on an inset axes.
+        """
+        frame_enabled = _not_none(frame=frame, frameon=frameon, default=False)
+        length = _not_none(length=length, shrink=shrink, default=1)
+        width = _not_none(width, rc["colorbar.width"])
+        pad = _not_none(pad, rc["colorbar.insetpad"])
+        side = _translate_loc(loc, "panel")
+        orientation = _not_none(
+            orientation, "vertical" if side in ("left", "right") else "horizontal"
+        )
+        if orientation == "horizontal":
+            ticklocation = _not_none(
+                tickloc,
+                ticklocation,
+                "bottom" if side == "bottom" else "top",
+            )
+        else:
+            ticklocation = _not_none(
+                tickloc,
+                ticklocation,
+                "left" if side == "left" else "right",
+            )
+
+        if isinstance(length, str):
+            length = units(
+                length, "em", "ax", axes=self, width=orientation == "horizontal"
+            )
+        width = units(width, "em", "ax", axes=self, width=orientation == "vertical")
+        xpad = units(pad, "em", "ax", axes=self, width=True)
+        ypad = units(pad, "em", "ax", axes=self, width=False)
+
+        if side == "right":
+            bounds = [1 + xpad, 0.5 * (1 - length), width, length]
+            bounds_frame = [
+                1 + 0.5 * xpad,
+                bounds[1] - ypad,
+                width + xpad,
+                length + 2 * ypad,
+            ]
+        elif side == "left":
+            bounds = [-xpad - width, 0.5 * (1 - length), width, length]
+            bounds_frame = [
+                bounds[0] - 0.5 * xpad,
+                bounds[1] - ypad,
+                width + xpad,
+                length + 2 * ypad,
+            ]
+        elif side == "top":
+            bounds = [0.5 * (1 - length), 1 + ypad, length, width]
+            bounds_frame = [
+                bounds[0] - xpad,
+                1 + 0.5 * ypad,
+                length + 2 * xpad,
+                width + ypad,
+            ]
+        else:
+            bounds = [0.5 * (1 - length), -ypad - width, length, width]
+            bounds_frame = [
+                bounds[0] - xpad,
+                bounds[1] - 0.5 * ypad,
+                length + 2 * xpad,
+                width + ypad,
+            ]
+
+        cls = mproj.get_projection_class("ultraplot_cartesian")
+        locator = self._make_inset_locator(bounds, self.transAxes)
+        ax = cls(self.figure, locator(self, None).bounds, zorder=5)
+        ax.patch.set_facecolor("none")
+        ax.set_axes_locator(locator)
+        self.add_child_axes(ax)
+        kw_frame, kwargs = self._parse_frame("colorbar", **kwargs)
+        frame_artist = None
+        if frame_enabled:
+            frame_artist = self._add_guide_frame(
+                *bounds_frame, fontsize=rc["xtick.labelsize"], **kw_frame
+            )
+        ax._inset_colorbar_parent = self
+        ax._inset_colorbar_frame = frame_artist
+
+        kwargs.update({"orientation": orientation, "ticklocation": ticklocation})
+        return ax, kwargs
+
     def _parse_legend_aligned(self, pairs, ncol=None, order=None, **kwargs):
         """
         Draw an individual legend with aligned columns. Includes support

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -674,9 +674,9 @@ def _align_bbox(align, length):
 def _get_side_colorbar_ticklocation(side, orientation, tickloc, ticklocation):
     """Return the outward-facing tick location for a side colorbar."""
     if orientation == "horizontal":
-        default = "bottom" if side == "bottom" else "top"
+        default = "top" if side == "top" else "bottom"
     else:
-        default = "left" if side == "left" else "right"
+        default = "right" if side == "right" else "left"
     return _not_none(tickloc, ticklocation, default)
 
 
@@ -704,6 +704,14 @@ def _get_side_colorbar_bounds(side, align, length, width, xpad, ypad):
     if side == "top":
         return [aligned, 1 + ypad, length, width]
     return [aligned, -ypad - width, length, width]
+
+
+def _get_filled_colorbar_bounds(side, align, length):
+    """Return panel-relative bounds for a side colorbar."""
+    aligned = _align_bbox(align, length).x0
+    if side in ("top", "bottom"):
+        return [aligned, 0, length, 1]
+    return [0, aligned, 1, length]
 
 
 class _TransformedBoundsLocator:
@@ -1949,50 +1957,14 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         side = _not_none(side, "left" if orientation == "vertical" else "bottom")
         align = _not_none(align, "center")
         length = _not_none(length=length, default=rc["colorbar.length"])
-        ticklocation = _not_none(tickloc=tickloc, ticklocation=ticklocation)
-
-        # Calculate inset bounds for the colorbar
-        delta = 0.5 * (1 - length)
-        if side in ("bottom", "top"):
-            if align == "left":
-                bounds = (0, 0, length, 1)
-            elif align == "center":
-                bounds = (delta, 0, length, 1)
-            elif align == "right":
-                bounds = (2 * delta, 0, length, 1)
-            else:
-                raise ValueError(f"Invalid align={align!r} for colorbar loc={side!r}.")
-        else:
-            if align == "bottom":
-                bounds = (0, 0, 1, length)
-            elif align == "center":
-                bounds = (0, delta, 1, length)
-            elif align == "top":
-                bounds = (0, 2 * delta, 1, length)
-            else:
-                raise ValueError(f"Invalid align={align!r} for colorbar loc={side!r}.")
-
-        # Add the axes as a child of the original axes
-        cls = mproj.get_projection_class("ultraplot_cartesian")
-        locator = self._make_inset_locator(bounds, self.transAxes)
-        ax = cls(self.figure, locator(self, None).bounds, zorder=5)
-        ax.set_axes_locator(locator)
-        self.add_child_axes(ax)
-        ax.patch.set_facecolor("none")  # ignore axes.alpha application
-
-        # Handle default keyword args
-        if orientation is None:
-            orientation = "horizontal" if side in ("bottom", "top") else "vertical"
-        if orientation == "horizontal":
-            outside, inside = "bottom", "top"
-            if side == "top":
-                outside, inside = inside, outside
-            ticklocation = _not_none(ticklocation, outside)
-        else:
-            outside, inside = "left", "right"
-            if side == "right":
-                outside, inside = inside, outside
-            ticklocation = _not_none(ticklocation, outside)
+        orientation = _not_none(
+            orientation, "horizontal" if side in ("bottom", "top") else "vertical"
+        )
+        ticklocation = _get_side_colorbar_ticklocation(
+            side, orientation, tickloc, ticklocation
+        )
+        bounds = _get_filled_colorbar_bounds(side, align, length)
+        ax = self._add_colorbar_child_axes(bounds, track_parent=False)
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})
         return ax, kwargs
 
@@ -2101,7 +2073,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         kwargs.update({"orientation": orientation, "ticklocation": ticklocation})
         return ax, kwargs
 
-    def _add_colorbar_child_axes(self, bounds, locator=None):
+    def _add_colorbar_child_axes(self, bounds, locator=None, track_parent=True):
         """Add and return a colorbar axes positioned relative to this axes."""
         cls = mproj.get_projection_class("ultraplot_cartesian")
         initial_locator = self._make_inset_locator(bounds, self.transAxes)
@@ -2109,7 +2081,8 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         ax.patch.set_facecolor("none")
         ax.set_axes_locator(locator or initial_locator)
         self.add_child_axes(ax)
-        ax._inset_colorbar_parent = self
+        if track_parent:
+            ax._inset_colorbar_parent = self
         return ax
 
     def _parse_colorbar_inset_side(

--- a/ultraplot/colorbar.py
+++ b/ultraplot/colorbar.py
@@ -163,7 +163,10 @@ class UltraColorbar:
         # NOTE: The inset axes function needs 'label' to know how to pad the box
         # TODO: Use seperate keywords for frame properties vs. colorbar edge properties?
         frame = _not_none(frame=frame, frameon=frameon)
-        if loc in ("fill", "left", "right", "top", "bottom"):
+        inset_side = loc in ("left", "right", "top", "bottom") and getattr(
+            ax, "_inset_parent", None
+        )
+        if loc in ("fill", "left", "right", "top", "bottom") and not inset_side:
             outline = _not_none(outline=outline, frame=frame)
             length = _not_none(length, rc["colorbar.length"])  # for _add_guide_panel
             kwargs.update({"align": align, "length": length})
@@ -183,17 +186,27 @@ class UltraColorbar:
             )  # noqa: E501
             cax, kwargs = panel_ax._parse_colorbar_filled(**kwargs)
         else:
-            kwargs.update({"label": label, "length": length, "width": width})
-            extendsize = _not_none(extendsize, rc["colorbar.insetextend"])
-            cax, kwargs = ax._parse_colorbar_inset(
-                loc=loc,
-                frame=frame,
-                labelloc=labelloc,
-                labelrotation=labelrotation,
-                labelsize=labelsize,
-                pad=pad,
-                **kwargs,
-            )  # noqa: E501
+            if inset_side:
+                kwargs.update({"length": length, "width": width})
+                extendsize = _not_none(extendsize, rc["colorbar.insetextend"])
+                cax, kwargs = ax._parse_colorbar_inset_side(
+                    loc=loc,
+                    frame=frame,
+                    pad=pad,
+                    **kwargs,
+                )
+            else:
+                kwargs.update({"label": label, "length": length, "width": width})
+                extendsize = _not_none(extendsize, rc["colorbar.insetextend"])
+                cax, kwargs = ax._parse_colorbar_inset(
+                    loc=loc,
+                    frame=frame,
+                    labelloc=labelloc,
+                    labelrotation=labelrotation,
+                    labelsize=labelsize,
+                    pad=pad,
+                    **kwargs,
+                )  # noqa: E501
 
         # Parse the colorbar mappable
         # NOTE: Account for special case where auto colorbar is generated from 1D

--- a/ultraplot/colorbar.py
+++ b/ultraplot/colorbar.py
@@ -166,11 +166,12 @@ class UltraColorbar:
         inset_side = loc in ("left", "right", "top", "bottom") and getattr(
             ax, "_inset_parent", None
         )
-        if loc in ("fill", "left", "right", "top", "bottom") and not inset_side:
+        if loc in ("fill", "left", "right", "top", "bottom"):
             outline = _not_none(outline=outline, frame=frame)
             length = _not_none(length, rc["colorbar.length"])  # for _add_guide_panel
             kwargs.update({"align": align, "length": length})
             extendsize = _not_none(extendsize, rc["colorbar.extend"])
+        if loc in ("fill", "left", "right", "top", "bottom") and not inset_side:
             panel_ax = ax._add_guide_panel(
                 loc,
                 align,
@@ -187,11 +188,11 @@ class UltraColorbar:
             cax, kwargs = panel_ax._parse_colorbar_filled(**kwargs)
         else:
             if inset_side:
-                kwargs.update({"length": length, "width": width})
-                extendsize = _not_none(extendsize, rc["colorbar.insetextend"])
+                kwargs.update(
+                    {"align": align, "length": length, "space": space, "width": width}
+                )
                 cax, kwargs = ax._parse_colorbar_inset_side(
                     loc=loc,
-                    frame=frame,
                     pad=pad,
                     **kwargs,
                 )

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -175,6 +175,42 @@ def test_inset_axes_side_colorbars_stack_outward(rng, loc):
 
 
 @pytest.mark.parametrize(
+    "loc, first_align, second_align, position",
+    [
+        ("left", "bottom", "top", "x0"),
+        ("right", "bottom", "top", "x0"),
+        ("top", "left", "right", "y0"),
+        ("bottom", "left", "right", "y0"),
+    ],
+)
+def test_nonoverlapping_inset_axes_side_colorbars_share_layer(
+    rng, loc, first_align, second_align, position
+):
+    fig, ax = uplt.subplots()
+    ix = ax.inset_axes([0.3, 0.3, 0.4, 0.4], zoom=False)[0]
+    m = ix.pcolormesh(rng.random((8, 8)))
+    first = ix.colorbar(m, loc=loc, align=first_align, length=0.4)
+    second = ix.colorbar(m, loc=loc, align=second_align, length=0.4)
+
+    fig.canvas.draw()
+    assert getattr(first.ax.bbox, position) == pytest.approx(
+        getattr(second.ax.bbox, position)
+    )
+
+
+@pytest.mark.parametrize("loc, align", [("left", "left"), ("top", "top")])
+@pytest.mark.parametrize("inset", [False, True])
+def test_side_colorbar_rejects_cross_axis_alignment(rng, loc, align, inset):
+    fig, ax = uplt.subplots()
+    if inset:
+        ax = ax.inset_axes([0.3, 0.3, 0.4, 0.4], zoom=False)[0]
+    m = ax.pcolormesh(rng.random((8, 8)))
+
+    with pytest.raises(ValueError, match="Invalid align"):
+        ax.colorbar(m, loc=loc, align=align)
+
+
+@pytest.mark.parametrize(
     "orientation, labelloc",
     [
         ("horizontal", "top"),

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -152,6 +152,28 @@ def test_left_inset_axes_colorbar_clears_parent_ticks(rng):
     assert cb.ax.bbox.x1 < ix.yaxis.get_tightbbox(renderer).x0
 
 
+@pytest.mark.parametrize("loc", ["left", "right", "top", "bottom"])
+def test_inset_axes_side_colorbars_stack_outward(rng, loc):
+    fig, ax = uplt.subplots()
+    ix = ax.inset_axes([0.3, 0.3, 0.4, 0.4], zoom=False)[0]
+    m = ix.pcolormesh(rng.random((8, 8)))
+    inner = ix.colorbar(m, loc=loc)
+    outer = ix.colorbar(m, loc=loc)
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    inner_bbox = inner.ax.get_tightbbox(renderer)
+    outer_bbox = outer.ax.bbox
+    if loc == "left":
+        assert outer_bbox.x1 < inner_bbox.x0
+    elif loc == "right":
+        assert outer_bbox.x0 > inner_bbox.x1
+    elif loc == "top":
+        assert outer_bbox.y0 > inner_bbox.y1
+    else:
+        assert outer_bbox.y1 < inner_bbox.y0
+
+
 @pytest.mark.parametrize(
     "orientation, labelloc",
     [

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -63,6 +63,34 @@ def test_inset_colorbar_frame_alias_still_controls_frame(rng, kwargs):
     assert cb.ax._inset_colorbar_frame is None
 
 
+def test_colorbar_side_locations_work_on_inset_axes(rng):
+    fig, ax = uplt.subplots()
+    ix = ax.inset_axes([0.55, 0.55, 0.35, 0.35], zoom=False)
+    m = ix.pcolormesh(rng.random((8, 8)))
+    ix_small = ax.inset_axes([0.65, 0.65, 0.15, 0.15], zoom=False)
+
+    cb_right = ix.colorbar(m, loc="right")
+    cb_bottom = fig.colorbar(m, ax=ix, loc="bottom")
+    ix_small.pcolormesh(rng.random((8, 8)), colorbar="r")
+    cb_auto = ix_small[0]._colorbar_dict[("right", "center")]
+
+    assert cb_right.orientation == "vertical"
+    assert cb_bottom.orientation == "horizontal"
+    assert cb_auto.orientation == "vertical"
+    assert cb_right.ax._inset_colorbar_parent is ix[0]
+    assert cb_bottom.ax._inset_colorbar_parent is ix[0]
+    assert cb_auto.ax._inset_colorbar_parent is ix_small[0]
+    assert cb_auto.ax._inset_colorbar_frame is None
+    assert cb_right.ax in ix[0].child_axes
+    assert cb_bottom.ax in ix[0].child_axes
+    assert cb_auto.ax in ix_small[0].child_axes
+
+    fig.canvas.draw()
+    assert cb_auto.ax.get_position().height == pytest.approx(
+        ix_small[0].get_position().height
+    )
+
+
 @pytest.mark.parametrize(
     "orientation, labelloc",
     [

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -55,6 +55,22 @@ def test_outer_colorbar_frame_alias_controls_outline(kwargs):
     assert not cb.outline.get_visible()
 
 
+def test_top_colorbar_inferred_orientation_keeps_outside_ticks():
+    fig, ax = uplt.subplots()
+    cb = ax.colorbar("magma", loc="top")
+
+    assert cb.ax.xaxis.get_ticks_position() == "top"
+    assert cb.ax.xaxis.get_label_position() == "top"
+
+
+def test_explicit_horizontal_colorbar_defaults_to_bottom_ticks():
+    fig, ax = uplt.subplots()
+    cb = ax.colorbar("magma", loc="top", orientation="horizontal")
+
+    assert cb.ax.xaxis.get_ticks_position() == "bottom"
+    assert cb.ax.xaxis.get_label_position() == "bottom"
+
+
 @pytest.mark.parametrize("kwargs", [{"frame": False}, {"frameon": False}])
 def test_inset_colorbar_frame_alias_still_controls_frame(rng, kwargs):
     fig, ax = uplt.subplots()

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -92,6 +92,67 @@ def test_colorbar_side_locations_work_on_inset_axes(rng):
 
 
 @pytest.mark.parametrize(
+    "loc, align, edge",
+    [
+        ("left", "top", "y1"),
+        ("right", "bottom", "y0"),
+        ("top", "left", "x0"),
+        ("bottom", "right", "x1"),
+    ],
+)
+def test_inset_axes_side_colorbar_uses_outer_api(rng, loc, align, edge):
+    fig, ax = uplt.subplots()
+    ix = ax.inset_axes([0.3, 0.3, 0.4, 0.4], zoom=False)[0]
+    m = ix.pcolormesh(rng.random((8, 8)))
+
+    cb = ix.colorbar(
+        m,
+        loc=loc,
+        align=align,
+        shrink=0.5,
+        width=0.1,
+        frame=False,
+        label="values",
+    )
+
+    fig.canvas.draw()
+    parent_bounds = ix.get_position()
+    colorbar_bounds = cb.ax.get_position()
+    assert getattr(colorbar_bounds, edge) == pytest.approx(getattr(parent_bounds, edge))
+    if cb.orientation == "vertical":
+        assert colorbar_bounds.height == pytest.approx(0.5 * parent_bounds.height)
+    else:
+        assert colorbar_bounds.width == pytest.approx(0.5 * parent_bounds.width)
+    assert cb.ax._inset_colorbar_frame is None
+    assert cb.outline.get_visible() is False
+    assert cb.ax.get_ylabel() == "values" or cb.ax.get_xlabel() == "values"
+
+
+def test_inset_axes_side_colorbar_numeric_width_scales_consistently(rng):
+    fig, ax = uplt.subplots()
+    ix = ax.inset_axes([0.3, 0.3, 0.4, 0.4], zoom=False)[0]
+    m = ix.pcolormesh(rng.random((8, 8)))
+    narrow = ix.colorbar(m, loc="left", width=0.1)
+    wide = ix.colorbar(m, loc="right", width=0.2)
+
+    fig.canvas.draw()
+    assert wide.ax.get_position().width == pytest.approx(
+        2 * narrow.ax.get_position().width
+    )
+
+
+def test_left_inset_axes_colorbar_clears_parent_ticks(rng):
+    fig, ax = uplt.subplots()
+    ix = ax.inset_axes([0.55, 0.45, 0.35, 0.35], zoom=False)[0]
+    ix.pcolormesh(rng.random((10, 10)), colorbar="left", colorbar_kw={"width": 0.1})
+    cb = ix._colorbar_dict[("left", "center")]
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    assert cb.ax.bbox.x1 < ix.yaxis.get_tightbbox(renderer).x0
+
+
+@pytest.mark.parametrize(
     "orientation, labelloc",
     [
         ("horizontal", "top"),


### PR DESCRIPTION
Closes #737 
Colorbars requested on inset axes with side locations now stay attached to the inset instead of trying to allocate a subplot panel, which fails for axes without a subplot spec. The change remaps side requests to inset colorbar placements with side-appropriate default orientations and adds a regression test covering both direct inset-axis calls and figure-level calls that target an inset axis.
