### PR TITLE
faster animating in ultraplot

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -60,6 +60,16 @@ Top-level functions
    :toctree: api
 
 
+Animation tools
+===============
+
+.. automodule:: ultraplot.animation
+   :no-private-members:
+
+.. automodsumm:: ultraplot.animation
+   :toctree: api
+
+
 Configuration tools
 ===================
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python>=3.10,<3.15
   - numpy
   - matplotlib>=3.9
+  - ffmpeg  # animation encoder for ultraplot.animation
   - basemap >=1.4.1
   - cartopy
   - xarray

--- a/ultraplot/__init__.py
+++ b/ultraplot/__init__.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     # __all__ — that is the only maintenance burden.
     import matplotlib.pyplot as pyplot
 
-    from .animation import animate as animate
     from .animation import ArtistAnimation as ArtistAnimation
     from .animation import FuncAnimation as FuncAnimation
     from .axes import Axes as Axes

--- a/ultraplot/__init__.py
+++ b/ultraplot/__init__.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
     # __all__ — that is the only maintenance burden.
     import matplotlib.pyplot as pyplot
 
+    from .animation import animate as animate
+    from .animation import ArtistAnimation as ArtistAnimation
+    from .animation import FuncAnimation as FuncAnimation
     from .axes import Axes as Axes
     from .axes import CartesianAxes as CartesianAxes
     from .axes import ExternalAxesContainer as ExternalAxesContainer

--- a/ultraplot/animation.py
+++ b/ultraplot/animation.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""
+Fast drop-in replacements for the `matplotlib.animation` classes.
+
+The classes here subclass their Matplotlib counterparts, so the constructor
+signatures, the attributes, and the notebook representations are unchanged.
+What differs is how frames are rendered:
+
+* `~ultraplot.animation.FuncAnimation.save` bypasses the per-frame
+  `~matplotlib.figure.Figure.savefig` call used by Matplotlib's writers and
+  instead renders straight into the Agg buffer, piping raw ``RGBA`` bytes to
+  the encoder. No PNG round-trip, no ``print_figure`` machinery.
+* The expensive UltraPlot tight-layout pass runs once, for the first frame,
+  rather than on every frame.
+* Blitting is used while saving, not just interactively, so only the artists
+  the update function returns are redrawn per frame.
+
+Everything falls back to Matplotlib's own implementation when the fast path
+cannot be used (custom writer instances, ``bbox_inches``, vector output, and
+so on), so the output is never silently wrong.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import subprocess
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.animation as manimation
+import numpy as np
+from matplotlib import cbook
+
+from .internals import warnings
+
+__all__ = [
+    "FuncAnimation",
+    "ArtistAnimation",
+    "animate",
+]
+
+#: Containers written frame-by-frame by piping raw RGBA to ``ffmpeg``.
+_FFMPEG_SUFFIXES = frozenset(
+    (".mp4", ".m4v", ".mov", ".mkv", ".webm", ".avi", ".ogv", ".ogg")
+)
+
+#: Containers assembled in memory by Pillow.
+_PILLOW_SUFFIXES = frozenset((".gif", ".webp", ".apng", ".png", ".tiff", ".tif"))
+
+#: Writer names whose behavior the fast path reproduces exactly. Anything else,
+#: ``imagemagick`` included, is handed back to Matplotlib.
+_FAST_WRITERS = frozenset(("ffmpeg", "pillow"))
+
+
+def _suffix(filename):
+    """
+    Return the lowercase suffix of a path-like filename.
+    """
+    return Path(os.fspath(filename)).suffix.lower()
+
+
+def _zsorted(artists):
+    """
+    Return the artists in ascending z-order, matching a normal draw.
+    """
+    return sorted(artists, key=lambda artist: artist.get_zorder())
+
+
+class _RawWriter:
+    """
+    Base class for writers that consume raw ``RGBA`` frames.
+    """
+
+    def __init__(self, filename, fps, metadata=None):
+        self.filename = os.fspath(filename)
+        self.fps = fps
+        self.metadata = metadata or {}
+        self.width = self.height = None
+
+    def setup(self, width, height):
+        self.width, self.height = width, height
+
+    def write(self, buffer):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def finish(self):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def cleanup(self):
+        pass
+
+
+class _RawFFMpegWriter(_RawWriter):
+    """
+    Pipe raw ``RGBA`` frames into ``ffmpeg`` with no intermediate encoding.
+    """
+
+    def __init__(
+        self,
+        filename,
+        fps,
+        *,
+        codec=None,
+        bitrate=None,
+        extra_args=None,
+        metadata=None,
+    ):
+        super().__init__(filename, fps, metadata)
+        self.codec = codec or mpl.rcParams["animation.codec"]
+        self.bitrate = mpl.rcParams["animation.bitrate"] if bitrate is None else bitrate
+        self.extra_args = extra_args
+        self._proc = None
+
+    @staticmethod
+    def available():
+        """
+        Return whether the configured ``ffmpeg`` binary can be executed.
+        """
+        try:
+            manimation.FFMpegWriter.bin_path()
+        except Exception:
+            return False
+        return bool(manimation.FFMpegWriter.isAvailable())
+
+    def _command(self):
+        args = [
+            manimation.FFMpegWriter.bin_path(),
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-vcodec",
+            "rawvideo",
+            "-s",
+            f"{self.width}x{self.height}",
+            "-pix_fmt",
+            "rgba",
+            "-framerate",
+            str(self.fps),
+            "-i",
+            "pipe:0",
+            "-an",
+        ]
+        if self.codec:
+            args += ["-vcodec", self.codec]
+        # Most players require even dimensions and 4:2:0 chroma for h264-family
+        # codecs. Scaling is a no-op when the frame is already even-sized.
+        if self.codec in ("h264", "libx264", "libx265", "hevc", "mpeg4"):
+            args += [
+                "-vf",
+                "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+                "-pix_fmt",
+                "yuv420p",
+            ]
+        if self.bitrate is not None and self.bitrate > 0:
+            args += ["-b:v", f"{int(self.bitrate)}k"]
+        for key, value in self.metadata.items():
+            args += ["-metadata", f"{key}={value}"]
+        extra = self.extra_args
+        if extra is None:
+            extra = mpl.rcParams["animation.ffmpeg_args"]
+        args += list(extra or ())
+        args += [self.filename]
+        return args
+
+    def setup(self, width, height):
+        super().setup(width, height)
+        self._proc = subprocess.Popen(
+            self._command(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+    def write(self, buffer):
+        try:
+            self._proc.stdin.write(buffer)
+        except BrokenPipeError as err:
+            _, stderr = self._proc.communicate()
+            raise RuntimeError(
+                "ffmpeg exited while frames were being written:\n"
+                + stderr.decode("utf-8", "replace")
+            ) from err
+
+    def finish(self):
+        # communicate() closes stdin itself, which signals end-of-stream.
+        _, stderr = self._proc.communicate()
+        if self._proc.returncode:
+            raise RuntimeError(
+                f"ffmpeg exited with code {self._proc.returncode}:\n"
+                + stderr.decode("utf-8", "replace")
+            )
+
+    def cleanup(self):
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            if proc.stdin is not None and not proc.stdin.closed:
+                proc.stdin.close()
+        finally:
+            proc.kill()
+            proc.wait()
+
+
+class _RawPillowWriter(_RawWriter):
+    """
+    Collect raw ``RGBA`` frames and write an animated image with Pillow.
+    """
+
+    def __init__(self, filename, fps, *, metadata=None):
+        super().__init__(filename, fps, metadata)
+        self._frames = []
+
+    def write(self, buffer):
+        from PIL import Image
+
+        # Copy: the canvas hands back the same buffer for every frame.
+        self._frames.append(
+            Image.frombuffer(
+                "RGBA", (self.width, self.height), bytes(buffer), "raw", "RGBA", 0, 1
+            )
+        )
+
+    def finish(self):
+        if not self._frames:
+            raise RuntimeError("No frames were rendered for the animation.")
+        first, *rest = self._frames
+        first.save(
+            self.filename,
+            save_all=True,
+            append_images=rest,
+            duration=int(1000 / self.fps),
+            loop=0,
+        )
+
+    def cleanup(self):
+        self._frames.clear()
+
+
+class _FastAnimationBase:
+    """
+    Mixin implementing the fast save path shared by the animation classes.
+
+    Subclasses must implement `_fast_frame_artists`, returning the artists a
+    given frame changed, and `_fast_frame_seq`, returning the frames to save.
+    """
+
+    #: Set by the subclass constructors.
+    _freeze_layout = True
+
+    # Fast-path hooks
+
+    def _fast_frame_seq(self):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _fast_frame_artists(self, frame):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _fast_init_artists(self, frame):  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    # Layout freezing
+
+    @contextmanager
+    def _frozen_layout(self):
+        """
+        Run the UltraPlot layout solver once instead of once per frame.
+
+        UltraPlot recomputes tight layout whenever the figure is marked dirty.
+        During an animation the geometry must stay fixed anyway, or frames
+        would jitter, so the solver is disabled after the first draw.
+        """
+        fig = self._fig
+        if not self._freeze_layout:
+            yield
+            return
+        state = (
+            getattr(fig, "_layout_initialized", False),
+            getattr(fig, "_layout_dirty", False),
+            getattr(fig, "_skip_autolayout", False),
+        )
+        try:
+            yield _LayoutFreezer(fig)
+        finally:
+            fig._layout_initialized, fig._layout_dirty, fig._skip_autolayout = state
+
+    @contextmanager
+    def _animated_artists(self, artists=()):
+        """
+        Temporarily mark artists as animated so full draws skip them.
+
+        Yields a function that marks further artists, for update functions that
+        return a different set of artists as the animation goes on.
+        """
+        previous = {}
+
+        def mark(artists):
+            for artist in artists:
+                previous.setdefault(artist, artist.get_animated())
+                artist.set_animated(True)
+
+        mark(artists)
+        try:
+            yield mark
+        finally:
+            for artist, animated in previous.items():
+                artist.set_animated(animated)
+
+    @contextmanager
+    def _suspended_event_source(self):
+        """
+        Keep the interactive timer from starting on the frames drawn here.
+
+        `matplotlib.animation.Animation` starts itself from the figure's first
+        ``draw_event``. The draws below are for the movie file, not the screen.
+        """
+        cid = getattr(self, "_first_draw_id", None)
+        canvas = self._fig.canvas
+        if cid is not None:
+            canvas.mpl_disconnect(cid)
+        try:
+            yield
+        finally:
+            if cid is not None:
+                self._first_draw_id = self._fig.canvas.mpl_connect(
+                    "draw_event", self._start
+                )
+
+    @contextmanager
+    def _agg_canvas(self):
+        """
+        Ensure the figure has a canvas that can blit and expose an RGBA buffer.
+        """
+        fig = self._fig
+        canvas = fig.canvas
+        if all(
+            callable(getattr(canvas, name, None))
+            for name in ("buffer_rgba", "copy_from_bbox", "restore_region")
+        ):
+            yield canvas
+            return
+        from matplotlib.backends.backend_agg import FigureCanvasAgg
+
+        original = canvas
+        try:
+            yield FigureCanvasAgg(fig)
+        finally:
+            fig.set_canvas(original)
+
+    def _can_fast_save(self, filename, writer, savefig_kwargs, extra_anim):
+        """
+        Return whether the fast path reproduces the requested output exactly.
+        """
+        if extra_anim:
+            return False
+        if writer is not None and not isinstance(writer, str):
+            return False  # a configured writer instance must be honored
+        if isinstance(writer, str) and writer not in _FAST_WRITERS:
+            return False
+        if savefig_kwargs:
+            # Any styling override (facecolor, transparency, bbox_inches, ...)
+            # belongs to the savefig pipeline the fast path skips.
+            return False
+        suffix = _suffix(filename)
+        if suffix in _FFMPEG_SUFFIXES:
+            return writer in (None, "ffmpeg") and _RawFFMpegWriter.available()
+        if suffix in _PILLOW_SUFFIXES:
+            if writer == "ffmpeg":
+                return False
+            try:
+                import PIL  # noqa: F401
+            except ImportError:
+                return False
+            return True
+        return False
+
+    def _make_raw_writer(self, filename, fps, codec, bitrate, extra_args, metadata):
+        """
+        Return the raw-frame writer matching the output file extension.
+        """
+        if _suffix(filename) in _FFMPEG_SUFFIXES:
+            return _RawFFMpegWriter(
+                filename,
+                fps,
+                codec=codec,
+                bitrate=bitrate,
+                extra_args=extra_args,
+                metadata=metadata,
+            )
+        return _RawPillowWriter(filename, fps, metadata=metadata)
+
+    def _fast_save(
+        self,
+        filename,
+        fps,
+        dpi,
+        codec,
+        bitrate,
+        extra_args,
+        metadata,
+        progress_callback,
+        blit,
+    ):
+        """
+        Render every frame straight into the Agg buffer and pipe it out.
+        """
+        fig = self._fig
+        self._draw_was_started = True
+        raw = self._make_raw_writer(filename, fps, codec, bitrate, extra_args, metadata)
+        total = getattr(self, "_save_count", None)
+
+        with ExitStack() as stack:
+            stack.callback(raw.cleanup)
+            canvas = stack.enter_context(self._agg_canvas())
+            # NOTE: Matplotlib's own save sets canvas._is_saving, but that makes
+            # `Axes.draw` include animated artists so that savefig captures
+            # them. That would bake the first frame into the blitting
+            # background. Suppress the timer-starting draw callback instead.
+            stack.enter_context(cbook._setattr_cm(canvas, manager=None))
+            stack.enter_context(self._suspended_event_source())
+            if dpi is not None and dpi != fig.dpi:
+                original_dpi = fig.dpi
+                stack.callback(fig.set_dpi, original_dpi)
+                fig.set_dpi(dpi)
+
+            # The first draw runs tight layout; every later one reuses it.
+            freezer = stack.enter_context(self._frozen_layout())
+            frames = self._fast_frame_seq()
+            try:
+                first = next(frames)
+            except StopIteration:
+                raise ValueError("The animation has no frames to save.") from None
+            frames = itertools.chain((first,), frames)
+            init_artists = list(self._fast_init_artists(first) or ())
+            if blit and not init_artists:
+                blit = False  # nothing was returned, so nothing can be blitted
+            mark_animated = None
+            if blit:
+                mark_animated = stack.enter_context(
+                    self._animated_artists(init_artists)
+                )
+
+            canvas.draw()
+            if freezer is not None:
+                freezer.freeze()
+            background = canvas.copy_from_bbox(fig.bbox) if blit else None
+
+            height, width = np.asarray(canvas.buffer_rgba()).shape[:2]
+            raw.setup(width, height)
+            stack.callback(raw.finish)
+
+            for count, frame in enumerate(frames):
+                artists = self._fast_frame_artists(frame)
+                if blit:
+                    artists = _zsorted(artists or init_artists)
+                    mark_animated(artists)
+                    canvas.restore_region(background)
+                    for artist in artists:
+                        fig.draw_artist(artist)
+                else:
+                    if freezer is not None:
+                        freezer.skip_next_layout()
+                    canvas.draw()
+                raw.write(memoryview(canvas.buffer_rgba()))
+                if progress_callback is not None:
+                    progress_callback(count, total)
+
+
+class _LayoutFreezer:
+    """
+    Hold an UltraPlot figure's layout fixed between animation frames.
+    """
+
+    def __init__(self, fig):
+        self._fig = fig
+        self._frozen = False
+
+    def freeze(self):
+        """
+        Mark the current layout as final.
+        """
+        self._fig._layout_initialized = True
+        self._fig._layout_dirty = False
+        self._frozen = True
+        self.skip_next_layout()
+
+    def skip_next_layout(self):
+        """
+        Skip the layout solver on the next draw of the figure.
+        """
+        if self._frozen:
+            self._fig._layout_dirty = False
+            self._fig._skip_autolayout = True
+
+
+class _FastSaveMixin(_FastAnimationBase):
+    """
+    Adds the fast `save` override to a Matplotlib animation class.
+    """
+
+    def save(
+        self,
+        filename,
+        writer=None,
+        fps=None,
+        dpi=None,
+        codec=None,
+        bitrate=None,
+        extra_args=None,
+        metadata=None,
+        extra_anim=None,
+        savefig_kwargs=None,
+        *,
+        progress_callback=None,
+        fast=None,
+        blit=None,
+    ):
+        """
+        Save the animation to a movie file.
+
+        Parameters
+        ----------
+        filename : path-like
+            The output file, e.g. ``'movie.mp4'`` or ``'movie.gif'``.
+        writer : str or `~matplotlib.animation.AbstractMovieWriter`, optional
+            Same meaning as in `matplotlib.animation.Animation.save`. Passing a
+            writer *instance*, or a writer the fast path does not implement,
+            transparently falls back to Matplotlib's implementation.
+        fps : int, optional
+            Frames per second. Defaults to the animation interval.
+        dpi : float, optional
+            Resolution of the saved frames. Unlike Matplotlib, which uses
+            :rc:`savefig.dpi`, this defaults to the figure's own dpi. UltraPlot
+            sets ``savefig.dpi`` to 1000 for publication-quality stills, which
+            for a movie means hundredfold larger frames and a hundredfold
+            slower encode.
+        codec, bitrate, extra_args, metadata : optional
+            Passed to the encoder, as in Matplotlib.
+        extra_anim : list, optional
+            Additional animations to composite. Forces the Matplotlib path.
+        savefig_kwargs : dict, optional
+            Extra `~matplotlib.figure.Figure.savefig` arguments. Any value here
+            forces the Matplotlib path, since the fast path skips ``savefig``.
+        progress_callback : callable, optional
+            Called as ``progress_callback(current_frame, total_frames)``.
+        fast : bool, optional
+            Whether to use the fast renderer. The default, ``None``, uses it
+            whenever it can reproduce the requested output exactly. Passing
+            ``True`` raises if the fast path is unavailable.
+        blit : bool, optional
+            Whether to blit while saving. Defaults to the animation's own
+            ``blit`` setting. Blitting only redraws the artists returned by the
+            update function, so anything else changed per frame (titles, ticks,
+            axes limits) will not appear. Pass ``False`` to redraw everything.
+
+        Other Parameters
+        ----------------
+        See `matplotlib.animation.Animation.save`.
+
+        See also
+        --------
+        matplotlib.animation.Animation.save
+        """
+        savefig_kwargs = savefig_kwargs or {}
+        usable = self._can_fast_save(filename, writer, savefig_kwargs, extra_anim)
+        if fast and not usable:
+            raise ValueError(
+                f"Cannot use the fast animation writer for {filename!r} with "
+                f"writer={writer!r}. Pass fast=False to use matplotlib instead."
+            )
+        if not usable or fast is False:
+            return super().save(
+                filename,
+                writer=writer,
+                fps=fps,
+                dpi=dpi,
+                codec=codec,
+                bitrate=bitrate,
+                extra_args=extra_args,
+                metadata=metadata,
+                extra_anim=extra_anim,
+                savefig_kwargs=savefig_kwargs or None,
+                progress_callback=progress_callback,
+            )
+
+        if fps is None:
+            fps = 1000.0 / getattr(self, "_interval", 200)
+        # NOTE: Matplotlib defaults to rc['savefig.dpi'], but UltraPlot raises
+        # that to 1000 for publication-quality stills. On a movie that means a
+        # hundredfold more pixels in every frame, so default to the figure's
+        # own dpi and let the caller ask for more.
+        if dpi is None or dpi == "figure":
+            dpi = self._fig.dpi
+        if blit is None:
+            blit = bool(getattr(self, "_blit", False))
+        return self._fast_save(
+            filename,
+            fps,
+            dpi,
+            codec,
+            bitrate,
+            extra_args,
+            metadata,
+            progress_callback,
+            blit,
+        )
+
+
+class FuncAnimation(_FastSaveMixin, manimation.FuncAnimation):
+    """
+    A faster drop-in replacement for `matplotlib.animation.FuncAnimation`.
+
+    The signature matches Matplotlib's, with two differences: `blit` defaults
+    to ``True`` instead of ``False``, and `freeze_layout` is added. Saving
+    renders frames directly into the Agg buffer instead of calling
+    `~matplotlib.figure.Figure.savefig` once per frame, which removes the
+    per-frame PNG round-trip and the repeated UltraPlot tight-layout pass.
+
+    Parameters
+    ----------
+    fig : `~ultraplot.figure.Figure`
+        The figure to animate.
+    func : callable
+        The update function, called as ``func(frame, *fargs)``. It should
+        return an iterable of the artists it modified. This is required when
+        `blit` is ``True``, and lets the fast path skip untouched artists.
+    frames : int, iterable, generator, or None, optional
+        Source of frame data, as in Matplotlib.
+    init_func : callable, optional
+        Function drawing the clear frame. Should return the animated artists.
+    fargs : tuple, optional
+        Extra positional arguments for `func` and `init_func`.
+    save_count : int, optional
+        Number of frames to cache from a generator.
+    blit : bool, default: True
+        Whether to redraw only the artists returned by `func`. This is the main
+        source of the speedup, but it means changes to artists that are *not*
+        returned, such as titles or tick labels, will not show up. Pass
+        ``False`` to redraw the whole figure each frame, which is still faster
+        than Matplotlib because the layout solver is frozen.
+    freeze_layout : bool, default: True
+        Whether to run UltraPlot's tight-layout solver only for the first
+        frame. Keeping it on avoids frames whose geometry jitters as labels
+        change size.
+    cache_frame_data : bool, default: True
+        Whether to cache frame data, as in Matplotlib.
+    **kwargs
+        Passed to `matplotlib.animation.TimedAnimation`, e.g. `interval`,
+        `repeat`, and `repeat_delay`.
+
+    Examples
+    --------
+    >>> import ultraplot as uplt
+    >>> import numpy as np
+    >>> fig, ax = uplt.subplots()
+    >>> x = np.linspace(0, 2 * np.pi, 200)
+    >>> (line,) = ax.plot(x, np.sin(x))
+    >>> def update(frame):
+    ...     line.set_ydata(np.sin(x + frame / 10))
+    ...     return (line,)
+    ...
+    >>> ani = uplt.FuncAnimation(fig, update, frames=100)
+    >>> ani.save('waves.mp4')
+
+    See also
+    --------
+    matplotlib.animation.FuncAnimation
+    ultraplot.animation.ArtistAnimation
+    ultraplot.animation.animate
+    """
+
+    def __init__(
+        self,
+        fig,
+        func,
+        frames=None,
+        init_func=None,
+        fargs=None,
+        save_count=None,
+        *,
+        blit=True,
+        freeze_layout=True,
+        **kwargs,
+    ):
+        self._freeze_layout = bool(freeze_layout)
+        super().__init__(
+            fig,
+            func,
+            frames=frames,
+            init_func=init_func,
+            fargs=fargs,
+            save_count=save_count,
+            blit=blit,
+            **kwargs,
+        )
+
+    def _fast_frame_seq(self):
+        return self.new_saved_frame_seq()
+
+    def _fast_init_artists(self, frame):
+        if self._init_func is None:
+            return self._func(frame, *self._args)
+        return self._init_func()
+
+    def _fast_frame_artists(self, frame):
+        return self._func(frame, *self._args)
+
+
+class ArtistAnimation(_FastSaveMixin, manimation.ArtistAnimation):
+    """
+    A faster drop-in replacement for `matplotlib.animation.ArtistAnimation`.
+
+    Frames are lists of artists that are made visible in turn. Saving uses the
+    same direct-to-buffer renderer as `FuncAnimation`.
+
+    Parameters
+    ----------
+    fig : `~ultraplot.figure.Figure`
+        The figure to animate.
+    artists : list of list of `~matplotlib.artist.Artist`
+        Each entry is the collection of artists making up one frame.
+    freeze_layout : bool, default: True
+        Whether to run UltraPlot's tight-layout solver only for the first
+        frame.
+    **kwargs
+        Passed to `matplotlib.animation.TimedAnimation`.
+
+    See also
+    --------
+    matplotlib.animation.ArtistAnimation
+    ultraplot.animation.FuncAnimation
+    """
+
+    def __init__(self, fig, artists, *args, freeze_layout=True, **kwargs):
+        self._freeze_layout = bool(freeze_layout)
+        super().__init__(fig, artists, *args, **kwargs)
+
+    def _fast_frame_seq(self):
+        return iter(self._framedata)
+
+    def _fast_init_artists(self, frame):
+        # Hide every frame, then show the first one, exactly as the parent
+        # class does when it initializes the animation.
+        for other in self._framedata:
+            for artist in other:
+                artist.set_visible(False)
+        return self._fast_frame_artists(frame)
+
+    def _fast_frame_artists(self, frame):
+        for other in self._framedata:
+            for artist in other:
+                artist.set_visible(False)
+        for artist in frame:
+            artist.set_visible(True)
+        return list(frame)
+
+
+def animate(fig, func, frames=None, /, *, save=None, **kwargs):
+    """
+    Build a `FuncAnimation`, optionally saving it in one call.
+
+    This is a thin convenience wrapper. Everything it does can be done with
+    `FuncAnimation` directly.
+
+    Parameters
+    ----------
+    fig : `~ultraplot.figure.Figure`
+        The figure to animate.
+    func : callable
+        The update function, called as ``func(frame)``. It should return the
+        artists it changed.
+    frames : int, iterable, generator, or None, optional
+        Source of frame data.
+    save : path-like, optional
+        If given, the animation is saved here before being returned.
+    **kwargs
+        Passed to `FuncAnimation`, or to `FuncAnimation.save` for the
+        save-specific keywords `fps`, `dpi`, `codec`, `bitrate`, `metadata`,
+        and `progress_callback`.
+
+    Returns
+    -------
+    FuncAnimation
+        The animation. Keep a reference to it, or it will be garbage collected
+        and stop updating.
+
+    Examples
+    --------
+    >>> uplt.animate(fig, update, 100, save='movie.mp4', fps=30)
+
+    See also
+    --------
+    ultraplot.animation.FuncAnimation
+    """
+    save_keys = ("fps", "dpi", "codec", "bitrate", "metadata", "progress_callback")
+    save_kwargs = {key: kwargs.pop(key) for key in save_keys if key in kwargs}
+    if save_kwargs and save is None:
+        warnings._warn_ultraplot(
+            f"Ignoring save keyword arguments {tuple(save_kwargs)} because no "
+            "save location was passed."
+        )
+    ani = FuncAnimation(fig, func, frames, **kwargs)
+    if save is not None:
+        ani.save(save, **save_kwargs)
+    return ani

--- a/ultraplot/animation.py
+++ b/ultraplot/animation.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 import itertools
 import os
 import subprocess
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, suppress
+from tempfile import TemporaryFile
 from pathlib import Path
 
 import matplotlib as mpl
@@ -33,21 +34,23 @@ import matplotlib.animation as manimation
 import numpy as np
 from matplotlib import cbook
 
-from .internals import warnings
-
 __all__ = [
     "FuncAnimation",
     "ArtistAnimation",
-    "animate",
 ]
 
 #: Containers written frame-by-frame by piping raw RGBA to ``ffmpeg``.
 _FFMPEG_SUFFIXES = frozenset(
     (".mp4", ".m4v", ".mov", ".mkv", ".webm", ".avi", ".ogv", ".ogg")
+    + (".gif", ".webp", ".apng", ".avif")
 )
 
 #: Containers assembled in memory by Pillow.
-_PILLOW_SUFFIXES = frozenset((".gif", ".webp", ".apng", ".png", ".tiff", ".tif"))
+_PILLOW_SUFFIXES = frozenset((".gif", ".webp", ".apng"))
+
+#: Containers whose codec is implied by the extension, as in Matplotlib's
+#: `~matplotlib.animation.FFMpegWriter.output_args`.
+_SUFFIX_CODECS = frozenset((".gif", ".webp", ".apng", ".avif"))
 
 #: Writer names whose behavior the fast path reproduces exactly. Anything else,
 #: ``imagemagick`` included, is handed back to Matplotlib.
@@ -61,35 +64,50 @@ def _suffix(filename):
     return Path(os.fspath(filename)).suffix.lower()
 
 
-def _zsorted(artists):
-    """
-    Return the artists in ascending z-order, matching a normal draw.
-    """
-    return sorted(artists, key=lambda artist: artist.get_zorder())
-
-
 class _RawWriter:
     """
     Base class for writers that consume raw ``RGBA`` frames.
+
+    Subclasses implement `write`, `_close`, and `_discard`. The output file is
+    deleted unless `finish` completed, so an animation that fails halfway
+    through never leaves a truncated movie that looks like a whole one.
     """
 
-    def __init__(self, filename, fps, metadata=None):
+    def __init__(self, filename, fps):
         self.filename = os.fspath(filename)
         self.fps = fps
-        self.metadata = metadata or {}
         self.width = self.height = None
+        self._started = False
+        self._finished = False
 
     def setup(self, width, height):
         self.width, self.height = width, height
+        self._started = True
 
     def write(self, buffer):  # pragma: no cover - abstract
         raise NotImplementedError
 
-    def finish(self):  # pragma: no cover - abstract
+    def _close(self):  # pragma: no cover - abstract
         raise NotImplementedError
 
-    def cleanup(self):
+    def _discard(self):
         pass
+
+    def finish(self):
+        """
+        Complete the file. Anything short of this counts as a failed save.
+        """
+        self._close()
+        self._finished = True
+
+    def cleanup(self):
+        """
+        Release resources, and remove the output of an unfinished save.
+        """
+        self._discard()
+        if self._started and not self._finished:
+            with suppress(OSError):
+                os.remove(self.filename)
 
 
 class _RawFFMpegWriter(_RawWriter):
@@ -107,11 +125,13 @@ class _RawFFMpegWriter(_RawWriter):
         extra_args=None,
         metadata=None,
     ):
-        super().__init__(filename, fps, metadata)
+        super().__init__(filename, fps)
+        self.metadata = metadata or {}
         self.codec = codec or mpl.rcParams["animation.codec"]
         self.bitrate = mpl.rcParams["animation.bitrate"] if bitrate is None else bitrate
         self.extra_args = extra_args
         self._proc = None
+        self._stderr = None
 
     @staticmethod
     def available():
@@ -144,66 +164,81 @@ class _RawFFMpegWriter(_RawWriter):
             "pipe:0",
             "-an",
         ]
-        if self.codec:
-            args += ["-vcodec", self.codec]
-        # Most players require even dimensions and 4:2:0 chroma for h264-family
-        # codecs. Scaling is a no-op when the frame is already even-sized.
-        if self.codec in ("h264", "libx264", "libx265", "hevc", "mpeg4"):
+        extra = self.extra_args
+        if extra is None:
+            extra = mpl.rcParams["animation.ffmpeg_args"]
+        extra = list(extra or ())
+
+        # Codec selection mirrors matplotlib's FFMpegWriter: animated-image
+        # containers take the codec implied by their extension, and only h264
+        # and gif get the extra treatment they need to play back correctly.
+        suffix = _suffix(self.filename)
+        codec = suffix[1:] if suffix in _SUFFIX_CODECS else self.codec
+        if suffix not in _SUFFIX_CODECS and codec:
+            args += ["-vcodec", codec]
+        if codec == "h264" and "-pix_fmt" not in extra:
+            # Most players need 4:2:0 chroma and even dimensions. The scale is a
+            # no-op when the frame is already even-sized.
+            args += ["-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2", "-pix_fmt", "yuv420p"]
+        elif codec == "gif" and "-filter_complex" not in extra:
             args += [
-                "-vf",
-                "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-                "-pix_fmt",
-                "yuv420p",
+                "-filter_complex",
+                "split [a][b];[a] palettegen [p];[b][p] paletteuse",
             ]
         if self.bitrate is not None and self.bitrate > 0:
             args += ["-b:v", f"{int(self.bitrate)}k"]
         for key, value in self.metadata.items():
             args += ["-metadata", f"{key}={value}"]
-        extra = self.extra_args
-        if extra is None:
-            extra = mpl.rcParams["animation.ffmpeg_args"]
-        args += list(extra or ())
+        args += extra
         args += [self.filename]
         return args
 
     def setup(self, width, height):
         super().setup(width, height)
+        # NOTE: stderr goes to a file, not a pipe. Nothing reads the pipe while
+        # frames are being written, so a chatty encoder would fill it and block.
+        self._stderr = TemporaryFile()
         self._proc = subprocess.Popen(
             self._command(),
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            stderr=self._stderr,
         )
+
+    def _stderr_text(self):
+        self._stderr.seek(0)
+        return self._stderr.read().decode("utf-8", "replace")
 
     def write(self, buffer):
         try:
             self._proc.stdin.write(buffer)
         except BrokenPipeError as err:
-            _, stderr = self._proc.communicate()
+            self._proc.wait()
             raise RuntimeError(
-                "ffmpeg exited while frames were being written:\n"
-                + stderr.decode("utf-8", "replace")
+                "ffmpeg exited while frames were being written:\n" + self._stderr_text()
             ) from err
 
-    def finish(self):
-        # communicate() closes stdin itself, which signals end-of-stream.
-        _, stderr = self._proc.communicate()
+    def _close(self):
+        self._proc.stdin.close()
+        self._proc.wait()
         if self._proc.returncode:
             raise RuntimeError(
                 f"ffmpeg exited with code {self._proc.returncode}:\n"
-                + stderr.decode("utf-8", "replace")
+                + self._stderr_text()
             )
 
-    def cleanup(self):
+    def _discard(self):
         proc = self._proc
-        if proc is None or proc.returncode is not None:
-            return
-        try:
-            if proc.stdin is not None and not proc.stdin.closed:
-                proc.stdin.close()
-        finally:
-            proc.kill()
-            proc.wait()
+        if proc is not None and proc.returncode is None:
+            try:
+                if proc.stdin is not None and not proc.stdin.closed:
+                    proc.stdin.close()
+            finally:
+                proc.kill()
+                proc.wait()
+        if self._stderr is not None:
+            self._stderr.close()
+            self._stderr = None
 
 
 class _RawPillowWriter(_RawWriter):
@@ -211,8 +246,8 @@ class _RawPillowWriter(_RawWriter):
     Collect raw ``RGBA`` frames and write an animated image with Pillow.
     """
 
-    def __init__(self, filename, fps, *, metadata=None):
-        super().__init__(filename, fps, metadata)
+    def __init__(self, filename, fps):
+        super().__init__(filename, fps)
         self._frames = []
 
     def write(self, buffer):
@@ -225,7 +260,7 @@ class _RawPillowWriter(_RawWriter):
             )
         )
 
-    def finish(self):
+    def _close(self):
         if not self._frames:
             raise RuntimeError("No frames were rendered for the animation.")
         first, *rest = self._frames
@@ -237,22 +272,19 @@ class _RawPillowWriter(_RawWriter):
             loop=0,
         )
 
-    def cleanup(self):
+    def _discard(self):
         self._frames.clear()
 
 
-class _FastAnimationBase:
+class _FastSaveMixin:
     """
-    Mixin implementing the fast save path shared by the animation classes.
+    The fast `save` path, shared by the animation classes.
 
-    Subclasses must implement `_fast_frame_artists`, returning the artists a
-    given frame changed, and `_fast_frame_seq`, returning the frames to save.
+    Subclasses supply the three frame hooks below; everything else here is the
+    machinery that renders those frames into a movie file.
     """
 
-    #: Set by the subclass constructors.
-    _freeze_layout = True
-
-    # Fast-path hooks
+    # Frame hooks
 
     def _fast_frame_seq(self):  # pragma: no cover - abstract
         raise NotImplementedError
@@ -263,8 +295,6 @@ class _FastAnimationBase:
     def _fast_init_artists(self, frame):  # pragma: no cover - abstract
         raise NotImplementedError
 
-    # Layout freezing
-
     @contextmanager
     def _frozen_layout(self):
         """
@@ -272,19 +302,23 @@ class _FastAnimationBase:
 
         UltraPlot recomputes tight layout whenever the figure is marked dirty.
         During an animation the geometry must stay fixed anyway, or frames
-        would jitter, so the solver is disabled after the first draw.
+        would jitter, so the solver is switched off after the first draw. Yields
+        a function that marks the current layout as final.
         """
         fig = self._fig
-        if not self._freeze_layout:
-            yield
-            return
         state = (
             getattr(fig, "_layout_initialized", False),
             getattr(fig, "_layout_dirty", False),
             getattr(fig, "_skip_autolayout", False),
         )
+
+        def freeze():
+            fig._layout_initialized = True
+            fig._layout_dirty = False
+            fig._skip_autolayout = True
+
         try:
-            yield _LayoutFreezer(fig)
+            yield freeze
         finally:
             fig._layout_initialized, fig._layout_dirty, fig._skip_autolayout = state
 
@@ -331,6 +365,25 @@ class _FastAnimationBase:
                 )
 
     @contextmanager
+    def _suspended_figure_blitting(self):
+        """
+        Stand down the figure's own retained-draw machinery while saving.
+
+        `~ultraplot.figure.Figure.savefig` does the same before printing. A live
+        `~ultraplot._animation._BlitManager` keeps its artists flagged animated
+        and repaints them from a ``draw_event`` handler, which would fight the
+        frames drawn here.
+        """
+        fig = self._fig
+        with ExitStack() as stack:
+            selective = getattr(fig, "_selective_draw_manager", None)
+            if selective is not None:
+                stack.enter_context(selective.save_context())
+            for manager in tuple(getattr(fig, "_blit_managers", ())):
+                stack.enter_context(manager._save_context())
+            yield
+
+    @contextmanager
     def _agg_canvas(self):
         """
         Ensure the figure has a canvas that can blit and expose an RGBA buffer.
@@ -351,38 +404,45 @@ class _FastAnimationBase:
         finally:
             fig.set_canvas(original)
 
-    def _can_fast_save(self, filename, writer, savefig_kwargs, extra_anim):
+    def _resolve_writer(self, filename, writer, savefig_kwargs, extra_anim):
         """
-        Return whether the fast path reproduces the requested output exactly.
+        Return the name of the fast writer to use, or ``None`` for none.
+
+        The fast path must pick the same writer Matplotlib would, or the same
+        call would produce a differently encoded file than before.
         """
         if extra_anim:
-            return False
+            return None
         if writer is not None and not isinstance(writer, str):
-            return False  # a configured writer instance must be honored
-        if isinstance(writer, str) and writer not in _FAST_WRITERS:
-            return False
+            return None  # a configured writer instance must be honored
         if savefig_kwargs:
             # Any styling override (facecolor, transparency, bbox_inches, ...)
             # belongs to the savefig pipeline the fast path skips.
-            return False
+            return None
+        # Matplotlib falls back to the rc setting when no writer is named.
+        writer = writer or mpl.rcParams["animation.writer"]
+        if writer not in _FAST_WRITERS:
+            return None
         suffix = _suffix(filename)
-        if suffix in _FFMPEG_SUFFIXES:
-            return writer in (None, "ffmpeg") and _RawFFMpegWriter.available()
-        if suffix in _PILLOW_SUFFIXES:
-            if writer == "ffmpeg":
-                return False
-            try:
-                import PIL  # noqa: F401
-            except ImportError:
-                return False
-            return True
-        return False
+        if writer == "ffmpeg":
+            if suffix in _FFMPEG_SUFFIXES and _RawFFMpegWriter.available():
+                return "ffmpeg"
+            return None
+        if suffix not in _PILLOW_SUFFIXES:
+            return None
+        try:
+            import PIL  # noqa: F401
+        except ImportError:
+            return None
+        return "pillow"
 
-    def _make_raw_writer(self, filename, fps, codec, bitrate, extra_args, metadata):
+    def _make_raw_writer(
+        self, filename, writer, fps, codec, bitrate, extra_args, metadata
+    ):
         """
-        Return the raw-frame writer matching the output file extension.
+        Return the raw-frame writer for the resolved writer name.
         """
-        if _suffix(filename) in _FFMPEG_SUFFIXES:
+        if writer == "ffmpeg":
             return _RawFFMpegWriter(
                 filename,
                 fps,
@@ -391,11 +451,12 @@ class _FastAnimationBase:
                 extra_args=extra_args,
                 metadata=metadata,
             )
-        return _RawPillowWriter(filename, fps, metadata=metadata)
+        return _RawPillowWriter(filename, fps)
 
     def _fast_save(
         self,
         filename,
+        writer,
         fps,
         dpi,
         codec,
@@ -410,25 +471,30 @@ class _FastAnimationBase:
         """
         fig = self._fig
         self._draw_was_started = True
-        raw = self._make_raw_writer(filename, fps, codec, bitrate, extra_args, metadata)
+        raw = self._make_raw_writer(
+            filename, writer, fps, codec, bitrate, extra_args, metadata
+        )
         total = getattr(self, "_save_count", None)
 
         with ExitStack() as stack:
+            # NOTE: `cleanup` is the only unconditional callback. `finish` runs
+            # after the loop instead, so a failing update function does not
+            # leave a truncated movie behind looking like a complete one.
             stack.callback(raw.cleanup)
+            # The event source is suspended before the canvas is swapped, so
+            # that its reconnect on the way out lands on the original canvas.
+            stack.enter_context(self._suspended_event_source())
             canvas = stack.enter_context(self._agg_canvas())
             # NOTE: Matplotlib's own save sets canvas._is_saving, but that makes
             # `Axes.draw` include animated artists so that savefig captures
             # them. That would bake the first frame into the blitting
             # background. Suppress the timer-starting draw callback instead.
             stack.enter_context(cbook._setattr_cm(canvas, manager=None))
-            stack.enter_context(self._suspended_event_source())
+            stack.enter_context(self._suspended_figure_blitting())
             if dpi is not None and dpi != fig.dpi:
-                original_dpi = fig.dpi
-                stack.callback(fig.set_dpi, original_dpi)
+                stack.callback(fig.set_dpi, fig.dpi)
                 fig.set_dpi(dpi)
 
-            # The first draw runs tight layout; every later one reuses it.
-            freezer = stack.enter_context(self._frozen_layout())
             frames = self._fast_frame_seq()
             try:
                 first = next(frames)
@@ -444,63 +510,33 @@ class _FastAnimationBase:
                     self._animated_artists(init_artists)
                 )
 
+            # The first draw runs tight layout; every later one reuses it.
+            freeze_layout = stack.enter_context(self._frozen_layout())
             canvas.draw()
-            if freezer is not None:
-                freezer.freeze()
+            freeze_layout()
             background = canvas.copy_from_bbox(fig.bbox) if blit else None
 
             height, width = np.asarray(canvas.buffer_rgba()).shape[:2]
             raw.setup(width, height)
-            stack.callback(raw.finish)
 
             for count, frame in enumerate(frames):
                 artists = self._fast_frame_artists(frame)
                 if blit:
-                    artists = _zsorted(artists or init_artists)
+                    artists = sorted(
+                        artists or init_artists, key=lambda a: a.get_zorder()
+                    )
                     mark_animated(artists)
                     canvas.restore_region(background)
                     for artist in artists:
                         fig.draw_artist(artist)
                 else:
-                    if freezer is not None:
-                        freezer.skip_next_layout()
+                    freeze_layout()
                     canvas.draw()
                 raw.write(memoryview(canvas.buffer_rgba()))
                 if progress_callback is not None:
                     progress_callback(count, total)
 
-
-class _LayoutFreezer:
-    """
-    Hold an UltraPlot figure's layout fixed between animation frames.
-    """
-
-    def __init__(self, fig):
-        self._fig = fig
-        self._frozen = False
-
-    def freeze(self):
-        """
-        Mark the current layout as final.
-        """
-        self._fig._layout_initialized = True
-        self._fig._layout_dirty = False
-        self._frozen = True
-        self.skip_next_layout()
-
-    def skip_next_layout(self):
-        """
-        Skip the layout solver on the next draw of the figure.
-        """
-        if self._frozen:
-            self._fig._layout_dirty = False
-            self._fig._skip_autolayout = True
-
-
-class _FastSaveMixin(_FastAnimationBase):
-    """
-    Adds the fast `save` override to a Matplotlib animation class.
-    """
+            raw.finish()
 
     def save(
         self,
@@ -566,13 +602,13 @@ class _FastSaveMixin(_FastAnimationBase):
         matplotlib.animation.Animation.save
         """
         savefig_kwargs = savefig_kwargs or {}
-        usable = self._can_fast_save(filename, writer, savefig_kwargs, extra_anim)
-        if fast and not usable:
+        resolved = self._resolve_writer(filename, writer, savefig_kwargs, extra_anim)
+        if fast and resolved is None:
             raise ValueError(
                 f"Cannot use the fast animation writer for {filename!r} with "
                 f"writer={writer!r}. Pass fast=False to use matplotlib instead."
             )
-        if not usable or fast is False:
+        if resolved is None or fast is False:
             return super().save(
                 filename,
                 writer=writer,
@@ -599,6 +635,7 @@ class _FastSaveMixin(_FastAnimationBase):
             blit = bool(getattr(self, "_blit", False))
         return self._fast_save(
             filename,
+            resolved,
             fps,
             dpi,
             codec,
@@ -642,10 +679,6 @@ class FuncAnimation(_FastSaveMixin, manimation.FuncAnimation):
         returned, such as titles or tick labels, will not show up. Pass
         ``False`` to redraw the whole figure each frame, which is still faster
         than Matplotlib because the layout solver is frozen.
-    freeze_layout : bool, default: True
-        Whether to run UltraPlot's tight-layout solver only for the first
-        frame. Keeping it on avoids frames whose geometry jitters as labels
-        change size.
     cache_frame_data : bool, default: True
         Whether to cache frame data, as in Matplotlib.
     **kwargs
@@ -670,7 +703,6 @@ class FuncAnimation(_FastSaveMixin, manimation.FuncAnimation):
     --------
     matplotlib.animation.FuncAnimation
     ultraplot.animation.ArtistAnimation
-    ultraplot.animation.animate
     """
 
     def __init__(
@@ -683,10 +715,8 @@ class FuncAnimation(_FastSaveMixin, manimation.FuncAnimation):
         save_count=None,
         *,
         blit=True,
-        freeze_layout=True,
         **kwargs,
     ):
-        self._freeze_layout = bool(freeze_layout)
         super().__init__(
             fig,
             func,
@@ -723,9 +753,6 @@ class ArtistAnimation(_FastSaveMixin, manimation.ArtistAnimation):
         The figure to animate.
     artists : list of list of `~matplotlib.artist.Artist`
         Each entry is the collection of artists making up one frame.
-    freeze_layout : bool, default: True
-        Whether to run UltraPlot's tight-layout solver only for the first
-        frame.
     **kwargs
         Passed to `matplotlib.animation.TimedAnimation`.
 
@@ -734,10 +761,6 @@ class ArtistAnimation(_FastSaveMixin, manimation.ArtistAnimation):
     matplotlib.animation.ArtistAnimation
     ultraplot.animation.FuncAnimation
     """
-
-    def __init__(self, fig, artists, *args, freeze_layout=True, **kwargs):
-        self._freeze_layout = bool(freeze_layout)
-        super().__init__(fig, artists, *args, **kwargs)
 
     def _fast_frame_seq(self):
         return iter(self._framedata)
@@ -757,53 +780,3 @@ class ArtistAnimation(_FastSaveMixin, manimation.ArtistAnimation):
         for artist in frame:
             artist.set_visible(True)
         return list(frame)
-
-
-def animate(fig, func, frames=None, /, *, save=None, **kwargs):
-    """
-    Build a `FuncAnimation`, optionally saving it in one call.
-
-    This is a thin convenience wrapper. Everything it does can be done with
-    `FuncAnimation` directly.
-
-    Parameters
-    ----------
-    fig : `~ultraplot.figure.Figure`
-        The figure to animate.
-    func : callable
-        The update function, called as ``func(frame)``. It should return the
-        artists it changed.
-    frames : int, iterable, generator, or None, optional
-        Source of frame data.
-    save : path-like, optional
-        If given, the animation is saved here before being returned.
-    **kwargs
-        Passed to `FuncAnimation`, or to `FuncAnimation.save` for the
-        save-specific keywords `fps`, `dpi`, `codec`, `bitrate`, `metadata`,
-        and `progress_callback`.
-
-    Returns
-    -------
-    FuncAnimation
-        The animation. Keep a reference to it, or it will be garbage collected
-        and stop updating.
-
-    Examples
-    --------
-    >>> uplt.animate(fig, update, 100, save='movie.mp4', fps=30)
-
-    See also
-    --------
-    ultraplot.animation.FuncAnimation
-    """
-    save_keys = ("fps", "dpi", "codec", "bitrate", "metadata", "progress_callback")
-    save_kwargs = {key: kwargs.pop(key) for key in save_keys if key in kwargs}
-    if save_kwargs and save is None:
-        warnings._warn_ultraplot(
-            f"Ignoring save keyword arguments {tuple(save_kwargs)} because no "
-            "save location was passed."
-        )
-    ani = FuncAnimation(fig, func, frames, **kwargs)
-    if save is not None:
-        ani.save(save, **save_kwargs)
-    return ani

--- a/ultraplot/tests/test_animation.py
+++ b/ultraplot/tests/test_animation.py
@@ -1577,6 +1577,13 @@ def test_selective_draw_detects_mutable_ticker_state():
 # --- ultraplot.animation fast writers ------------------------------------
 
 
+#: Keeps the fast path deterministic. Without this, ``.gif`` resolves through
+#: :rc:`animation.writer` (``ffmpeg`` by default) and silently falls back to
+#: matplotlib on a machine with no ffmpeg, so the tests would stop covering
+#: this module at all.
+FAST = {"writer": "pillow"}
+
+
 def _fast_animation(nframes=4, **kwargs):
     """
     Return a simple figure, its animated line, and an UltraPlot animation.
@@ -1592,13 +1599,36 @@ def _fast_animation(nframes=4, **kwargs):
     return fig, line, uplt_animation.FuncAnimation(fig, update, nframes, **kwargs)
 
 
+def test_fast_save_actually_takes_the_fast_path(tmp_path, monkeypatch):
+    """
+    Guard against the tests above silently exercising matplotlib instead.
+
+    Every other test here would still pass if `save` fell back, so this one
+    asserts that the fast renderer is what ran.
+    """
+    matplotlib.use("Agg")
+    calls = []
+    original = uplt_animation._FastSaveMixin._fast_save
+
+    def spy(self, *args, **kwargs):
+        calls.append(args[0])
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(uplt_animation._FastSaveMixin, "_fast_save", spy)
+    fig, _, ani = _fast_animation(nframes=2)
+    path = tmp_path / "movie.gif"
+    ani.save(path, **FAST)
+    assert calls == [path]
+    uplt.close(fig)
+
+
 @pytest.mark.parametrize("blit", (True, False))
 def test_fast_save_gif_frame_count(tmp_path, blit):
     """The fast Pillow path writes one image frame per animation frame."""
     matplotlib.use("Agg")
     path = tmp_path / "movie.gif"
     fig, _, ani = _fast_animation(nframes=5, blit=blit)
-    ani.save(path)
+    ani.save(path, **FAST)
     with Image.open(path) as image:
         assert image.n_frames == 5
     uplt.close(fig)
@@ -1609,7 +1639,7 @@ def test_fast_save_frames_differ(tmp_path):
     matplotlib.use("Agg")
     path = tmp_path / "movie.gif"
     fig, _, ani = _fast_animation(nframes=3)
-    ani.save(path, writer="pillow")  # the in-memory encoder, not ffmpeg
+    ani.save(path, **FAST)
     with Image.open(path) as image:
         frames = []
         for index in range(image.n_frames):
@@ -1627,7 +1657,7 @@ def test_fast_save_matches_full_draw(tmp_path):
     for blit in (True, False):
         path = tmp_path / f"movie-{blit}.gif"
         fig, _, ani = _fast_animation(nframes=3, blit=blit)
-        ani.save(path)
+        ani.save(path, **FAST)
         with Image.open(path) as image:
             image.seek(image.n_frames - 1)
             outputs.append(np.asarray(image.convert("RGB")).astype(int))
@@ -1660,12 +1690,15 @@ def test_fast_save_falls_back_for_unsupported_targets(tmp_path):
 def test_fast_save_picks_the_writer_matplotlib_would(tmp_path):
     """The rc writer decides the encoder, exactly as in matplotlib."""
     matplotlib.use("Agg")
+    from ultraplot.animation import _RawFFMpegWriter
+
     fig, _, ani = _fast_animation(nframes=2)
     gif = tmp_path / "movie.gif"
     with matplotlib.rc_context({"animation.writer": "pillow"}):
         assert ani._resolve_writer(gif, None, {}, None) == "pillow"
     with matplotlib.rc_context({"animation.writer": "ffmpeg"}):
-        assert ani._resolve_writer(gif, None, {}, None) == "ffmpeg"
+        expected = "ffmpeg" if _RawFFMpegWriter.available() else None
+        assert ani._resolve_writer(gif, None, {}, None) is expected
     with matplotlib.rc_context({"animation.writer": "html"}):
         assert ani._resolve_writer(gif, None, {}, None) is None
     uplt.close(fig)
@@ -1726,9 +1759,14 @@ def test_fast_save_writes_mp4_through_ffmpeg(tmp_path):
     uplt.close(fig)
 
 
-def test_fast_save_failure_leaves_no_output(tmp_path):
+@pytest.mark.parametrize("writer", ("pillow", "ffmpeg"))
+def test_fast_save_failure_leaves_no_output(tmp_path, writer):
     """A failing update function must not leave a truncated movie behind."""
     matplotlib.use("Agg")
+    from ultraplot.animation import _RawFFMpegWriter
+
+    if writer == "ffmpeg" and not _RawFFMpegWriter.available():
+        pytest.skip("ffmpeg is not installed")
     fig, ax = uplt.subplots(refwidth=1.5)
     x = np.linspace(0, 2 * np.pi, 50)
     (line,) = ax.plot(x, np.sin(x))
@@ -1742,7 +1780,7 @@ def test_fast_save_failure_leaves_no_output(tmp_path):
     ani = uplt_animation.FuncAnimation(fig, update, 6)
     path = tmp_path / "movie.gif"
     with pytest.raises(RuntimeError, match="update failed"):
-        ani.save(path)
+        ani.save(path, writer=writer)
     assert not path.exists()
     uplt.close(fig)
 
@@ -1754,7 +1792,7 @@ def test_fast_save_honors_dpi(tmp_path):
     for dpi in (50, 100):
         fig, _, ani = _fast_animation(nframes=2)
         path = tmp_path / f"movie-{dpi}.gif"
-        ani.save(path, dpi=dpi)
+        ani.save(path, dpi=dpi, **FAST)
         with Image.open(path) as image:
             sizes[dpi] = image.size
         assert fig.dpi == 100
@@ -1767,7 +1805,11 @@ def test_fast_save_reports_progress(tmp_path):
     matplotlib.use("Agg")
     seen = []
     fig, _, ani = _fast_animation(nframes=4)
-    ani.save(tmp_path / "movie.gif", progress_callback=lambda i, n: seen.append((i, n)))
+    ani.save(
+        tmp_path / "movie.gif",
+        progress_callback=lambda i, n: seen.append((i, n)),
+        **FAST,
+    )
     assert [index for index, _ in seen] == [0, 1, 2, 3]
     assert all(total == 4 for _, total in seen)
     uplt.close(fig)
@@ -1777,8 +1819,8 @@ def test_fast_save_restores_the_event_source(tmp_path):
     """The interactive draw callback survives a save."""
     matplotlib.use("Agg")
     fig, _, ani = _fast_animation(nframes=3)
-    canvas, before = fig.canvas, ani._first_draw_id
-    ani.save(tmp_path / "movie.gif")
+    canvas = fig.canvas
+    ani.save(tmp_path / "movie.gif", **FAST)
     assert fig.canvas is canvas
     assert ani._first_draw_id is not None
     connected = canvas.callbacks.callbacks.get("draw_event", {})
@@ -1791,7 +1833,7 @@ def test_fast_save_rejects_an_empty_frame_sequence(tmp_path):
     matplotlib.use("Agg")
     fig, _, ani = _fast_animation(nframes=0)
     with pytest.raises(ValueError, match="no frames"):
-        ani.save(tmp_path / "movie.gif")
+        ani.save(tmp_path / "movie.gif", **FAST)
     uplt.close(fig)
 
 
@@ -1809,7 +1851,7 @@ def test_fast_save_restores_artist_state(tmp_path):
     matplotlib.use("Agg")
     fig, line, ani = _fast_animation(nframes=3)
     before = line.get_animated()
-    ani.save(tmp_path / "movie.gif")
+    ani.save(tmp_path / "movie.gif", **FAST)
     assert line.get_animated() is before
     uplt.close(fig)
 
@@ -1826,7 +1868,7 @@ def test_fast_save_runs_tight_layout_once(tmp_path):
         return original(*args, **kwargs)
 
     fig.auto_layout = wrapped
-    ani.save(tmp_path / "movie.gif")
+    ani.save(tmp_path / "movie.gif", **FAST)
     assert len(calls) == 1
     uplt.close(fig)
 
@@ -1839,7 +1881,7 @@ def test_artist_animation_fast_save(tmp_path):
     frames = [ax.plot(x, np.sin(x + shift)) for shift in (0, 1, 2)]
     ani = uplt_animation.ArtistAnimation(fig, frames, interval=100)
     path = tmp_path / "movie.gif"
-    ani.save(path)
+    ani.save(path, **FAST)
     with Image.open(path) as image:
         assert image.n_frames == 3
     uplt.close(fig)

--- a/ultraplot/tests/test_animation.py
+++ b/ultraplot/tests/test_animation.py
@@ -12,6 +12,7 @@ from matplotlib.backend_bases import FigureCanvasBase, MouseEvent, TimerBase
 from PIL import Image
 
 import ultraplot as uplt
+from ultraplot import animation as uplt_animation
 from ultraplot._animation import _BlitManager
 from ultraplot._layout import _AxisTickCache, _LayoutTransaction
 
@@ -1571,3 +1572,152 @@ def test_selective_draw_detects_mutable_ticker_state():
     fig.canvas.draw()
     full = np.asarray(fig.canvas.buffer_rgba()).copy()
     assert np.array_equal(retained, full)
+
+
+# --- ultraplot.animation fast writers ------------------------------------
+
+
+def _fast_animation(nframes=4, **kwargs):
+    """
+    Return a simple figure, its animated line, and an UltraPlot animation.
+    """
+    fig, ax = uplt.subplots(refwidth=1.5)
+    x = np.linspace(0, 2 * np.pi, 50)
+    (line,) = ax.plot(x, np.sin(x))
+
+    def update(frame):
+        line.set_ydata(np.sin(x + frame))
+        return (line,)
+
+    return fig, line, uplt_animation.FuncAnimation(fig, update, nframes, **kwargs)
+
+
+@pytest.mark.parametrize("blit", (True, False))
+def test_fast_save_gif_frame_count(tmp_path, blit):
+    """The fast Pillow path writes one image frame per animation frame."""
+    matplotlib.use("Agg")
+    path = tmp_path / "movie.gif"
+    fig, _, ani = _fast_animation(nframes=5, blit=blit)
+    ani.save(path)
+    with Image.open(path) as image:
+        assert image.n_frames == 5
+    uplt.close(fig)
+
+
+def test_fast_save_frames_differ(tmp_path):
+    """Blitted frames must actually show the updated artist."""
+    matplotlib.use("Agg")
+    path = tmp_path / "movie.gif"
+    fig, _, ani = _fast_animation(nframes=3)
+    ani.save(path)
+    with Image.open(path) as image:
+        frames = []
+        for index in range(image.n_frames):
+            image.seek(index)
+            frames.append(np.asarray(image.convert("RGB")).copy())
+    assert not np.array_equal(frames[0], frames[1])
+    assert not np.array_equal(frames[1], frames[2])
+    uplt.close(fig)
+
+
+def test_fast_save_matches_full_draw(tmp_path):
+    """Blitting must reproduce what a full redraw of every frame produces."""
+    matplotlib.use("Agg")
+    outputs = []
+    for blit in (True, False):
+        path = tmp_path / f"movie-{blit}.gif"
+        fig, _, ani = _fast_animation(nframes=3, blit=blit)
+        ani.save(path)
+        with Image.open(path) as image:
+            image.seek(image.n_frames - 1)
+            outputs.append(np.asarray(image.convert("RGB")).astype(int))
+        uplt.close(fig)
+    # Blitting always draws the animated artist last, so a handful of pixels
+    # where it crosses the spines can differ. Everything else must match.
+    differing = (np.abs(outputs[0] - outputs[1]).sum(axis=-1) > 0).sum()
+    assert differing < 0.005 * outputs[0][..., 0].size
+
+
+def test_fast_save_falls_back_for_unsupported_targets(tmp_path):
+    """Unknown containers and writer instances use the matplotlib path."""
+    matplotlib.use("Agg")
+    from matplotlib.animation import PillowWriter
+
+    fig, _, ani = _fast_animation(nframes=2)
+    assert not ani._can_fast_save(tmp_path / "movie.htm", None, {}, None)
+    assert not ani._can_fast_save(tmp_path / "movie.gif", PillowWriter(fps=5), {}, None)
+    assert not ani._can_fast_save(
+        tmp_path / "movie.gif", None, {"bbox_inches": "tight"}, None
+    )
+    assert ani._can_fast_save(tmp_path / "movie.gif", None, {}, None)
+    uplt.close(fig)
+
+
+def test_fast_save_requires_fast_path_when_requested(tmp_path):
+    """``fast=True`` is an assertion, not a hint."""
+    matplotlib.use("Agg")
+    fig, _, ani = _fast_animation(nframes=2)
+    with pytest.raises(ValueError, match="fast animation writer"):
+        ani.save(tmp_path / "movie.htm", fast=True)
+    uplt.close(fig)
+
+
+def test_fast_save_restores_artist_state(tmp_path):
+    """Saving must not leave the animated artists flagged as animated."""
+    matplotlib.use("Agg")
+    fig, line, ani = _fast_animation(nframes=3)
+    before = line.get_animated()
+    ani.save(tmp_path / "movie.gif")
+    assert line.get_animated() is before
+    uplt.close(fig)
+
+
+def test_fast_save_runs_tight_layout_once(tmp_path):
+    """The layout solver runs for the first frame only."""
+    matplotlib.use("Agg")
+    fig, _, ani = _fast_animation(nframes=6, blit=False)
+    calls = []
+    original = fig.auto_layout
+
+    def wrapped(*args, **kwargs):
+        calls.append(kwargs.get("tight", None))
+        return original(*args, **kwargs)
+
+    fig.auto_layout = wrapped
+    ani.save(tmp_path / "movie.gif")
+    assert len(calls) <= 1
+    uplt.close(fig)
+
+
+def test_animate_helper_saves(tmp_path):
+    """``uplt.animate`` builds and saves in one call."""
+    matplotlib.use("Agg")
+    fig, ax = uplt.subplots(refwidth=1.5)
+    x = np.linspace(0, 2 * np.pi, 50)
+    (line,) = ax.plot(x, np.sin(x))
+    path = tmp_path / "movie.gif"
+    ani = uplt.animate(
+        fig,
+        lambda frame: (line.set_ydata(np.sin(x + frame)), (line,))[1],
+        4,
+        save=path,
+        fps=10,
+    )
+    assert isinstance(ani, uplt_animation.FuncAnimation)
+    with Image.open(path) as image:
+        assert image.n_frames == 4
+    uplt.close(fig)
+
+
+def test_artist_animation_fast_save(tmp_path):
+    """``ArtistAnimation`` uses the same fast writer."""
+    matplotlib.use("Agg")
+    fig, ax = uplt.subplots(refwidth=1.5)
+    x = np.linspace(0, 2 * np.pi, 50)
+    frames = [ax.plot(x, np.sin(x + shift)) for shift in (0, 1, 2)]
+    ani = uplt_animation.ArtistAnimation(fig, frames, interval=100)
+    path = tmp_path / "movie.gif"
+    ani.save(path)
+    with Image.open(path) as image:
+        assert image.n_frames == 3
+    uplt.close(fig)

--- a/ultraplot/tests/test_animation.py
+++ b/ultraplot/tests/test_animation.py
@@ -1609,7 +1609,7 @@ def test_fast_save_frames_differ(tmp_path):
     matplotlib.use("Agg")
     path = tmp_path / "movie.gif"
     fig, _, ani = _fast_animation(nframes=3)
-    ani.save(path)
+    ani.save(path, writer="pillow")  # the in-memory encoder, not ffmpeg
     with Image.open(path) as image:
         frames = []
         for index in range(image.n_frames):
@@ -1644,12 +1644,154 @@ def test_fast_save_falls_back_for_unsupported_targets(tmp_path):
     from matplotlib.animation import PillowWriter
 
     fig, _, ani = _fast_animation(nframes=2)
-    assert not ani._can_fast_save(tmp_path / "movie.htm", None, {}, None)
-    assert not ani._can_fast_save(tmp_path / "movie.gif", PillowWriter(fps=5), {}, None)
-    assert not ani._can_fast_save(
-        tmp_path / "movie.gif", None, {"bbox_inches": "tight"}, None
+    assert ani._resolve_writer(tmp_path / "movie.htm", None, {}, None) is None
+    assert (
+        ani._resolve_writer(tmp_path / "movie.gif", PillowWriter(fps=5), {}, None)
+        is None
     )
-    assert ani._can_fast_save(tmp_path / "movie.gif", None, {}, None)
+    assert (
+        ani._resolve_writer(tmp_path / "movie.gif", None, {"bbox_inches": "t"}, None)
+        is None
+    )
+    assert ani._resolve_writer(tmp_path / "movie.gif", "pillow", {}, None) == "pillow"
+    uplt.close(fig)
+
+
+def test_fast_save_picks_the_writer_matplotlib_would(tmp_path):
+    """The rc writer decides the encoder, exactly as in matplotlib."""
+    matplotlib.use("Agg")
+    fig, _, ani = _fast_animation(nframes=2)
+    gif = tmp_path / "movie.gif"
+    with matplotlib.rc_context({"animation.writer": "pillow"}):
+        assert ani._resolve_writer(gif, None, {}, None) == "pillow"
+    with matplotlib.rc_context({"animation.writer": "ffmpeg"}):
+        assert ani._resolve_writer(gif, None, {}, None) == "ffmpeg"
+    with matplotlib.rc_context({"animation.writer": "html"}):
+        assert ani._resolve_writer(gif, None, {}, None) is None
+    uplt.close(fig)
+
+
+def test_fast_save_falls_back_to_matplotlib_implementation(tmp_path, monkeypatch):
+    """A rejected target really does reach ``Animation.save``."""
+    matplotlib.use("Agg")
+    from matplotlib.animation import Animation
+
+    calls = []
+    original = Animation.save
+
+    def spy(self, *args, **kwargs):
+        calls.append(args[0])
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Animation, "save", spy)
+    fig, _, ani = _fast_animation(nframes=2)
+    path = tmp_path / "movie.gif"
+    ani.save(path, writer=matplotlib.animation.PillowWriter(fps=5))
+    assert calls == [path]
+    assert path.exists()
+    uplt.close(fig)
+
+
+def test_fast_save_writes_mp4_through_ffmpeg(tmp_path):
+    """The ffmpeg path produces a readable video with every frame."""
+    matplotlib.use("Agg")
+    pytest.importorskip("matplotlib.animation")
+    from ultraplot.animation import _RawFFMpegWriter
+
+    if not _RawFFMpegWriter.available():
+        pytest.skip("ffmpeg is not installed")
+    import subprocess
+
+    fig, _, ani = _fast_animation(nframes=5)
+    path = tmp_path / "movie.mp4"
+    ani.save(path, fps=10)
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-count_frames",
+            "-show_entries",
+            "stream=nb_read_frames",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert probe.stdout.strip().rstrip(",") == "5"
+    uplt.close(fig)
+
+
+def test_fast_save_failure_leaves_no_output(tmp_path):
+    """A failing update function must not leave a truncated movie behind."""
+    matplotlib.use("Agg")
+    fig, ax = uplt.subplots(refwidth=1.5)
+    x = np.linspace(0, 2 * np.pi, 50)
+    (line,) = ax.plot(x, np.sin(x))
+
+    def update(frame):
+        if frame == 3:
+            raise RuntimeError("update failed")
+        line.set_ydata(np.sin(x + frame))
+        return (line,)
+
+    ani = uplt_animation.FuncAnimation(fig, update, 6)
+    path = tmp_path / "movie.gif"
+    with pytest.raises(RuntimeError, match="update failed"):
+        ani.save(path)
+    assert not path.exists()
+    uplt.close(fig)
+
+
+def test_fast_save_honors_dpi(tmp_path):
+    """``dpi`` scales the frames and is restored afterwards."""
+    matplotlib.use("Agg")
+    sizes = {}
+    for dpi in (50, 100):
+        fig, _, ani = _fast_animation(nframes=2)
+        path = tmp_path / f"movie-{dpi}.gif"
+        ani.save(path, dpi=dpi)
+        with Image.open(path) as image:
+            sizes[dpi] = image.size
+        assert fig.dpi == 100
+        uplt.close(fig)
+    assert sizes[100][0] > sizes[50][0]
+
+
+def test_fast_save_reports_progress(tmp_path):
+    """``progress_callback`` fires once per frame, in order."""
+    matplotlib.use("Agg")
+    seen = []
+    fig, _, ani = _fast_animation(nframes=4)
+    ani.save(tmp_path / "movie.gif", progress_callback=lambda i, n: seen.append((i, n)))
+    assert [index for index, _ in seen] == [0, 1, 2, 3]
+    assert all(total == 4 for _, total in seen)
+    uplt.close(fig)
+
+
+def test_fast_save_restores_the_event_source(tmp_path):
+    """The interactive draw callback survives a save."""
+    matplotlib.use("Agg")
+    fig, _, ani = _fast_animation(nframes=3)
+    canvas, before = fig.canvas, ani._first_draw_id
+    ani.save(tmp_path / "movie.gif")
+    assert fig.canvas is canvas
+    assert ani._first_draw_id is not None
+    connected = canvas.callbacks.callbacks.get("draw_event", {})
+    assert ani._first_draw_id in connected
+    uplt.close(fig)
+
+
+def test_fast_save_rejects_an_empty_frame_sequence(tmp_path):
+    """Saving nothing is an error, not an empty file."""
+    matplotlib.use("Agg")
+    fig, _, ani = _fast_animation(nframes=0)
+    with pytest.raises(ValueError, match="no frames"):
+        ani.save(tmp_path / "movie.gif")
     uplt.close(fig)
 
 
@@ -1685,27 +1827,7 @@ def test_fast_save_runs_tight_layout_once(tmp_path):
 
     fig.auto_layout = wrapped
     ani.save(tmp_path / "movie.gif")
-    assert len(calls) <= 1
-    uplt.close(fig)
-
-
-def test_animate_helper_saves(tmp_path):
-    """``uplt.animate`` builds and saves in one call."""
-    matplotlib.use("Agg")
-    fig, ax = uplt.subplots(refwidth=1.5)
-    x = np.linspace(0, 2 * np.pi, 50)
-    (line,) = ax.plot(x, np.sin(x))
-    path = tmp_path / "movie.gif"
-    ani = uplt.animate(
-        fig,
-        lambda frame: (line.set_ydata(np.sin(x + frame)), (line,))[1],
-        4,
-        save=path,
-        fps=10,
-    )
-    assert isinstance(ani, uplt_animation.FuncAnimation)
-    with Image.open(path) as image:
-        assert image.n_frames == 4
+    assert len(calls) == 1
     uplt.close(fig)
 
 


### PR DESCRIPTION
Closes #802 

Matplotlib (I believe) dumps frames to disk before stacking into a png. This creates an unnecessary slowdown that we don't need. Instead we can just directly pass on buffers to ffmpeg. This creates some performance gains:

 
<img width="1312" height="676" alt="animation_speed" src="https://github.com/user-attachments/assets/fe5b7283-b48b-4221-8e3a-3c363b483eea" />
