### PR TITLE
Preserve explicit axes frame styling across reformatting

### DIFF
--- a/ultraplot/axes/_formatting.py
+++ b/ultraplot/axes/_formatting.py
@@ -6,8 +6,24 @@ Shared metadata for axis formatting keyword routing and persistence.
 import inspect
 
 _AXIS_STYLE_FIELD_TEMPLATES = {
-    "color": ("{axis}color", "color", "{axis}ec", "ec", "{axis}edgecolor", "edgecolor"),
-    "linewidth": ("{axis}linewidth", "linewidth", "{axis}lw", "lw"),
+    "color": (
+        "{axis}color",
+        "color",
+        "{axis}ec",
+        "ec",
+        "{axis}edgecolor",
+        "edgecolor",
+        "axesec",
+        "axesedgecolor",
+    ),
+    "linewidth": (
+        "{axis}linewidth",
+        "linewidth",
+        "{axis}lw",
+        "lw",
+        "axeslw",
+        "axeslinewidth",
+    ),
     "rotation": ("{axis}rotation", "rotation"),
     "spineloc": ("{axis}spineloc", "{axis}loc"),
     "tickloc": ("{axis}tickloc",),

--- a/ultraplot/tests/test_axes_alt_styles.py
+++ b/ultraplot/tests/test_axes_alt_styles.py
@@ -197,6 +197,34 @@ def test_subplots_preserve_generic_tickcolor_across_later_axis_color():
         } == {mcolors.to_rgba("C1")}
 
 
+def test_subplots_preserve_per_axes_axesedgecolor_on_reformat():
+    fig, axs = uplt.subplots(ncols=2)
+    expected = []
+    for i, ax in enumerate(axs):
+        color = f"C{i}"
+        expected.append(mcolors.to_rgba(color))
+        ax.format(axesedgecolor=color)
+
+    axs.format(title="Axes edge color")
+
+    actual = [mcolors.to_rgba(ax.spines["left"].get_edgecolor()) for ax in axs]
+    assert actual == expected
+
+
+def test_subplots_preserve_per_axes_axeslinewidth_on_reformat():
+    fig, axs = uplt.subplots(ncols=2)
+    expected = []
+    for i, ax in enumerate(axs):
+        linewidth = i + 1
+        expected.append(linewidth)
+        ax.format(axeslinewidth=linewidth)
+
+    axs.format(title="Axes line width")
+
+    actual = [ax.spines["left"].get_linewidth() for ax in axs]
+    assert actual == expected
+
+
 def test_subplots_apply_generic_labelcolor():
     fig, axs = uplt.subplots()
     ax = axs[0]


### PR DESCRIPTION
Treat axesedgecolor and axeslinewidth as explicit Cartesian frame style overrides so per-axes values set with ax.format(...) survive later axs.format(...) calls that only update unrelated properties like titles. Closes #739.