### PR TITLE
Pin the docs extensions that Sphinx 9 broke

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,16 @@ docs = [
     "lxml-html-clean",
     "markdown",
     "mpltern",
-    "nbsphinx",
+    # Floors below are the versions that work with Sphinx 9, which removed
+    # sphinx.ext.autosummary.get_documenter. Without them pip is free to pair a
+    # current Sphinx with an extension that cannot import it, and the build
+    # dies with "Extension error (sphinx_automodapi.automodsumm)".
+    "nbsphinx>=0.9.8",          # 0.9.7 declares sphinx<8.2
     "sphinx",
     "sphinx-autoapi",
-    "sphinx-automodapi",
+    "sphinx-automodapi>=0.22",  # 0.19 imports the removed get_documenter
     "sphinx-copybutton",
-    "sphinx-design",
+    "sphinx-design>=0.7",       # 0.6.1 declares sphinx<9
     "sphinx-gallery",
     "shibuya",
     "sphinx-sitemap",


### PR DESCRIPTION
Sphinx 9 removed `sphinx.ext.autosummary.get_documenter`. sphinx-automodapi 0.19 imports it at module level, so a docs build against Sphinx 9 dies before it starts:

    Extension error (sphinx_automodapi.automodsumm)!
    cannot import name 'get_documenter' from 'sphinx.ext.autosummary'

sphinx-design 0.6.1 and nbsphinx 0.9.7 also declare upper bounds that exclude Sphinx 9. The docs extra listed all three unconstrained, so `pip install .[docs]` was free to produce a combination that cannot build.

Floors are the versions verified to build the docs against Sphinx 9.1.0 on Python 3.14: nbsphinx 0.9.8, sphinx-automodapi 0.22, sphinx-design 0.7.