### PR TITLE
Deprecation fix for cross product computation.

### DIFF
--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -286,8 +286,13 @@ def _infer_hawkeye_relation(parent_extent, inset_extent):
 def _segments_intersect(start1, end1, start2, end2):
     """Return whether two display-coordinate line segments intersect."""
 
-    def _cross(origin, point1, point2):
-        return np.cross(point1 - origin, point2 - origin)
+    def _cross(origin: np.ndarray, point1: np.ndarray, point2: np.ndarray) -> float:
+        if len(origin) != 3:
+            # Cross needs at least 3D
+            tmp = np.stack([origin, point1, point2])
+            tmp = np.pad(tmp, ((0, 0), (0, 3 - tmp.shape[1])), mode="constant")
+            origin, point1, point2 = tmp
+        return np.cross(point1 - origin, point2 - origin).sum()
 
     cross1 = _cross(start1, end1, start2)
     cross2 = _cross(start1, end1, end2)

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -287,12 +287,11 @@ def _segments_intersect(start1, end1, start2, end2):
     """Return whether two display-coordinate line segments intersect."""
 
     def _cross(origin: np.ndarray, point1: np.ndarray, point2: np.ndarray) -> float:
-        if len(origin) != 3:
-            # Cross needs at least 3D
-            tmp = np.stack([origin, point1, point2])
-            tmp = np.pad(tmp, ((0, 0), (0, 3 - tmp.shape[1])), mode="constant")
-            origin, point1, point2 = tmp
-        return np.cross(point1 - origin, point2 - origin).sum()
+        if len(origin) == 2:
+            diff1 = point1 - origin
+            diff2 = point2 - origin
+            return diff1[0] * diff2[1] - diff1[1] * diff2[0]
+        return np.cross(point1 - origin, point2 - origin)
 
     cross1 = _cross(start1, end1, start2)
     cross2 = _cross(start1, end1, end2)


### PR DESCRIPTION
Closes #773 

Replaces the 2D array manipulation with manual computation otherwise route through cross.
