### PR TITLE
Fix centering of titles

### DIFF
--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -3076,8 +3076,15 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                     self.transAxes.inverted()
                 )
                 ax0, ax1 = abc_bbox.x0, abc_bbox.x1
+                ay0, ay1 = abc_bbox.y0, abc_bbox.y1
                 tx0, tx1 = title_bbox.x0, title_bbox.x1
-                if tx0 < ax1 + abc_title_sep and tx1 > ax0 - abc_title_sep:
+                ty0, ty1 = title_bbox.y0, title_bbox.y1
+                if (
+                    tx0 < ax1 + abc_title_sep
+                    and tx1 > ax0 - abc_title_sep
+                    and ty0 < ay1
+                    and ty1 > ay0
+                ):
                     base_x = title_obj.get_position()[0]
                     ha = title_obj.get_ha()
                     max_width = 0

--- a/ultraplot/tests/test_axes.py
+++ b/ultraplot/tests/test_axes.py
@@ -356,6 +356,18 @@ def test_title_shifts_when_abc_overlaps_different_loc():
     assert title_obj.get_position()[0] > original_x
 
 
+def test_centered_title_does_not_shift_for_inset_abc():
+    """
+    Centered titles do not collide with an inset upper-left abc label.
+    """
+    fig, axs = uplt.subplots(figsize=(3, 2))
+    axs.format(abc=True, title="X" * 100, titleloc="center", abcloc="upper left")
+    title_obj = axs[0]._title_dict["center"]
+    original_x = title_obj.get_position()[0]
+    fig.canvas.draw()
+    assert title_obj.get_position()[0] == pytest.approx(original_x)
+
+
 def test_title_shrinks_right_aligned_same_location():
     """
     Test that right-aligned titles shrink when they would overflow with abc label.


### PR DESCRIPTION
Fix an issue where the added abc logic was interferring with a shift in the title. 