### PR TITLE
Stop pycirclize from restyling the session on import

### DIFF
--- a/ultraplot/axes/plot_types/circlize.py
+++ b/ultraplot/axes/plot_types/circlize.py
@@ -15,8 +15,34 @@ from matplotlib.projections.polar import PolarAxes as MplPolarAxes
 from ... import constructor
 from ...config import rc
 
+#: Settings ``pycirclize.config`` writes into the global rcParams the moment it
+#: is imported. Importing a library must not change how unrelated figures are
+#: saved, so `_import_pycirclize` puts these back.
+_PYCIRCLIZE_RC_LEAKS = ("savefig.bbox", "savefig.pad_inches", "svg.fonttype")
+
 
 def _import_pycirclize():
+    """
+    Import pycirclize without letting it restyle the session.
+
+    ``pycirclize.config`` runs ``mpl.rcParams.update(...)`` at import time,
+    setting ``savefig.bbox='tight'`` and ``savefig.pad_inches=0.5``. Since the
+    import is lazy, the first chord, radar, phylogeny or circos plot in a
+    session would otherwise silently change the size and padding of every
+    figure saved afterwards.
+    """
+    import matplotlib as mpl
+
+    restore = {key: mpl.rcParams[key] for key in _PYCIRCLIZE_RC_LEAKS}
+    try:
+        return _import_pycirclize_unguarded()
+    finally:
+        for key, value in restore.items():
+            if mpl.rcParams[key] != value:
+                mpl.rcParams[key] = value
+
+
+def _import_pycirclize_unguarded():
     try:
         import pycirclize
     except ImportError as exc:

--- a/ultraplot/tests/test_circlize_integration.py
+++ b/ultraplot/tests/test_circlize_integration.py
@@ -211,3 +211,51 @@ def test_alias_methods(fake_pycirclize, tmp_path):
     circos = ax.bed(bed_path, plot=False)
     assert hasattr(circos, "sectors")
     uplt.close(fig)
+
+
+def test_import_pycirclize_restores_savefig_settings():
+    """
+    Importing pycirclize must not change how unrelated figures are saved.
+
+    ``pycirclize.config`` runs ``mpl.rcParams.update(...)`` at import time,
+    setting ``savefig.bbox='tight'`` and ``savefig.pad_inches=0.5``. UltraPlot
+    imports it lazily, so without a guard the first chord or radar plot in a
+    session would silently pad and resize every figure saved afterwards.
+    """
+    import matplotlib as mpl
+
+    pytest.importorskip("pycirclize")
+    watched = ("savefig.bbox", "savefig.pad_inches", "svg.fonttype")
+    before = {key: mpl.rcParams[key] for key in watched}
+    try:
+        circlize_mod._import_pycirclize()
+        assert {key: mpl.rcParams[key] for key in watched} == before
+    finally:
+        for key, value in before.items():
+            mpl.rcParams[key] = value
+
+
+def test_chord_diagram_does_not_resize_later_figures():
+    """
+    A figure made after a chord diagram keeps the size it was asked for.
+    """
+    import matplotlib as mpl
+
+    pytest.importorskip("pycirclize")
+    pandas = pytest.importorskip("pandas")
+    numpy = pytest.importorskip("numpy")
+
+    watched = ("savefig.bbox", "savefig.pad_inches")
+    before = {key: mpl.rcParams[key] for key in watched}
+    try:
+        names = list("ABCD")
+        matrix = pandas.DataFrame(
+            numpy.arange(16).reshape(4, 4) + 1, index=names, columns=names
+        )
+        fig, ax = uplt.subplots(figwidth="26mm", figheight="26mm", proj="polar")
+        ax.chord_diagram(matrix, ticks_interval=None)
+        uplt.close(fig)
+        assert {key: mpl.rcParams[key] for key in watched} == before
+    finally:
+        for key, value in before.items():
+            mpl.rcParams[key] = value


### PR DESCRIPTION
`pycirclize.config` runs `mpl.rcParams.update(...)` at import time, setting `savefig.bbox='tight'`, `savefig.pad_inches=0.5` and `svg.fonttype='none'`. UltraPlot imports it lazily, so the first chord, radar, phylogeny or circos plot in a session silently changed how every figure saved afterwards was sized and padded — a 26mm figure saved as 434px instead of 225px, with half an inch of padding nobody asked for.

`_import_pycirclize` now restores those three settings after the import.

Found while rendering a gallery of small figures: every thumbnail drawn after the first chord diagram came out roughly twice the canvas size.