### PR TITLE
Refactor keyword aliases behind a compatibility layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ docs/_build
 docs/_static/ultraplotrc
 docs/_static/rctable.rst
 docs/_static/*
+!docs/_static/alias-explorer-v3.css
+!docs/_static/alias-explorer-v3.js
+!docs/_static/alias-map.svg
 !docs/_static/why_plots/
 *.html
 docs/gallery/

--- a/docs/_static/alias-explorer-v3.css
+++ b/docs/_static/alias-explorer-v3.css
@@ -1,0 +1,438 @@
+.uplt-alias-explorer {
+    --alias-ink: var(--uplt-color-text-main, #24323b);
+    --alias-muted: var(--uplt-color-text-secondary, #59656d);
+    --alias-panel: var(--uplt-color-panel-bg, #fff);
+    --alias-soft: var(--uplt-color-sidebar-bg, #f3f6f7);
+    --alias-border: var(--uplt-color-border-muted, #d9e1e5);
+    --alias-accent: var(--uplt-color-accent, #0f766e);
+    --alias-blue: #3976d3;
+    margin: 1.5rem 0 2.25rem;
+    color: var(--alias-ink);
+}
+
+.uplt-alias-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-bottom: 0.75rem;
+}
+
+.uplt-alias-summary span {
+    padding: 0.24rem 0.62rem;
+    border: 1px solid var(--alias-border);
+    border-radius: 999px;
+    background: var(--alias-soft);
+    color: var(--alias-muted);
+    font-size: 0.76rem;
+    letter-spacing: 0.015em;
+}
+
+.uplt-alias-summary strong {
+    color: var(--alias-accent);
+}
+
+.uplt-alias-map-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(14rem, 1fr);
+    align-items: stretch;
+    border: 1px solid var(--alias-border);
+    border-radius: 0.85rem;
+    overflow: visible;
+    background: var(--alias-panel);
+    box-shadow: 0 8px 30px var(--uplt-color-shadow, rgba(15, 23, 42, 0.08));
+}
+
+.uplt-alias-visual-column {
+    min-width: 0;
+    overflow: visible;
+}
+
+.uplt-alias-map {
+    position: relative;
+    z-index: 2;
+    min-width: 0;
+    padding: 0.8rem;
+    overflow: visible;
+    background:
+        radial-gradient(circle at 38% 46%, rgba(57, 118, 211, 0.08), transparent 34%),
+        linear-gradient(145deg, var(--alias-soft), var(--alias-panel));
+}
+
+.uplt-alias-map svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    min-height: 25rem;
+    overflow: visible;
+}
+
+.uplt-alias-real-figure {
+    filter: drop-shadow(0 3px 8px rgba(15, 23, 42, 0.12));
+}
+
+.uplt-alias-target {
+    fill: var(--alias-accent);
+    fill-opacity: 0;
+    stroke: var(--alias-accent);
+    stroke-opacity: 0;
+    stroke-width: 2.5;
+    pointer-events: none;
+}
+
+.uplt-alias-target-line {
+    fill: none;
+    stroke-width: 13;
+}
+
+.uplt-alias-target.is-preview,
+.uplt-alias-target.is-active {
+    fill-opacity: 0.13;
+    stroke-opacity: 0.9;
+}
+
+.uplt-alias-target-line.is-preview,
+.uplt-alias-target-line.is-active {
+    stroke-opacity: 0.5;
+}
+
+.uplt-alias-wire {
+    fill: none;
+    stroke: color-mix(in srgb, var(--callout-color) 72%, var(--alias-border));
+    stroke-width: 3;
+    stroke-linecap: round;
+    pointer-events: none;
+    vector-effect: non-scaling-stroke;
+}
+
+.uplt-alias-node {
+    --callout-color: var(--alias-accent);
+    cursor: pointer;
+    outline: none;
+    touch-action: none;
+}
+
+.uplt-alias-node[data-layout-key="titles"] {
+    --callout-color: #f472b6;
+}
+
+.uplt-alias-node[data-layout-key="layout"] {
+    --callout-color: #a78bfa;
+}
+
+.uplt-alias-node[data-layout-key="axes"] {
+    --callout-color: #60a5fa;
+}
+
+.uplt-alias-node[data-layout-key="plot"] {
+    --callout-color: #34d399;
+}
+
+.uplt-alias-node[data-layout-key="legend"] {
+    --callout-color: #fbbf24;
+}
+
+.uplt-alias-node[data-layout-key="colorbar"] {
+    --callout-color: #fb7185;
+}
+
+.uplt-alias-node[data-layout-key="style"] {
+    --callout-color: #c084fc;
+}
+
+.uplt-alias-node.is-dragging {
+    cursor: grabbing;
+}
+
+.uplt-alias-node rect {
+    fill: color-mix(in srgb, var(--callout-color) 18%, var(--alias-panel));
+    stroke: color-mix(in srgb, var(--callout-color) 72%, var(--alias-border));
+    stroke-width: 2.25;
+    filter: drop-shadow(0 5px 9px color-mix(in srgb, var(--callout-color) 24%, transparent));
+}
+
+.uplt-alias-node text {
+    fill: var(--alias-ink);
+    font-family: ui-rounded, "Arial Rounded MT Bold", system-ui, sans-serif;
+    font-size: 16px;
+    font-weight: 700;
+    text-anchor: middle;
+    pointer-events: none;
+}
+
+.uplt-alias-node:hover rect,
+.uplt-alias-node:focus-visible rect,
+.uplt-alias-node.is-preview rect,
+.uplt-alias-node.is-active rect {
+    fill: color-mix(in srgb, var(--callout-color) 30%, var(--alias-panel));
+    stroke: var(--callout-color);
+    stroke-width: 2.25;
+}
+
+.uplt-alias-node:hover .uplt-alias-wire,
+.uplt-alias-node:focus-visible .uplt-alias-wire,
+.uplt-alias-node.is-preview .uplt-alias-wire,
+.uplt-alias-node.is-active .uplt-alias-wire {
+    stroke: var(--callout-color);
+    stroke-width: 3;
+}
+
+.uplt-alias-detail {
+    min-width: 0;
+    min-height: 0;
+    padding: 1rem 1.05rem;
+    border-left: 1px solid var(--alias-border);
+    background: var(--alias-panel);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+}
+
+.uplt-alias-detail-help {
+    margin: 0 0 0.75rem !important;
+    color: var(--alias-muted);
+    font-family: inherit;
+    font-size: 0.86rem;
+    font-weight: 400;
+    line-height: 1.45;
+}
+
+.uplt-alias-detail h3 {
+    margin: 0.1rem 0 0.3rem;
+    font-size: 1.25rem;
+}
+
+.uplt-alias-detail > p:not(.uplt-alias-detail-help) {
+    margin: 0 0 0.75rem;
+    color: var(--alias-muted);
+    font-size: 0.86rem;
+}
+
+.uplt-alias-preview {
+    display: grid;
+    gap: 0.38rem;
+    min-height: 9rem;
+}
+
+.uplt-alias-pair {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: 0.38rem;
+    padding: 0.3rem 0.4rem;
+    border-radius: 0.35rem;
+    background: var(--alias-soft);
+}
+
+.uplt-alias-pair code {
+    overflow: hidden;
+    color: var(--alias-ink);
+    font-size: 0.72rem;
+    text-overflow: ellipsis;
+}
+
+.uplt-alias-keyword-link {
+    min-width: 0;
+    border-bottom: 0 !important;
+    border-radius: 0.2rem;
+    text-decoration: none !important;
+}
+
+.uplt-alias-keyword-link:hover,
+.uplt-alias-keyword-link:focus-visible {
+    background: color-mix(in srgb, var(--alias-accent) 13%, transparent);
+    outline: 2px solid color-mix(in srgb, var(--alias-accent) 35%, transparent);
+    outline-offset: 1px;
+    text-decoration: none !important;
+}
+
+.uplt-alias-table .uplt-alias-keyword-link {
+    display: inline-block;
+    padding: 0.08rem 0.16rem;
+}
+
+.uplt-alias-table .uplt-alias-keyword-link code {
+    color: inherit;
+}
+
+.uplt-alias-pair span {
+    color: var(--alias-accent);
+}
+
+.uplt-alias-pair small {
+    grid-column: 1 / -1;
+    color: var(--alias-muted);
+    font-size: 0.62rem;
+}
+
+.uplt-alias-more {
+    margin: 0.2rem 0 0 !important;
+    color: var(--alias-muted);
+    font-size: 0.72rem;
+}
+
+.uplt-alias-api-link {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
+    margin-top: 0.85rem;
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.uplt-alias-categories {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(6.6rem, 1fr));
+    gap: 0.45rem;
+    margin: 0;
+    padding: 0.7rem;
+    border-top: 1px solid var(--alias-border);
+}
+
+.uplt-alias-categories button,
+.uplt-alias-filter button {
+    border: 1px solid var(--alias-border);
+    border-radius: 0.55rem;
+    background: var(--alias-panel);
+    color: var(--alias-ink);
+    cursor: pointer;
+    font: inherit;
+}
+
+.uplt-alias-categories button {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    min-height: 4.25rem;
+    padding: 0.55rem 0.6rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-align: left;
+}
+
+.uplt-alias-categories button span {
+    color: var(--alias-accent);
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.uplt-alias-categories button:hover,
+.uplt-alias-categories button:focus-visible,
+.uplt-alias-categories button.is-preview,
+.uplt-alias-categories button.is-active,
+.uplt-alias-filter button:hover,
+.uplt-alias-filter button:focus-visible {
+    border-color: var(--alias-accent);
+    background: color-mix(in srgb, var(--alias-accent) 9%, var(--alias-panel));
+    outline: none;
+}
+
+.uplt-alias-filter {
+    margin: 0 0.7rem 0.7rem;
+    padding: 0.75rem;
+    border: 1px solid var(--alias-border);
+    border-radius: 0.7rem;
+    background: var(--alias-soft);
+}
+
+.uplt-alias-filter label {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--alias-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.uplt-alias-filter > div {
+    display: flex;
+    gap: 0.45rem;
+}
+
+.uplt-alias-filter input {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0.48rem 0.62rem;
+    border: 1px solid var(--alias-border);
+    border-radius: 0.45rem;
+    background: var(--alias-panel);
+    color: var(--alias-ink);
+    font: inherit;
+    font-size: 0.84rem;
+}
+
+.uplt-alias-filter input:focus {
+    border-color: var(--alias-accent);
+    outline: 2px solid color-mix(in srgb, var(--alias-accent) 24%, transparent);
+    outline-offset: 1px;
+}
+
+.uplt-alias-filter button {
+    padding: 0.42rem 0.72rem;
+    font-size: 0.76rem;
+    font-weight: 700;
+}
+
+.uplt-alias-filter-status {
+    min-height: 1.2em;
+    margin: 0.4rem 0 0 !important;
+    color: var(--alias-muted);
+    font-size: 0.72rem;
+}
+
+.uplt-alias-table tbody tr.is-alias-match td {
+    background: color-mix(in srgb, var(--alias-accent) 8%, transparent);
+}
+
+@media (max-width: 1000px) {
+    .uplt-alias-map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .uplt-alias-detail {
+        border-top: 1px solid var(--alias-border);
+        border-left: 0;
+    }
+
+    .uplt-alias-preview {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        min-height: 0;
+    }
+
+    .uplt-alias-categories {
+        grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .uplt-alias-map {
+        padding: 0.2rem;
+        overflow: visible;
+    }
+
+    .uplt-alias-map svg {
+        min-width: 39rem;
+    }
+
+    .uplt-alias-categories {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .uplt-alias-preview {
+        grid-template-columns: 1fr;
+    }
+
+    .uplt-alias-filter > div {
+        align-items: stretch;
+        flex-direction: column;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .uplt-alias-explorer *,
+    .uplt-alias-explorer *::before,
+    .uplt-alias-explorer *::after {
+        scroll-behavior: auto !important;
+        transition: none !important;
+    }
+}
+    overflow: visible;

--- a/docs/_static/alias-explorer-v3.css
+++ b/docs/_static/alias-explorer-v3.css
@@ -1,73 +1,27 @@
 .uplt-alias-explorer {
-    --alias-ink: var(--uplt-color-text-main, #24323b);
-    --alias-muted: var(--uplt-color-text-secondary, #59656d);
-    --alias-panel: var(--uplt-color-panel-bg, #fff);
-    --alias-soft: var(--uplt-color-sidebar-bg, #f3f6f7);
-    --alias-border: var(--uplt-color-border-muted, #d9e1e5);
+    --alias-ink: var(--uplt-color-text-main, var(--sy-c-text, #24323b));
+    --alias-muted: var(--uplt-color-text-secondary, var(--sy-c-light, #59656d));
+    --alias-panel: var(--uplt-color-panel-bg, var(--sy-c-bg, #fff));
+    --alias-border: var(--uplt-color-border-muted, var(--sy-c-divider, #d9e1e5));
     --alias-accent: var(--uplt-color-accent, #0f766e);
-    --alias-blue: #3976d3;
     margin: 1.5rem 0 2.25rem;
     color: var(--alias-ink);
 }
 
-.uplt-alias-summary {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-    margin-bottom: 0.75rem;
-}
-
-.uplt-alias-summary span {
-    padding: 0.24rem 0.62rem;
-    border: 1px solid var(--alias-border);
-    border-radius: 999px;
-    background: var(--alias-soft);
-    color: var(--alias-muted);
-    font-size: 0.76rem;
-    letter-spacing: 0.015em;
-}
-
-.uplt-alias-summary strong {
-    color: var(--alias-accent);
-}
-
-.uplt-alias-map-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 3fr) minmax(14rem, 1fr);
-    align-items: stretch;
-    border: 1px solid var(--alias-border);
-    border-radius: 0.85rem;
-    overflow: visible;
-    background: var(--alias-panel);
-    box-shadow: 0 8px 30px var(--uplt-color-shadow, rgba(15, 23, 42, 0.08));
-}
-
-.uplt-alias-visual-column {
-    min-width: 0;
-    overflow: visible;
+.uplt-alias-explorer [hidden] {
+    display: none !important;
 }
 
 .uplt-alias-map {
-    position: relative;
-    z-index: 2;
     min-width: 0;
-    padding: 0.8rem;
-    overflow: visible;
-    background:
-        radial-gradient(circle at 38% 46%, rgba(57, 118, 211, 0.08), transparent 34%),
-        linear-gradient(145deg, var(--alias-soft), var(--alias-panel));
+    margin-bottom: 1.5rem;
+    overflow-x: auto;
 }
 
 .uplt-alias-map svg {
     display: block;
     width: 100%;
     height: auto;
-    min-height: 25rem;
-    overflow: visible;
-}
-
-.uplt-alias-real-figure {
-    filter: drop-shadow(0 3px 8px rgba(15, 23, 42, 0.12));
 }
 
 .uplt-alias-target {
@@ -75,30 +29,31 @@
     fill-opacity: 0;
     stroke: var(--alias-accent);
     stroke-opacity: 0;
-    stroke-width: 2.5;
+    stroke-width: 1.5;
     pointer-events: none;
 }
 
 .uplt-alias-target-line {
     fill: none;
-    stroke-width: 13;
+    stroke-width: 9;
 }
 
 .uplt-alias-target.is-preview,
 .uplt-alias-target.is-active {
-    fill-opacity: 0.13;
-    stroke-opacity: 0.9;
+    fill-opacity: 0.06;
+    stroke-opacity: 0.8;
 }
 
 .uplt-alias-target-line.is-preview,
 .uplt-alias-target-line.is-active {
-    stroke-opacity: 0.5;
+    stroke-opacity: 0.4;
 }
 
 .uplt-alias-wire {
     fill: none;
-    stroke: color-mix(in srgb, var(--callout-color) 72%, var(--alias-border));
-    stroke-width: 3;
+    stroke: color-mix(in srgb, var(--callout-color) 70%, var(--alias-ink));
+    stroke-opacity: 1;
+    stroke-width: 2.25;
     stroke-linecap: round;
     pointer-events: none;
     vector-effect: non-scaling-stroke;
@@ -111,32 +66,39 @@
     touch-action: none;
 }
 
-.uplt-alias-node[data-layout-key="titles"] {
-    --callout-color: #f472b6;
+.uplt-alias-node[data-layout-key="titles"],
+.uplt-alias-categories button[data-alias-color="titles"] {
+    --callout-color: #f05aa6;
 }
 
-.uplt-alias-node[data-layout-key="layout"] {
-    --callout-color: #a78bfa;
+.uplt-alias-node[data-layout-key="layout"],
+.uplt-alias-categories button[data-alias-color="layout"] {
+    --callout-color: #9b6dff;
 }
 
-.uplt-alias-node[data-layout-key="axes"] {
-    --callout-color: #60a5fa;
+.uplt-alias-node[data-layout-key="axes"],
+.uplt-alias-categories button[data-alias-color="axes"] {
+    --callout-color: #36a9f4;
 }
 
-.uplt-alias-node[data-layout-key="plot"] {
-    --callout-color: #34d399;
+.uplt-alias-node[data-layout-key="plot"],
+.uplt-alias-categories button[data-alias-color="plot"] {
+    --callout-color: #28bf91;
 }
 
-.uplt-alias-node[data-layout-key="legend"] {
-    --callout-color: #fbbf24;
+.uplt-alias-node[data-layout-key="legend"],
+.uplt-alias-categories button[data-alias-color="legend"] {
+    --callout-color: #f5b82e;
 }
 
-.uplt-alias-node[data-layout-key="colorbar"] {
-    --callout-color: #fb7185;
+.uplt-alias-node[data-layout-key="colorbar"],
+.uplt-alias-categories button[data-alias-color="colorbar"] {
+    --callout-color: #ff8750;
 }
 
-.uplt-alias-node[data-layout-key="style"] {
-    --callout-color: #c084fc;
+.uplt-alias-node[data-layout-key="style"],
+.uplt-alias-categories button[data-alias-color="style"] {
+    --callout-color: #31c6cb;
 }
 
 .uplt-alias-node.is-dragging {
@@ -144,295 +106,303 @@
 }
 
 .uplt-alias-node rect {
-    fill: color-mix(in srgb, var(--callout-color) 18%, var(--alias-panel));
-    stroke: color-mix(in srgb, var(--callout-color) 72%, var(--alias-border));
-    stroke-width: 2.25;
-    filter: drop-shadow(0 5px 9px color-mix(in srgb, var(--callout-color) 24%, transparent));
+    fill: color-mix(in srgb, var(--callout-color) 26%, var(--alias-panel));
+    stroke: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
 }
 
 .uplt-alias-node text {
     fill: var(--alias-ink);
-    font-family: ui-rounded, "Arial Rounded MT Bold", system-ui, sans-serif;
+    font-family: inherit;
     font-size: 16px;
-    font-weight: 700;
+    font-weight: 500;
     text-anchor: middle;
     pointer-events: none;
 }
 
 .uplt-alias-node:hover rect,
-.uplt-alias-node:focus-visible rect,
 .uplt-alias-node.is-preview rect,
 .uplt-alias-node.is-active rect {
-    fill: color-mix(in srgb, var(--callout-color) 30%, var(--alias-panel));
-    stroke: var(--callout-color);
-    stroke-width: 2.25;
+    fill: color-mix(in srgb, var(--callout-color) 38%, var(--alias-panel));
+    stroke: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+}
+
+.uplt-alias-node:focus-visible rect {
+    stroke: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+    stroke-width: 2.5;
 }
 
 .uplt-alias-node:hover .uplt-alias-wire,
 .uplt-alias-node:focus-visible .uplt-alias-wire,
 .uplt-alias-node.is-preview .uplt-alias-wire,
 .uplt-alias-node.is-active .uplt-alias-wire {
-    stroke: var(--callout-color);
+    stroke: color-mix(in srgb, var(--callout-color) 70%, var(--alias-ink));
+    stroke-opacity: 1;
     stroke-width: 3;
 }
 
-.uplt-alias-detail {
-    min-width: 0;
-    min-height: 0;
-    padding: 1rem 1.05rem;
-    border-left: 1px solid var(--alias-border);
-    background: var(--alias-panel);
-    overflow-y: auto;
-    overscroll-behavior: contain;
-    scrollbar-gutter: stable;
+.uplt-alias-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem 0;
+    border-block: 1px solid var(--alias-border);
 }
 
-.uplt-alias-detail-help {
-    margin: 0 0 0.75rem !important;
+.uplt-alias-categories button,
+.uplt-alias-filter button {
+    padding: 0.5rem 0;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    background: none;
     color: var(--alias-muted);
-    font-family: inherit;
-    font-size: 0.86rem;
-    font-weight: 400;
-    line-height: 1.45;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    text-align: left;
+}
+
+.uplt-alias-filter button:hover {
+    color: var(--alias-accent);
+    border-bottom-color: var(--alias-accent);
+}
+
+.uplt-alias-categories button:focus-visible,
+.uplt-alias-filter button:focus-visible,
+.uplt-alias-keyword-link:focus-visible,
+.uplt-alias-api-link:focus-visible {
+    outline: 2px solid var(--alias-accent);
+    outline-offset: 3px;
+}
+
+.uplt-alias-categories button {
+    --callout-color: var(--alias-muted);
+    padding: 0.35rem 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--callout-color) 26%, var(--alias-panel));
+    color: var(--alias-ink);
+}
+
+.uplt-alias-categories button:hover,
+.uplt-alias-categories button.is-preview,
+.uplt-alias-categories button.is-active {
+    background: color-mix(in srgb, var(--callout-color) 38%, var(--alias-panel));
+    border-color: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+    color: var(--alias-ink);
+}
+
+.uplt-alias-categories button.is-active {
+    box-shadow: inset 0 -2px color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+}
+
+.uplt-alias-categories button:focus-visible {
+    outline-color: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+}
+
+.uplt-alias-detail {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+    gap: 1rem 2rem;
+    padding: 1.75rem 0;
+    border-bottom: 1px solid var(--alias-border);
 }
 
 .uplt-alias-detail h3 {
-    margin: 0.1rem 0 0.3rem;
-    font-size: 1.25rem;
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
 }
 
-.uplt-alias-detail > p:not(.uplt-alias-detail-help) {
+.uplt-alias-detail-heading p {
     margin: 0 0 0.75rem;
     color: var(--alias-muted);
-    font-size: 0.86rem;
+    font-size: 0.85rem;
 }
 
 .uplt-alias-preview {
     display: grid;
-    gap: 0.38rem;
-    min-height: 9rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-content: start;
+    gap: 0.75rem 1.5rem;
 }
 
 .uplt-alias-pair {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) 1.6rem minmax(0, 1.35fr);
+    align-content: start;
     align-items: center;
-    gap: 0.38rem;
-    padding: 0.3rem 0.4rem;
-    border-radius: 0.35rem;
-    background: var(--alias-soft);
-}
-
-.uplt-alias-pair code {
-    overflow: hidden;
-    color: var(--alias-ink);
-    font-size: 0.72rem;
-    text-overflow: ellipsis;
+    gap: 0.3rem 0.55rem;
 }
 
 .uplt-alias-keyword-link {
     min-width: 0;
     border-bottom: 0 !important;
-    border-radius: 0.2rem;
     text-decoration: none !important;
 }
 
-.uplt-alias-keyword-link:hover,
-.uplt-alias-keyword-link:focus-visible {
-    background: color-mix(in srgb, var(--alias-accent) 13%, transparent);
-    outline: 2px solid color-mix(in srgb, var(--alias-accent) 35%, transparent);
-    outline-offset: 1px;
-    text-decoration: none !important;
+.uplt-alias-keyword-link:hover {
+    text-decoration: underline !important;
+    text-underline-offset: 3px;
 }
 
-.uplt-alias-table .uplt-alias-keyword-link {
-    display: inline-block;
-    padding: 0.08rem 0.16rem;
+.uplt-alias-pair code {
+    padding: 0;
+    background: none;
+    color: var(--alias-ink);
+    font-size: 0.8rem;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.uplt-alias-pair > :first-child {
+    text-align: right;
+}
+
+.uplt-alias-arrow {
+    position: relative;
+    display: block;
+    height: 1rem;
+    color: var(--alias-muted);
+}
+
+.uplt-alias-arrow::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 1px;
+    border-top: 1.5px solid currentColor;
+    transform: translateY(-50%);
+}
+
+.uplt-alias-arrow::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    right: 1px;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-top: 1.5px solid currentColor;
+    border-right: 1.5px solid currentColor;
+    transform: translateY(-50%) rotate(45deg);
+}
+
+.uplt-alias-pair small {
+    grid-column: 1 / -1;
+    color: var(--alias-muted);
+    font-size: 0.72rem;
+    overflow-wrap: anywhere;
+}
+
+.uplt-alias-more {
+    grid-column: 1 / -1;
+    margin: 0.25rem 0 0 !important;
+    color: var(--alias-muted);
+    font-size: 0.8rem;
+}
+
+.uplt-alias-api-link {
+    font-size: 0.85rem;
 }
 
 .uplt-alias-table .uplt-alias-keyword-link code {
     color: inherit;
 }
 
-.uplt-alias-pair span {
-    color: var(--alias-accent);
-}
-
-.uplt-alias-pair small {
-    grid-column: 1 / -1;
-    color: var(--alias-muted);
-    font-size: 0.62rem;
-}
-
-.uplt-alias-more {
-    margin: 0.2rem 0 0 !important;
-    color: var(--alias-muted);
-    font-size: 0.72rem;
-}
-
-.uplt-alias-api-link {
-    display: inline-flex;
-    gap: 0.35rem;
-    align-items: center;
-    margin-top: 0.85rem;
-    font-size: 0.82rem;
-    font-weight: 700;
-}
-
-.uplt-alias-categories {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(6.6rem, 1fr));
-    gap: 0.45rem;
-    margin: 0;
-    padding: 0.7rem;
-    border-top: 1px solid var(--alias-border);
-}
-
-.uplt-alias-categories button,
-.uplt-alias-filter button {
-    border: 1px solid var(--alias-border);
-    border-radius: 0.55rem;
-    background: var(--alias-panel);
-    color: var(--alias-ink);
-    cursor: pointer;
-    font: inherit;
-}
-
-.uplt-alias-categories button {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: space-between;
-    min-height: 4.25rem;
-    padding: 0.55rem 0.6rem;
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-align: left;
-}
-
-.uplt-alias-categories button span {
-    color: var(--alias-accent);
-    font-size: 1.25rem;
-    line-height: 1;
-}
-
-.uplt-alias-categories button:hover,
-.uplt-alias-categories button:focus-visible,
-.uplt-alias-categories button.is-preview,
-.uplt-alias-categories button.is-active,
-.uplt-alias-filter button:hover,
-.uplt-alias-filter button:focus-visible {
-    border-color: var(--alias-accent);
-    background: color-mix(in srgb, var(--alias-accent) 9%, var(--alias-panel));
-    outline: none;
-}
-
 .uplt-alias-filter {
-    margin: 0 0.7rem 0.7rem;
-    padding: 0.75rem;
-    border: 1px solid var(--alias-border);
-    border-radius: 0.7rem;
-    background: var(--alias-soft);
+    margin-top: 2rem;
 }
 
 .uplt-alias-filter label {
     display: block;
-    margin-bottom: 0.35rem;
-    color: var(--alias-muted);
-    font-size: 0.75rem;
-    font-weight: 700;
+    margin-bottom: 0.6rem;
+    font-size: 1rem;
+    font-weight: 600;
 }
 
-.uplt-alias-filter > div {
+.uplt-alias-search-row {
     display: flex;
-    gap: 0.45rem;
+    align-items: center;
+    gap: 1.25rem;
 }
 
 .uplt-alias-filter input {
     flex: 1 1 auto;
     min-width: 0;
-    padding: 0.48rem 0.62rem;
+    max-width: 32rem;
+    padding: 0.6rem 0.75rem;
     border: 1px solid var(--alias-border);
-    border-radius: 0.45rem;
+    border-radius: 3px;
     background: var(--alias-panel);
     color: var(--alias-ink);
     font: inherit;
-    font-size: 0.84rem;
+    font-size: 0.9rem;
 }
 
-.uplt-alias-filter input:focus {
+.uplt-alias-filter input:focus-visible {
     border-color: var(--alias-accent);
-    outline: 2px solid color-mix(in srgb, var(--alias-accent) 24%, transparent);
-    outline-offset: 1px;
-}
-
-.uplt-alias-filter button {
-    padding: 0.42rem 0.72rem;
-    font-size: 0.76rem;
-    font-weight: 700;
+    outline: 2px solid var(--alias-accent);
+    outline-offset: 2px;
 }
 
 .uplt-alias-filter-status {
-    min-height: 1.2em;
-    margin: 0.4rem 0 0 !important;
+    margin: 0.5rem 0 0 !important;
     color: var(--alias-muted);
-    font-size: 0.72rem;
+    font-size: 0.8rem;
 }
 
 .uplt-alias-table tbody tr.is-alias-match td {
-    background: color-mix(in srgb, var(--alias-accent) 8%, transparent);
+    background: color-mix(in srgb, var(--alias-accent) 6%, transparent);
 }
 
-@media (max-width: 1000px) {
-    .uplt-alias-map-layout {
+@media (max-width: 800px) {
+    .uplt-alias-categories button {
+    --callout-color: var(--alias-muted);
+    padding: 0.35rem 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--callout-color) 26%, var(--alias-panel));
+    color: var(--alias-ink);
+}
+
+.uplt-alias-categories button:hover,
+.uplt-alias-categories button.is-preview,
+.uplt-alias-categories button.is-active {
+    background: color-mix(in srgb, var(--callout-color) 38%, var(--alias-panel));
+    border-color: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+    color: var(--alias-ink);
+}
+
+.uplt-alias-categories button.is-active {
+    box-shadow: inset 0 -2px color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+}
+
+.uplt-alias-categories button:focus-visible {
+    outline-color: color-mix(in srgb, var(--callout-color) 75%, var(--alias-ink));
+}
+
+.uplt-alias-detail {
         grid-template-columns: 1fr;
-    }
-
-    .uplt-alias-detail {
-        border-top: 1px solid var(--alias-border);
-        border-left: 0;
-    }
-
-    .uplt-alias-preview {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        min-height: 0;
-    }
-
-    .uplt-alias-categories {
-        grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
     }
 }
 
 @media (max-width: 640px) {
-    .uplt-alias-map {
-        padding: 0.2rem;
-        overflow: visible;
-    }
-
     .uplt-alias-map svg {
-        min-width: 39rem;
-    }
-
-    .uplt-alias-categories {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        min-width: 36rem;
     }
 
     .uplt-alias-preview {
         grid-template-columns: 1fr;
     }
 
-    .uplt-alias-filter > div {
-        align-items: stretch;
-        flex-direction: column;
+    .uplt-alias-search-row {
+        gap: 0.75rem;
     }
-}
 
-@media (prefers-reduced-motion: reduce) {
-    .uplt-alias-explorer *,
-    .uplt-alias-explorer *::before,
-    .uplt-alias-explorer *::after {
-        scroll-behavior: auto !important;
-        transition: none !important;
+    .uplt-alias-filter button {
+        flex-shrink: 0;
     }
 }
-    overflow: visible;

--- a/docs/_static/alias-explorer-v3.js
+++ b/docs/_static/alias-explorer-v3.js
@@ -1,0 +1,482 @@
+(function () {
+  "use strict";
+
+  const apiTargets = {
+    "figure.init": "api/ultraplot.figure.Figure.html#ultraplot.figure.Figure",
+    "figure.format": "api/ultraplot.figure.Figure.html#ultraplot.figure.Figure.format",
+    "axes.format": "api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.format",
+    "cartesian.format": "api/ultraplot.axes.CartesianAxes.html#ultraplot.axes.CartesianAxes.format",
+    "geo.format": "api/ultraplot.axes.GeoAxes.html#ultraplot.axes.GeoAxes.format",
+    "polar.format": "api/ultraplot.axes.PolarAxes.html#ultraplot.axes.PolarAxes.format",
+    "taylor.format": "api/ultraplot.axes.TaylorAxes.html#ultraplot.axes.TaylorAxes.format",
+    colorbar: "api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.colorbar",
+    legend: "api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.legend",
+    gridspec: "api/ultraplot.gridspec.GridSpec.html#ultraplot.gridspec.GridSpec",
+    subplot: "api/ultraplot.ui.subplots.html#ultraplot.ui.subplots",
+    inset: "api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.inset",
+    cycle: "api/ultraplot.constructor.Cycle.html#ultraplot.constructor.Cycle",
+    projection: "api/ultraplot.constructor.Proj.html#ultraplot.constructor.Proj",
+    "scale.log": "api/ultraplot.scale.LogScale.html#ultraplot.scale.LogScale",
+    "scale.symlog": "api/ultraplot.scale.SymmetricalLogScale.html#ultraplot.scale.SymmetricalLogScale",
+    "plot.labels": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes",
+    "plot.text": "api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.text",
+    "plot.contour_labels": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.contour",
+    "plot.error_bars": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.plot",
+    "plot.error_shading": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.plot",
+    "plot.colormap": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.contour",
+    "plot.levels": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.contour",
+    "plot.stacked": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.bar",
+    "plot.statistics": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.boxplot",
+    "plot.boxplot": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.boxplot",
+    "plot.violinplot": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.violinplot",
+    "plot.hist": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.hist",
+    "plot.pie": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.pie",
+    "style.rgba": "api.html#colormaps-and-normalizers",
+    "style.hsla": "api.html#colormaps-and-normalizers",
+    "style.patch": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.bar",
+    "style.line": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.plot",
+    "style.collection": "api/ultraplot.axes.PlotAxes.html#ultraplot.axes.PlotAxes.scatter",
+    "style.text": "api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.text",
+    "rc (dotless)": "api/ultraplot.config.Configurator.html#ultraplot.config.Configurator",
+  };
+
+  function splitContexts(value) {
+    return String(value || "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  function contextMatches(context, pattern) {
+    if (pattern.endsWith(".*")) {
+      return context.startsWith(pattern.slice(0, -1));
+    }
+    return context === pattern;
+  }
+
+  function rowMatchesContexts(row, patterns) {
+    return (
+      !patterns.length ||
+      patterns.some((pattern) => contextMatches(row.context, pattern))
+    );
+  }
+
+  function makeCode(value) {
+    const code = document.createElement("code");
+    code.textContent = value;
+    return code;
+  }
+
+  function highlightedApiUrl(context, canonical) {
+    const target = apiTargets[context];
+    if (!target) return "";
+    const hashIndex = target.indexOf("#");
+    const base = hashIndex === -1 ? target : target.slice(0, hashIndex);
+    const hash = hashIndex === -1 ? "" : target.slice(hashIndex);
+    const joiner = base.includes("?") ? "&" : "?";
+    return `${base}${joiner}highlight=${encodeURIComponent(canonical)}${hash}`;
+  }
+
+  function makeKeywordLink(row, value) {
+    const target = highlightedApiUrl(row.context, row.canonical);
+    if (!target) return makeCode(value);
+    const link = document.createElement("a");
+    link.className = "uplt-alias-keyword-link";
+    link.href = target;
+    link.title = `Open the canonical API documentation for ${row.canonical}`;
+    link.appendChild(makeCode(value));
+    return link;
+  }
+
+  function initializeAliasExplorer(root) {
+    const sectionIds = [
+      "function-keyword-aliases",
+      "artist-property-aliases",
+      "dotless-rc-aliases",
+    ];
+    const sections = sectionIds
+      .map((id) => document.getElementById(id))
+      .filter(Boolean);
+    const rows = [];
+
+    sections.forEach((section) => {
+      const table = section.querySelector("table");
+      if (!table) return;
+      table.classList.add("uplt-alias-table");
+      Array.from(table.querySelectorAll("tbody tr")).forEach((element) => {
+        const cells = Array.from(element.querySelectorAll("td"));
+        if (cells.length < 3) return;
+        const row = {
+          element,
+          context: cells[0].textContent.trim(),
+          accepted: cells[1].textContent.trim(),
+          canonical: cells[2].textContent.trim(),
+        };
+        element.dataset.aliasContext = row.context;
+        rows.push(row);
+      });
+    });
+
+    if (!rows.length) return;
+
+    const contextCount = new Set(rows.map((row) => row.context)).size;
+    const totalNode = root.querySelector("[data-alias-total]");
+    const contextTotalNode = root.querySelector("[data-alias-context-total]");
+    const titleNode = root.querySelector("[data-alias-detail-title]");
+    const copyNode = root.querySelector("[data-alias-detail-copy]");
+    const previewNode = root.querySelector("[data-alias-preview]");
+    const apiNode = root.querySelector("[data-alias-api]");
+    const searchNode = root.querySelector("#uplt-alias-search");
+    const resetNode = root.querySelector("[data-alias-reset]");
+    const statusNode = root.querySelector("[data-alias-filter-status]");
+    const controls = Array.from(
+      root.querySelectorAll("[data-contexts][data-label]"),
+    );
+    const targets = Array.from(root.querySelectorAll("[data-alias-target]"));
+    const svg = root.querySelector(".uplt-alias-map svg");
+    const draggableNodes = Array.from(
+      root.querySelectorAll(".uplt-alias-node[data-layout-key]"),
+    );
+    const suppressedClicks = new WeakSet();
+
+    function svgPoint(event) {
+      const point = svg.createSVGPoint();
+      point.x = event.clientX;
+      point.y = event.clientY;
+      return point.matrixTransform(svg.getScreenCTM().inverse());
+    }
+
+    function nodePosition(node) {
+      const match = /translate\(\s*([-+\d.]+)[ ,]+([-+\d.]+)\s*\)/.exec(
+        node.getAttribute("transform") || "",
+      );
+      return {
+        x: match ? Number(match[1]) : 0,
+        y: match ? Number(match[2]) : 0,
+      };
+    }
+
+    function updateLeader(node, x, y) {
+      const rect = node.querySelector("rect");
+      const wire = node.querySelector(".uplt-alias-wire");
+      if (!rect || !wire) return;
+      const width = Number(rect.getAttribute("width"));
+      const height = Number(rect.getAttribute("height"));
+      const targetX = Number(node.dataset.anchorX);
+      const targetY = Number(node.dataset.anchorY);
+      const centerX = x + width / 2;
+      const centerY = y + height / 2;
+      const dx = targetX - centerX;
+      const dy = targetY - centerY;
+      if (!dx && !dy) {
+        wire.setAttribute("d", "");
+        return;
+      }
+      const factor = Math.min(
+        dx ? width / 2 / Math.abs(dx) : Infinity,
+        dy ? height / 2 / Math.abs(dy) : Infinity,
+      );
+      const length = Math.hypot(dx, dy) || 1;
+      const overlap = 3;
+      const startX = centerX + dx * factor - (dx / length) * overlap;
+      const startY = centerY + dy * factor - (dy / length) * overlap;
+      wire.setAttribute(
+        "d",
+        `M${(startX - x).toFixed(1)} ${(startY - y).toFixed(1)} ` +
+          `L${(targetX - x).toFixed(1)} ${(targetY - y).toFixed(1)}`,
+      );
+    }
+
+    function setNodePosition(node, x, y) {
+      node.setAttribute("transform", `translate(${x.toFixed(1)} ${y.toFixed(1)})`);
+      updateLeader(node, x, y);
+    }
+
+    function layoutSnapshot() {
+      return Object.fromEntries(
+        draggableNodes.map((node) => {
+          const position = nodePosition(node);
+          return [
+            node.dataset.layoutKey,
+            [Number(position.x.toFixed(1)), Number(position.y.toFixed(1))],
+          ];
+        }),
+      );
+    }
+
+    function saveDraftLayout() {
+      fetch("/__alias_layout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: 1, nodes: layoutSnapshot() }),
+      }).catch(() => {});
+    }
+
+    function restoreDraftLayout() {
+      fetch("/__alias_layout")
+        .then((response) => (response.ok ? response.json() : null))
+        .then((draft) => {
+          if (!draft || !draft.nodes) return;
+          draggableNodes.forEach((node) => {
+            const position = draft.nodes[node.dataset.layoutKey];
+            if (
+              Array.isArray(position) &&
+              position.length === 2 &&
+              position.every(Number.isFinite)
+            ) {
+              setNodePosition(node, position[0], position[1]);
+            }
+          });
+        })
+        .catch(() => {});
+    }
+
+    draggableNodes.forEach((node) => {
+      const rect = node.querySelector("rect");
+      const width = Number(rect.getAttribute("width"));
+      const height = Number(rect.getAttribute("height"));
+      let drag = null;
+
+      updateLeader(node, nodePosition(node).x, nodePosition(node).y);
+      node.addEventListener("pointerdown", (event) => {
+        if (event.button !== 0) return;
+        const point = svgPoint(event);
+        const position = nodePosition(node);
+        drag = {
+          pointerId: event.pointerId,
+          offsetX: point.x - position.x,
+          offsetY: point.y - position.y,
+          originX: point.x,
+          originY: point.y,
+          moved: false,
+        };
+        node.setPointerCapture(event.pointerId);
+        node.classList.add("is-dragging");
+        event.preventDefault();
+      });
+      node.addEventListener("pointermove", (event) => {
+        if (!drag || event.pointerId !== drag.pointerId) return;
+        const point = svgPoint(event);
+        drag.moved ||= Math.hypot(
+          point.x - drag.originX,
+          point.y - drag.originY,
+        ) > 2;
+        const viewBox = svg.viewBox.baseVal;
+        const grip = 16;
+        const x = Math.max(
+          viewBox.x + grip - width,
+          Math.min(viewBox.x + viewBox.width - grip, point.x - drag.offsetX),
+        );
+        const y = Math.max(
+          viewBox.y + grip - height,
+          Math.min(viewBox.y + viewBox.height - grip, point.y - drag.offsetY),
+        );
+        setNodePosition(node, x, y);
+      });
+      node.addEventListener("pointerup", (event) => {
+        if (!drag || event.pointerId !== drag.pointerId) return;
+        if (drag.moved) {
+          suppressedClicks.add(node);
+          saveDraftLayout();
+        }
+        node.classList.remove("is-dragging");
+        node.releasePointerCapture(event.pointerId);
+        drag = null;
+      });
+      node.addEventListener("pointercancel", () => {
+        node.classList.remove("is-dragging");
+        drag = null;
+      });
+    });
+
+    restoreDraftLayout();
+
+    rows.forEach((row) => {
+      const cells = Array.from(row.element.querySelectorAll("td"));
+      cells[1].replaceChildren(makeKeywordLink(row, row.accepted));
+      cells[2].replaceChildren(makeKeywordLink(row, row.canonical));
+    });
+
+    totalNode.textContent = rows.length.toLocaleString();
+    contextTotalNode.textContent = contextCount.toLocaleString();
+
+    let selected = {
+      patterns: [],
+      targets: [],
+      label: "All aliases",
+      api: "",
+    };
+
+    function getRows(patterns) {
+      return rows.filter((row) => rowMatchesContexts(row, patterns));
+    }
+
+    function renderDetail(state, temporary) {
+      const matches = getRows(state.patterns);
+      titleNode.textContent = state.label;
+      copyNode.textContent = matches.length
+        ? `${matches.length.toLocaleString()} accepted ${
+            matches.length === 1 ? "spelling" : "spellings"
+          } in this area${temporary ? " — click to keep this view" : ""}.`
+        : "No compatibility aliases are registered for this area.";
+      previewNode.replaceChildren();
+
+      matches.slice(0, 8).forEach((row) => {
+        const item = document.createElement("div");
+        item.className = "uplt-alias-pair";
+        item.appendChild(makeKeywordLink(row, row.accepted));
+        const arrow = document.createElement("span");
+        arrow.setAttribute("aria-hidden", "true");
+        arrow.textContent = "→";
+        item.appendChild(arrow);
+        item.appendChild(makeKeywordLink(row, row.canonical));
+        const context = document.createElement("small");
+        context.textContent = row.context;
+        item.appendChild(context);
+        previewNode.appendChild(item);
+      });
+
+      if (matches.length > 8) {
+        const more = document.createElement("p");
+        more.className = "uplt-alias-more";
+        more.textContent = `+ ${(matches.length - 8).toLocaleString()} more below`;
+        previewNode.appendChild(more);
+      }
+
+      if (state.api) {
+        apiNode.href = state.api;
+        apiNode.hidden = false;
+      } else {
+        apiNode.removeAttribute("href");
+        apiNode.hidden = true;
+      }
+
+      targets.forEach((target) => {
+        const name = target.dataset.aliasTarget;
+        target.classList.toggle("is-active", selected.targets.includes(name));
+        target.classList.toggle(
+          "is-preview",
+          temporary && state.targets.includes(name),
+        );
+      });
+    }
+
+    function updateControlState() {
+      controls.forEach((control) => {
+        const patterns = splitContexts(control.dataset.contexts);
+        const active =
+          selected.patterns.length > 0 &&
+          patterns.some((pattern) =>
+            getRows(selected.patterns).some((row) =>
+              contextMatches(row.context, pattern),
+            ),
+          );
+        control.classList.toggle("is-active", active);
+        control.setAttribute("aria-pressed", active ? "true" : "false");
+      });
+    }
+
+    function applyFilter() {
+      const query = searchNode.value.trim().toLowerCase();
+      let visible = 0;
+      rows.forEach((row) => {
+        const inArea = rowMatchesContexts(row, selected.patterns);
+        const inSearch =
+          !query ||
+          `${row.context} ${row.accepted} ${row.canonical}`
+            .toLowerCase()
+            .includes(query);
+        const show = inArea && inSearch;
+        row.element.hidden = !show;
+        row.element.classList.toggle("is-alias-match", show && Boolean(query));
+        if (show) visible += 1;
+      });
+
+      sections.forEach((section) => {
+        section.hidden = !section.querySelector("tbody tr:not([hidden])");
+      });
+
+      const area = selected.patterns.length ? ` · ${selected.label}` : "";
+      statusNode.textContent = `${visible.toLocaleString()} of ${rows.length.toLocaleString()} mappings shown${area}`;
+      root.classList.toggle("has-filter", Boolean(query || selected.patterns.length));
+      updateControlState();
+    }
+
+    function stateForControl(control) {
+      return {
+        patterns: splitContexts(control.dataset.contexts),
+        targets: splitContexts(control.dataset.targets),
+        label: control.dataset.label,
+        api: control.dataset.api || "",
+      };
+    }
+
+    function previewControl(control) {
+      control.classList.add("is-preview");
+      renderDetail(stateForControl(control), true);
+    }
+
+    function stopPreview(control) {
+      control.classList.remove("is-preview");
+      renderDetail(selected, false);
+    }
+
+    function selectControl(control) {
+      const next = stateForControl(control);
+      const same =
+        next.patterns.join("|") === selected.patterns.join("|");
+      selected = same
+        ? { patterns: [], targets: [], label: "All aliases", api: "" }
+        : next;
+      renderDetail(selected, false);
+      applyFilter();
+    }
+
+    controls.forEach((control) => {
+      control.addEventListener("pointerenter", () => previewControl(control));
+      control.addEventListener("pointerleave", () => stopPreview(control));
+      control.addEventListener("focus", () => previewControl(control));
+      control.addEventListener("blur", () => stopPreview(control));
+      control.addEventListener("click", (event) => {
+        if (suppressedClicks.has(control)) {
+          suppressedClicks.delete(control);
+          event.preventDefault();
+          return;
+        }
+        selectControl(control);
+      });
+      if (control.tagName.toLowerCase() !== "button") {
+        control.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            selectControl(control);
+          }
+        });
+      }
+    });
+
+    searchNode.addEventListener("input", applyFilter);
+    resetNode.addEventListener("click", () => {
+      selected = {
+        patterns: [],
+        targets: [],
+        label: "All aliases",
+        api: "",
+      };
+      searchNode.value = "";
+      renderDetail(selected, false);
+      applyFilter();
+      searchNode.focus();
+    });
+
+    renderDetail(selected, false);
+    applyFilter();
+    root.dataset.aliasExplorerReady = "true";
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document
+      .querySelectorAll(".uplt-alias-explorer")
+      .forEach(initializeAliasExplorer);
+  });
+})();

--- a/docs/_static/alias-explorer-v3.js
+++ b/docs/_static/alias-explorer-v3.js
@@ -119,9 +119,6 @@
 
     if (!rows.length) return;
 
-    const contextCount = new Set(rows.map((row) => row.context)).size;
-    const totalNode = root.querySelector("[data-alias-total]");
-    const contextTotalNode = root.querySelector("[data-alias-context-total]");
     const titleNode = root.querySelector("[data-alias-detail-title]");
     const copyNode = root.querySelector("[data-alias-detail-copy]");
     const previewNode = root.querySelector("[data-alias-preview]");
@@ -297,9 +294,6 @@
       cells[2].replaceChildren(makeKeywordLink(row, row.canonical));
     });
 
-    totalNode.textContent = rows.length.toLocaleString();
-    contextTotalNode.textContent = contextCount.toLocaleString();
-
     let selected = {
       patterns: [],
       targets: [],
@@ -317,17 +311,17 @@
       copyNode.textContent = matches.length
         ? `${matches.length.toLocaleString()} accepted ${
             matches.length === 1 ? "spelling" : "spellings"
-          } in this area${temporary ? " — click to keep this view" : ""}.`
+          }${temporary ? ". Select to keep this view." : "."}`
         : "No compatibility aliases are registered for this area.";
       previewNode.replaceChildren();
 
-      matches.slice(0, 8).forEach((row) => {
+      matches.slice(0, 6).forEach((row) => {
         const item = document.createElement("div");
         item.className = "uplt-alias-pair";
         item.appendChild(makeKeywordLink(row, row.accepted));
         const arrow = document.createElement("span");
         arrow.setAttribute("aria-hidden", "true");
-        arrow.textContent = "→";
+        arrow.className = "uplt-alias-arrow";
         item.appendChild(arrow);
         item.appendChild(makeKeywordLink(row, row.canonical));
         const context = document.createElement("small");
@@ -336,10 +330,10 @@
         previewNode.appendChild(item);
       });
 
-      if (matches.length > 8) {
+      if (matches.length > 6) {
         const more = document.createElement("p");
         more.className = "uplt-alias-more";
-        more.textContent = `+ ${(matches.length - 8).toLocaleString()} more below`;
+        more.textContent = `+ ${(matches.length - 6).toLocaleString()} more below`;
         previewNode.appendChild(more);
       }
 

--- a/docs/_static/alias-map.svg
+++ b/docs/_static/alias-map.svg
@@ -1,0 +1,3505 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="469.44pt" height="278.64pt" viewBox="0 0 469.44 278.64" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 278.64
+L 469.44 278.64
+L 469.44 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 64.33 243.48
+L 395.86 243.48
+L 395.86 34.44
+L 64.33 34.44
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 64.33 243.48
+L 64.33 34.44
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m398e1269bb" d="M 0 0
+L 0 4
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m398e1269bb" x="64.33" y="243.48" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(61.550312 256.770625) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-30" d="M 275 2221
+C 275 691 787 -96 1760 -96
+C 2720 -96 3245 691 3245 2182
+C 3245 3757 2746 4538 1760 4538
+C 781 4538 275 3744 275 2221
+z
+M 851 2214
+C 851 3456 1152 4038 1760 4038
+C 2368 4038 2669 3450 2669 2234
+C 2669 947 2374 371 1747 371
+C 1152 371 851 973 851 2214
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 130.636 243.48
+L 130.636 34.44
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m398e1269bb" x="130.636" y="243.48" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(127.856312 256.770625) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-32" d="M 218 0
+L 3238 0
+L 3238 557
+L 851 557
+C 909 928 1114 1165 1670 1491
+L 2310 1837
+C 2944 2176 3270 2650 3270 3206
+C 3270 3974 2675 4538 1818 4538
+C 890 4538 352 4064 320 2963
+L 883 2963
+C 928 3725 1242 4045 1798 4045
+C 2310 4045 2694 3680 2694 3194
+C 2694 2835 2483 2528 2080 2298
+L 1491 1965
+C 544 1427 269 998 218 0
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 196.942 243.48
+L 196.942 34.44
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m398e1269bb" x="196.942" y="243.48" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(194.162312 256.770625) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-34" d="M 179 1088
+L 2093 1088
+L 2093 0
+L 2656 0
+L 2656 1088
+L 3328 1088
+L 3328 1594
+L 2656 1594
+L 2656 4538
+L 2240 4538
+L 179 1683
+L 179 1088
+z
+M 672 1594
+L 2093 3578
+L 2093 1594
+L 672 1594
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 263.248 243.48
+L 263.248 34.44
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m398e1269bb" x="263.248" y="243.48" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 6 -->
+      <g transform="translate(260.468312 256.770625) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-36" d="M 275 2067
+C 275 653 762 -96 1798 -96
+C 2662 -96 3283 518 3283 1408
+C 3283 2253 2707 2822 1894 2822
+C 1446 2822 1094 2650 851 2317
+C 858 3424 1216 4038 1862 4038
+C 2259 4038 2534 3789 2624 3354
+L 3187 3354
+C 3078 4096 2592 4538 1901 4538
+C 845 4538 275 3648 275 2067
+z
+M 883 1395
+C 883 1958 1267 2323 1824 2323
+C 2368 2323 2707 1971 2707 1363
+C 2707 794 2323 403 1805 403
+C 1280 403 883 813 883 1395
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 329.554 243.48
+L 329.554 34.44
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m398e1269bb" x="329.554" y="243.48" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 8 -->
+      <g transform="translate(326.774312 256.770625) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-38" d="M 237 1286
+C 237 454 864 -96 1760 -96
+C 2656 -96 3283 454 3283 1280
+C 3283 1786 3027 2138 2502 2387
+C 2970 2669 3123 2899 3123 3328
+C 3123 4038 2566 4538 1760 4538
+C 960 4538 397 4038 397 3328
+C 397 2906 550 2675 1011 2387
+C 493 2138 237 1786 237 1286
+z
+M 813 1274
+C 813 1805 1197 2138 1760 2138
+C 2323 2138 2707 1805 2707 1274
+C 2707 736 2323 403 1747 403
+C 1197 403 813 742 813 1274
+z
+M 973 3322
+C 973 3757 1286 4038 1760 4038
+C 2240 4038 2547 3757 2547 3315
+C 2547 2893 2234 2611 1760 2611
+C 1286 2611 973 2893 973 3322
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 395.86 243.48
+L 395.86 34.44
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m398e1269bb" x="395.86" y="243.48" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 10 -->
+      <g transform="translate(390.300625 256.770625) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-31" d="M 653 3232
+L 1658 3232
+L 1658 0
+L 2221 0
+L 2221 4538
+L 1850 4538
+C 1651 3840 1523 3744 653 3635
+L 653 3232
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-31"/>
+       <use xlink:href="#TeXGyreHeros-Regular-30" transform="translate(55.599991 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <defs>
+       <path id="m87c731c3f8" d="M 0 0
+L 0 2
+" style="stroke: #000000; stroke-width: 0.48"/>
+      </defs>
+      <g>
+       <use xlink:href="#m87c731c3f8" x="80.9065" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="97.483" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="114.0595" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="147.2125" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="163.789" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="180.3655" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="213.5185" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="230.095" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="246.6715" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="279.8245" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="296.401" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="312.9775" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="346.1305" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="362.707" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m87c731c3f8" x="379.2835" y="243.48" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!--   -->
+     <g transform="translate(228.705156 270.240937) scale(0.1 -0.1)">
+      <defs>
+       <path id="TeXGyreHeros-Regular-20" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#TeXGyreHeros-Regular-20"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_28">
+      <path d="M 64.33 225.193941
+L 395.86 225.193941
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <defs>
+       <path id="m8716649d8c" d="M 0 0
+L -4 0
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8716649d8c" x="64.33" y="225.193941" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(52.770625 228.839254) scale(0.1 -0.1)">
+       <use xlink:href="#TeXGyreHeros-Regular-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_30">
+      <path d="M 64.33 168.815634
+L 395.86 168.815634
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m8716649d8c" x="64.33" y="168.815634" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.25 -->
+      <g transform="translate(38.872187 172.460946) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-2e" d="M 557 0
+L 1222 0
+L 1222 666
+L 557 666
+L 557 0
+z
+" transform="scale(0.015625)"/>
+        <path id="TeXGyreHeros-Regular-35" d="M 224 1165
+C 410 262 922 -96 1728 -96
+C 2643 -96 3283 544 3283 1504
+C 3283 2400 2688 2989 1818 2989
+C 1498 2989 1242 2906 979 2714
+L 1158 3885
+L 3046 3885
+L 3046 4442
+L 704 4442
+L 365 2067
+L 883 2067
+C 1146 2381 1363 2490 1715 2490
+C 2323 2490 2707 2099 2707 1427
+C 2707 774 2330 403 1715 403
+C 1222 403 922 653 787 1165
+L 224 1165
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-30"/>
+       <use xlink:href="#TeXGyreHeros-Regular-2e" transform="translate(55.599991 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-32" transform="translate(83.399979 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-35" transform="translate(138.999969 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_32">
+      <path d="M 64.33 112.437326
+L 395.86 112.437326
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m8716649d8c" x="64.33" y="112.437326" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.5 -->
+      <g transform="translate(44.431562 116.082638) scale(0.1 -0.1)">
+       <use xlink:href="#TeXGyreHeros-Regular-30"/>
+       <use xlink:href="#TeXGyreHeros-Regular-2e" transform="translate(55.599991 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-35" transform="translate(83.399979 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_34">
+      <path d="M 64.33 56.059018
+L 395.86 56.059018
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #000000; stroke-opacity: 0.18; stroke-width: 0.6; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m8716649d8c" x="64.33" y="56.059018" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.75 -->
+      <g transform="translate(38.872187 59.704331) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-37" d="M 294 3885
+L 2746 3885
+C 1843 2746 1203 1421 883 0
+L 1485 0
+C 1734 1466 2374 2835 3328 3968
+L 3328 4442
+L 294 4442
+L 294 3885
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-30"/>
+       <use xlink:href="#TeXGyreHeros-Regular-2e" transform="translate(55.599991 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-37" transform="translate(83.399979 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-35" transform="translate(138.999969 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_36">
+      <defs>
+       <path id="ma8a9766b95" d="M 0 0
+L -2 0
+" style="stroke: #000000; stroke-width: 0.48"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="236.469603" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="213.91828" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="202.642618" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="191.366957" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="180.091295" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="157.539972" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="146.264311" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="134.988649" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="123.712988" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="101.161664" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="89.886003" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="78.610341" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="67.33468" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#ma8a9766b95" x="64.33" y="44.783357" style="stroke: #000000; stroke-width: 0.48"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_12">
+     <!--   -->
+     <g transform="translate(12.9725 140.349844) rotate(-90) scale(0.1 -0.1)">
+      <use xlink:href="#TeXGyreHeros-Regular-20"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_50">
+    <path d="M 64.33 225.193941
+L 67.678788 215.235529
+L 71.027576 205.389847
+L 74.376364 195.768109
+L 77.725152 186.478507
+L 81.073939 177.624759
+L 84.422727 169.304706
+L 87.771515 161.608998
+L 91.120303 154.619868
+L 94.469091 148.410026
+L 97.817879 143.041679
+L 101.166667 138.565693
+L 104.515455 135.020903
+L 107.864242 132.433596
+L 111.21303 130.817154
+L 114.561818 130.171871
+L 117.910606 130.484953
+L 121.259394 131.730688
+L 124.608182 133.870795
+L 127.95697 136.854936
+L 131.305758 140.621398
+L 134.654545 145.097924
+L 138.003333 150.202685
+L 141.352121 155.845387
+L 144.700909 161.928483
+L 148.049697 168.348492
+L 151.398485 174.99739
+L 154.747273 181.764069
+L 158.096061 188.535834
+L 161.444848 195.199922
+L 164.793636 201.645019
+L 168.142424 207.762763
+L 171.491212 213.449208
+L 174.84 218.606216
+L 178.188788 223.142788
+L 181.537576 226.976287
+L 184.886364 230.033551
+L 188.235152 232.251882
+L 191.583939 233.57989
+L 194.932727 233.978182
+L 198.281515 233.419899
+L 201.630303 231.891073
+L 204.979091 229.390819
+L 208.327879 225.931345
+L 211.676667 221.537787
+L 215.025455 216.247871
+L 218.374242 210.111404
+L 221.72303 203.189605
+L 225.071818 195.554275
+L 228.420606 187.286836
+L 231.769394 178.477226
+L 235.118182 169.222694
+L 238.46697 159.626482
+L 241.815758 149.796441
+L 245.164545 139.843572
+L 248.513333 129.880531
+L 251.862121 120.020111
+L 255.210909 110.373724
+L 258.559697 101.049895
+L 261.908485 92.152802
+L 265.257273 83.780871
+L 268.606061 76.025451
+L 271.954848 68.96958
+L 275.303636 62.686868
+L 278.652424 57.240504
+L 282.001212 52.682404
+L 285.35 49.052512
+L 288.698788 46.378261
+L 292.047576 44.674205
+L 295.396364 43.941818
+L 298.745152 44.169481
+L 302.093939 45.332634
+L 305.442727 47.394107
+L 308.791515 50.304624
+L 312.140303 54.003463
+L 315.489091 58.419278
+L 318.837879 63.471061
+L 322.186667 69.069229
+L 325.535455 75.116837
+L 328.884242 81.51088
+L 332.23303 88.143687
+L 335.581818 94.904366
+L 338.930606 101.680302
+L 342.279394 108.358676
+L 345.628182 114.827982
+L 348.97697 120.979532
+L 352.325758 126.708922
+L 355.674545 131.917438
+L 359.023333 136.513386
+L 362.372121 140.413328
+L 365.720909 143.543207
+L 369.069697 145.839346
+L 372.418485 147.249306
+L 375.767273 147.73259
+L 379.116061 147.261193
+L 382.464848 145.819977
+L 385.813636 143.406875
+L 389.162424 140.032921
+L 392.511212 135.722097
+L 395.86 130.511015
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke: #168f83; stroke-width: 2.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_51">
+    <path d="M 64.33 135.12494
+L 67.678788 136.530214
+L 71.027576 138.322151
+L 74.376364 140.475605
+L 77.725152 142.962444
+L 81.073939 145.751783
+L 84.422727 148.810239
+L 87.771515 152.102205
+L 91.120303 155.590146
+L 94.469091 159.23491
+L 97.817879 162.996049
+L 101.166667 166.832152
+L 104.515455 170.701192
+L 107.864242 174.560867
+L 111.21303 178.368955
+L 114.561818 182.083658
+L 117.910606 185.663952
+L 121.259394 189.069918
+L 124.608182 192.263083
+L 127.95697 195.206726
+L 131.305758 197.866191
+L 134.654545 200.209165
+L 138.003333 202.205953
+L 141.352121 203.829715
+L 144.700909 205.056696
+L 148.049697 205.866414
+L 151.398485 206.241834
+L 154.747273 206.169511
+L 158.096061 205.639693
+L 161.444848 204.64641
+L 164.793636 203.187517
+L 168.142424 201.264717
+L 171.491212 198.883542
+L 174.84 196.053311
+L 178.188788 192.787051
+L 181.537576 189.10139
+L 184.886364 185.016421
+L 188.235152 180.555534
+L 191.583939 175.745222
+L 194.932727 170.614866
+L 198.281515 165.196489
+L 201.630303 159.524494
+L 204.979091 153.635377
+L 208.327879 147.567428
+L 211.676667 141.360414
+L 215.025455 135.05525
+L 218.374242 128.693662
+L 221.72303 122.317843
+L 225.071818 115.9701
+L 228.420606 109.692513
+L 231.769394 103.526578
+L 235.118182 97.512873
+L 238.46697 91.690716
+L 241.815758 86.097844
+L 245.164545 80.770099
+L 248.513333 75.741137
+L 251.862121 71.042142
+L 255.210909 66.701576
+L 258.559697 62.744939
+L 261.908485 59.194561
+L 265.257273 56.069417
+L 268.606061 53.384971
+L 271.954848 51.153044
+L 275.303636 49.381724
+L 278.652424 48.075291
+L 282.001212 47.23419
+L 285.35 46.855018
+L 288.698788 46.93056
+L 292.047576 47.449846
+L 295.396364 48.39824
+L 298.745152 49.757562
+L 302.093939 51.50624
+L 305.442727 53.619483
+L 308.791515 56.069492
+L 312.140303 58.825687
+L 315.489091 61.854956
+L 318.837879 65.121937
+L 322.186667 68.589299
+L 325.535455 72.218059
+L 328.884242 75.967903
+L 332.23303 79.797513
+L 335.581818 83.664915
+L 338.930606 87.527821
+L 342.279394 91.343983
+L 345.628182 95.071535
+L 348.97697 98.669346
+L 352.325758 102.097356
+L 355.674545 105.316906
+L 359.023333 108.291059
+L 362.372121 110.984907
+L 365.720909 113.365853
+L 369.069697 115.403888
+L 372.418485 117.071832
+L 375.767273 118.345564
+L 379.116061 119.204217
+L 382.464848 119.630352
+L 385.813636 119.610103
+L 389.162424 119.13329
+L 392.511212 118.193505
+L 395.86 116.788162
+" clip-path="url(#p20e8e39b88)" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #3976d3; stroke-width: 2"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 64.33 243.48
+L 64.33 34.44
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 395.86 243.48
+L 395.86 34.44
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 64.33 243.48
+L 395.86 243.48
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 64.33 34.44
+L 395.86 34.44
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="C0_0_1d1049f862" d="M 0 2.645751
+C 0.701661 2.645751 1.374679 2.366978 1.870829 1.870829
+C 2.366978 1.374679 2.645751 0.701661 2.645751 -0
+C 2.645751 -0.701661 2.366978 -1.374679 1.870829 -1.870829
+C 1.374679 -2.366978 0.701661 -2.645751 0 -2.645751
+C -0.701661 -2.645751 -1.374679 -2.366978 -1.870829 -1.870829
+C -2.366978 -1.374679 -2.645751 -0.701661 -2.645751 0
+C -2.645751 0.701661 -2.366978 1.374679 -1.870829 1.870829
+C -1.374679 2.366978 -0.701661 2.645751 0 2.645751
+z
+"/>
+    </defs>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="64.33" y="225.193941" style="fill: #011959; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="97.817879" y="143.041679" style="fill: #103f60; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="131.305758" y="140.621398" style="fill: #1b5962; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="164.793636" y="201.645019" style="fill: #3c6d56; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="198.281515" y="233.419899" style="fill: #687b3e; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="231.769394" y="178.477226" style="fill: #9d892b; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="265.257273" y="83.780871" style="fill: #d29343; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="298.745152" y="44.169481" style="fill: #f8a27e; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="332.23303" y="88.143687" style="fill: #fdb7bc; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+    <g clip-path="url(#p20e8e39b88)">
+     <use xlink:href="#C0_0_1d1049f862" x="365.720909" y="143.543207" style="fill: #faccfa; stroke: #ffffff; stroke-width: 0.7"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- Primary title -->
+    <g transform="translate(64.33 29.44) scale(0.11 -0.11)">
+     <defs>
+      <path id="TeXGyreHeros-Regular-50" d="M 582 0
+L 1178 0
+L 1178 1978
+L 2643 1978
+C 3411 1978 3949 2522 3949 3296
+C 3949 4173 3430 4666 2509 4666
+L 582 4666
+L 582 0
+z
+M 1178 2502
+L 1178 4141
+L 2419 4141
+C 2989 4141 3328 3834 3328 3322
+C 3328 2810 2989 2502 2419 2502
+L 1178 2502
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-72" d="M 448 0
+L 979 0
+L 979 1741
+C 979 2496 1229 2874 2054 2886
+L 2054 3430
+C 1965 3443 1920 3450 1850 3450
+C 1504 3450 1242 3245 934 2746
+L 934 3354
+L 448 3354
+L 448 0
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-69" d="M 384 3859
+L 1050 3859
+L 1050 4525
+L 384 4525
+L 384 3859
+z
+M 448 0
+L 979 0
+L 979 3354
+L 448 3354
+L 448 0
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-6d" d="M 454 0
+L 986 0
+L 986 2106
+C 986 2592 1338 2982 1773 2982
+C 2170 2982 2394 2739 2394 2310
+L 2394 0
+L 2925 0
+L 2925 2106
+C 2925 2592 3283 2982 3718 2982
+C 4109 2982 4333 2733 4333 2310
+L 4333 0
+L 4864 0
+L 4864 2515
+C 4864 3117 4531 3450 3904 3450
+C 3456 3450 3187 3315 2874 2938
+C 2675 3296 2406 3450 1971 3450
+C 1523 3450 1229 3283 941 2880
+L 941 3354
+L 454 3354
+L 454 0
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-61" d="M 269 870
+C 269 262 691 -96 1370 -96
+C 1798 -96 2214 83 2509 397
+C 2566 141 2797 -45 3059 -45
+C 3168 -45 3251 -32 3424 13
+L 3424 416
+C 3366 403 3341 403 3309 403
+C 3123 403 3021 499 3021 666
+L 3021 2534
+C 3021 3130 2586 3450 1760 3450
+C 947 3450 448 3136 416 2362
+L 954 2362
+C 998 2771 1242 2957 1741 2957
+C 2221 2957 2490 2778 2490 2458
+L 2490 2317
+C 2490 2093 2355 1997 1933 1946
+C 1178 1850 1062 1824 858 1741
+C 467 1581 269 1280 269 870
+z
+M 826 883
+C 826 1235 1062 1389 1632 1472
+C 2195 1549 2310 1574 2490 1658
+L 2490 1158
+C 2490 678 2003 371 1485 371
+C 1069 371 826 518 826 883
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-79" d="M 128 3354
+L 1261 -13
+L 1056 -544
+C 966 -781 858 -870 627 -870
+C 550 -870 461 -858 346 -832
+L 346 -1312
+C 454 -1370 563 -1395 704 -1395
+C 1082 -1395 1389 -1184 1568 -704
+L 3059 3354
+L 2483 3354
+L 1555 742
+L 698 3354
+L 128 3354
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-74" d="M 90 2918
+L 544 2918
+L 544 486
+C 544 147 774 -45 1190 -45
+C 1318 -45 1446 -32 1626 0
+L 1626 448
+C 1555 429 1472 422 1370 422
+C 1139 422 1075 486 1075 723
+L 1075 2918
+L 1626 2918
+L 1626 3354
+L 1075 3354
+L 1075 4275
+L 544 4275
+L 544 3354
+L 90 3354
+L 90 2918
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-6c" d="M 435 0
+L 966 0
+L 966 4666
+L 435 4666
+L 435 0
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-65" d="M 256 1658
+C 256 557 838 -96 1779 -96
+C 2547 -96 3078 339 3213 1018
+L 2675 1018
+C 2528 576 2227 397 1798 397
+C 1242 397 826 755 813 1523
+L 3283 1523
+C 3283 2010 3245 2317 3149 2566
+C 2931 3117 2419 3450 1792 3450
+C 858 3450 256 2758 256 1658
+z
+M 826 1958
+C 870 2554 1248 2957 1786 2957
+C 2310 2957 2714 2522 2714 1997
+C 2714 1997 2714 1971 2707 1958
+L 826 1958
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#TeXGyreHeros-Regular-50"/>
+     <use xlink:href="#TeXGyreHeros-Regular-72" transform="translate(66.699997 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-69" transform="translate(99.999985 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-6d" transform="translate(122.199982 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-61" transform="translate(205.499969 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-72" transform="translate(261.09996 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-79" transform="translate(294.399948 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-20" transform="translate(344.399933 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-74" transform="translate(372.199921 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-69" transform="translate(399.999908 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-74" transform="translate(422.199905 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-6c" transform="translate(449.999893 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(472.19989 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- Context -->
+    <g transform="translate(357.956406 29.44) scale(0.11 -0.11)">
+     <defs>
+      <path id="TeXGyreHeros-Regular-43" d="M 307 2278
+C 307 915 1043 -115 2413 -115
+C 3552 -115 4192 486 4333 1702
+L 3718 1702
+C 3578 819 3206 410 2419 410
+C 1491 410 902 1120 902 2285
+C 902 3482 1466 4256 2368 4256
+C 3098 4256 3482 3930 3629 3219
+L 4237 3219
+C 4051 4243 3462 4781 2438 4781
+C 1024 4781 307 3642 307 2278
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-6f" d="M 230 1677
+C 230 550 794 -96 1747 -96
+C 2688 -96 3264 550 3264 1651
+C 3264 2810 2707 3450 1741 3450
+C 800 3450 230 2803 230 1677
+z
+M 787 1677
+C 787 2483 1152 2957 1747 2957
+C 2349 2957 2707 2490 2707 1658
+C 2707 870 2336 397 1747 397
+C 1152 397 787 864 787 1677
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-6e" d="M 448 0
+L 979 0
+L 979 1850
+C 979 2534 1350 2982 1894 2982
+C 2317 2982 2586 2726 2586 2323
+L 2586 0
+L 3117 0
+L 3117 2534
+C 3117 3091 2701 3450 2054 3450
+C 1555 3450 1235 3258 941 2790
+L 941 3354
+L 448 3354
+L 448 0
+z
+" transform="scale(0.015625)"/>
+      <path id="TeXGyreHeros-Regular-78" d="M 109 0
+L 717 0
+L 1568 1286
+L 2406 0
+L 3027 0
+L 1869 1734
+L 2995 3354
+L 2394 3354
+L 1587 2138
+L 781 3354
+L 173 3354
+L 1293 1709
+L 109 0
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#TeXGyreHeros-Regular-43"/>
+     <use xlink:href="#TeXGyreHeros-Regular-6f" transform="translate(72.199982 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-6e" transform="translate(127.799973 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-74" transform="translate(183.399963 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(211.199951 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-78" transform="translate(266.799942 0)"/>
+     <use xlink:href="#TeXGyreHeros-Regular-74" transform="translate(316.799927 0)"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 64.33 229.945045
+L 178.188788 229.945045
+L 178.188788 125.420768
+L 64.33 125.420768
+L 64.33 229.945045
+z
+M 87.5371 59.5248
+Q 75.93355 92.472784 64.33 125.420768
+M 177.0502 59.5248
+Q 177.619494 92.472784 178.188788 125.420768
+" style="fill: none; opacity: 0.5; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="axes_2">
+    <g id="patch_8">
+     <path d="M 87.5371 111.7848
+L 177.0502 111.7848
+L 177.0502 59.5248
+L 87.5371 59.5248
+z
+" style="fill: #ffffff"/>
+    </g>
+    <g id="matplotlib.axis_3"/>
+    <g id="matplotlib.axis_4"/>
+    <g id="line2d_52">
+     <path d="M 87.5371 109.409345
+L 90.169838 104.430343
+L 92.802576 99.507704
+L 95.435315 94.697031
+L 98.068053 90.052421
+L 100.700791 85.625727
+L 103.333529 81.465871
+L 105.966268 77.618175
+L 108.599006 74.123753
+L 111.231744 71.018959
+L 113.864482 68.334895
+L 116.497221 66.096994
+L 119.129959 64.324671
+L 121.762697 63.031071
+L 124.395435 62.222883
+L 127.028174 61.900255
+L 129.660912 62.056789
+L 132.29365 62.679631
+L 134.926388 63.749641
+L 137.559126 65.24165
+L 140.191865 67.124804
+L 142.824603 69.362975
+L 145.457341 71.915252
+L 148.090079 74.736487
+L 150.722818 77.777911
+L 153.355556 80.987784
+L 155.988294 84.312097
+L 158.621032 87.695298
+L 161.253771 91.081042
+L 163.886509 94.412949
+L 166.519247 97.635366
+L 169.151985 100.694113
+L 171.784724 103.537219
+L 174.417462 106.115617
+L 177.0502 108.383811
+" clip-path="url(#p19882f2ac8)" style="fill: none; stroke: #168f83; stroke-width: 1.3; stroke-linecap: square"/>
+    </g>
+    <g id="patch_9">
+     <path d="M 87.5371 111.7848
+L 87.5371 59.5248
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+    </g>
+    <g id="patch_10">
+     <path d="M 177.0502 111.7848
+L 177.0502 59.5248
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+    </g>
+    <g id="patch_11">
+     <path d="M 87.5371 111.7848
+L 177.0502 111.7848
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+    </g>
+    <g id="patch_12">
+     <path d="M 87.5371 59.5248
+L 177.0502 59.5248
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+    </g>
+    <g id="text_15">
+     <!-- Inset -->
+     <g transform="translate(120.370681 54.5248) scale(0.11 -0.11)">
+      <defs>
+       <path id="TeXGyreHeros-Regular-49" d="M 640 0
+L 1235 0
+L 1235 4666
+L 640 4666
+L 640 0
+z
+" transform="scale(0.015625)"/>
+       <path id="TeXGyreHeros-Regular-73" d="M 218 1024
+C 243 250 678 -96 1555 -96
+C 2400 -96 2938 294 2938 941
+C 2938 1440 2656 1690 1990 1850
+L 1478 1971
+C 1043 2074 858 2214 858 2451
+C 858 2758 1133 2957 1568 2957
+C 1997 2957 2227 2771 2240 2419
+L 2803 2419
+C 2797 3078 2362 3450 1587 3450
+C 806 3450 301 3046 301 2426
+C 301 1901 570 1651 1363 1459
+L 1862 1338
+C 2234 1248 2381 1139 2381 896
+C 2381 582 2067 397 1600 397
+C 1120 397 851 512 781 1024
+L 218 1024
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#TeXGyreHeros-Regular-49"/>
+      <use xlink:href="#TeXGyreHeros-Regular-6e" transform="translate(27.799988 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-73" transform="translate(83.399979 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(133.399963 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-74" transform="translate(188.999954 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_13">
+     <path d="M 314.733437 69.599375
+L 395.86 69.599375
+L 395.86 34.44
+L 314.733437 34.44
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_53">
+     <path d="M 319.733437 43.39
+L 329.733437 43.39
+L 339.733437 43.39
+" style="fill: none; stroke: #168f83; stroke-width: 2.2"/>
+    </g>
+    <g id="text_16">
+     <!-- Observed -->
+     <g transform="translate(344.733437 47.34) scale(0.1 -0.1)">
+      <defs>
+       <path id="TeXGyreHeros-Regular-4f" d="M 243 2298
+C 243 838 1152 -115 2496 -115
+C 3866 -115 4749 890 4749 2259
+C 4749 3763 3859 4781 2490 4781
+C 1152 4781 243 3757 243 2298
+z
+M 838 2298
+C 838 3450 1504 4256 2490 4256
+C 3501 4256 4154 3450 4154 2272
+C 4154 1146 3482 410 2496 410
+C 1504 410 838 1146 838 2298
+z
+" transform="scale(0.015625)"/>
+       <path id="TeXGyreHeros-Regular-62" d="M 346 0
+L 826 0
+L 826 480
+C 1082 90 1421 -96 1888 -96
+C 2771 -96 3347 627 3347 1715
+C 3347 2803 2797 3450 1914 3450
+C 1453 3450 1126 3277 877 2899
+L 877 4666
+L 346 4666
+L 346 0
+z
+M 877 1677
+C 877 2464 1248 2976 1811 2950
+C 2406 2950 2790 2432 2790 1683
+C 2790 922 2394 403 1811 403
+C 1248 403 877 915 877 1677
+z
+" transform="scale(0.015625)"/>
+       <path id="TeXGyreHeros-Regular-76" d="M 64 3354
+L 1242 0
+L 1824 0
+L 3110 3354
+L 2509 3354
+L 1562 634
+L 666 3354
+L 64 3354
+z
+" transform="scale(0.015625)"/>
+       <path id="TeXGyreHeros-Regular-64" d="M 166 1709
+C 166 576 723 -96 1626 -96
+C 2086 -96 2406 77 2694 493
+L 2694 0
+L 3168 0
+L 3168 4666
+L 2637 4666
+L 2637 2931
+C 2413 3270 2054 3450 1606 3450
+C 736 3450 166 2778 166 1709
+z
+M 723 1677
+C 723 2458 1114 2950 1696 2950
+C 2272 2950 2637 2438 2637 1664
+C 2637 890 2266 403 1702 403
+C 1114 403 723 896 723 1677
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#TeXGyreHeros-Regular-4f"/>
+      <use xlink:href="#TeXGyreHeros-Regular-62" transform="translate(77.799988 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-73" transform="translate(133.399979 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(183.399963 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-72" transform="translate(238.999954 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-76" transform="translate(272.299942 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(322.299927 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-64" transform="translate(377.899918 0)"/>
+     </g>
+    </g>
+    <g id="line2d_54">
+     <path d="M 319.733437 58.469688
+L 329.733437 58.469688
+L 339.733437 58.469688
+" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #3976d3; stroke-width: 2"/>
+    </g>
+    <g id="text_17">
+     <!-- Reference -->
+     <g transform="translate(344.733437 62.419688) scale(0.1 -0.1)">
+      <defs>
+       <path id="TeXGyreHeros-Regular-52" d="M 595 0
+L 1190 0
+L 1190 2010
+L 2726 2010
+C 3251 2010 3501 1754 3494 1178
+L 3488 762
+C 3482 474 3539 192 3622 0
+L 4346 0
+L 4346 147
+C 4122 301 4070 467 4064 1088
+C 4051 1856 3936 2086 3430 2304
+C 3955 2560 4166 2886 4166 3418
+C 4166 4224 3661 4666 2746 4666
+L 595 4666
+L 595 0
+z
+M 1190 2534
+L 1190 4141
+L 2630 4141
+C 3296 4141 3546 3859 3546 3334
+C 3546 2784 3264 2534 2630 2534
+L 1190 2534
+z
+" transform="scale(0.015625)"/>
+       <path id="TeXGyreHeros-Regular-66" d="M 115 2918
+L 563 2918
+L 563 0
+L 1094 0
+L 1094 2918
+L 1651 2918
+L 1651 3354
+L 1094 3354
+L 1094 3878
+C 1094 4102 1222 4218 1466 4218
+C 1510 4218 1530 4218 1651 4211
+L 1651 4653
+C 1530 4678 1459 4685 1350 4685
+C 858 4685 563 4403 563 3923
+L 563 3354
+L 115 3354
+L 115 2918
+z
+" transform="scale(0.015625)"/>
+       <path id="TeXGyreHeros-Regular-63" d="M 198 1645
+C 198 563 774 -96 1683 -96
+C 2483 -96 2989 384 3053 1152
+L 2515 1152
+C 2426 614 2150 397 1696 397
+C 1107 397 755 851 755 1645
+C 755 2483 1101 2957 1683 2957
+C 2131 2957 2413 2694 2477 2227
+L 3014 2227
+C 2950 3046 2438 3450 1690 3450
+C 787 3450 198 2758 198 1645
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#TeXGyreHeros-Regular-52"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(72.199982 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-66" transform="translate(127.799973 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(155.59996 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-72" transform="translate(211.199951 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(244.499939 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-6e" transform="translate(300.09993 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-63" transform="translate(355.699921 0)"/>
+      <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(405.699905 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_14">
+    <path d="M 407.86 243.48
+L 422.26 243.48
+L 422.26 34.44
+L 407.86 34.44
+L 407.86 243.48
+z
+" style="fill: none"/>
+   </g>
+   <g id="axes_4">
+    <g id="patch_15">
+     <path d="M 407.86 220.4856
+L 422.26 220.4856
+L 422.26 57.4344
+L 407.86 57.4344
+L 407.86 220.4856
+z
+" style="fill: none"/>
+    </g>
+    <g id="QuadMesh_1">
+     <path d="M 407.86 220.4856
+L 422.26 220.4856
+L 422.26 219.848681
+L 407.86 219.848681
+L 407.86 220.4856
+" clip-path="url(#pffc3051ed0)" style="fill: #011959; stroke: #011959; stroke-width: 0.3"/>
+     <path d="M 407.86 219.848681
+L 422.26 219.848681
+L 422.26 219.211762
+L 407.86 219.211762
+L 407.86 219.848681
+" clip-path="url(#pffc3051ed0)" style="fill: #021b59; stroke: #021b59; stroke-width: 0.3"/>
+     <path d="M 407.86 219.211762
+L 422.26 219.211762
+L 422.26 218.574844
+L 407.86 218.574844
+L 407.86 219.211762
+" clip-path="url(#pffc3051ed0)" style="fill: #031c5a; stroke: #031c5a; stroke-width: 0.3"/>
+     <path d="M 407.86 218.574844
+L 422.26 218.574844
+L 422.26 217.937925
+L 407.86 217.937925
+L 407.86 218.574844
+" clip-path="url(#pffc3051ed0)" style="fill: #041e5a; stroke: #041e5a; stroke-width: 0.3"/>
+     <path d="M 407.86 217.937925
+L 422.26 217.937925
+L 422.26 217.301006
+L 407.86 217.301006
+L 407.86 217.937925
+" clip-path="url(#pffc3051ed0)" style="fill: #051f5a; stroke: #051f5a; stroke-width: 0.3"/>
+     <path d="M 407.86 217.301006
+L 422.26 217.301006
+L 422.26 216.664087
+L 407.86 216.664087
+L 407.86 217.301006
+" clip-path="url(#pffc3051ed0)" style="fill: #06215b; stroke: #06215b; stroke-width: 0.3"/>
+     <path d="M 407.86 216.664087
+L 422.26 216.664087
+L 422.26 216.027169
+L 407.86 216.027169
+L 407.86 216.664087
+" clip-path="url(#pffc3051ed0)" style="fill: #07225b; stroke: #07225b; stroke-width: 0.3"/>
+     <path d="M 407.86 216.027169
+L 422.26 216.027169
+L 422.26 215.39025
+L 407.86 215.39025
+L 407.86 216.027169
+" clip-path="url(#pffc3051ed0)" style="fill: #07245b; stroke: #07245b; stroke-width: 0.3"/>
+     <path d="M 407.86 215.39025
+L 422.26 215.39025
+L 422.26 214.753331
+L 407.86 214.753331
+L 407.86 215.39025
+" clip-path="url(#pffc3051ed0)" style="fill: #08255b; stroke: #08255b; stroke-width: 0.3"/>
+     <path d="M 407.86 214.753331
+L 422.26 214.753331
+L 422.26 214.116412
+L 407.86 214.116412
+L 407.86 214.753331
+" clip-path="url(#pffc3051ed0)" style="fill: #09275c; stroke: #09275c; stroke-width: 0.3"/>
+     <path d="M 407.86 214.116412
+L 422.26 214.116412
+L 422.26 213.479494
+L 407.86 213.479494
+L 407.86 214.116412
+" clip-path="url(#pffc3051ed0)" style="fill: #0a285c; stroke: #0a285c; stroke-width: 0.3"/>
+     <path d="M 407.86 213.479494
+L 422.26 213.479494
+L 422.26 212.842575
+L 407.86 212.842575
+L 407.86 213.479494
+" clip-path="url(#pffc3051ed0)" style="fill: #0a2a5c; stroke: #0a2a5c; stroke-width: 0.3"/>
+     <path d="M 407.86 212.842575
+L 422.26 212.842575
+L 422.26 212.205656
+L 407.86 212.205656
+L 407.86 212.842575
+" clip-path="url(#pffc3051ed0)" style="fill: #0b2b5c; stroke: #0b2b5c; stroke-width: 0.3"/>
+     <path d="M 407.86 212.205656
+L 422.26 212.205656
+L 422.26 211.568737
+L 407.86 211.568737
+L 407.86 212.205656
+" clip-path="url(#pffc3051ed0)" style="fill: #0b2d5d; stroke: #0b2d5d; stroke-width: 0.3"/>
+     <path d="M 407.86 211.568737
+L 422.26 211.568737
+L 422.26 210.931819
+L 407.86 210.931819
+L 407.86 211.568737
+" clip-path="url(#pffc3051ed0)" style="fill: #0c2e5d; stroke: #0c2e5d; stroke-width: 0.3"/>
+     <path d="M 407.86 210.931819
+L 422.26 210.931819
+L 422.26 210.2949
+L 407.86 210.2949
+L 407.86 210.931819
+" clip-path="url(#pffc3051ed0)" style="fill: #0c2f5d; stroke: #0c2f5d; stroke-width: 0.3"/>
+     <path d="M 407.86 210.2949
+L 422.26 210.2949
+L 422.26 209.657981
+L 407.86 209.657981
+L 407.86 210.2949
+" clip-path="url(#pffc3051ed0)" style="fill: #0d315d; stroke: #0d315d; stroke-width: 0.3"/>
+     <path d="M 407.86 209.657981
+L 422.26 209.657981
+L 422.26 209.021062
+L 407.86 209.021062
+L 407.86 209.657981
+" clip-path="url(#pffc3051ed0)" style="fill: #0d325e; stroke: #0d325e; stroke-width: 0.3"/>
+     <path d="M 407.86 209.021062
+L 422.26 209.021062
+L 422.26 208.384144
+L 407.86 208.384144
+L 407.86 209.021062
+" clip-path="url(#pffc3051ed0)" style="fill: #0d335e; stroke: #0d335e; stroke-width: 0.3"/>
+     <path d="M 407.86 208.384144
+L 422.26 208.384144
+L 422.26 207.747225
+L 407.86 207.747225
+L 407.86 208.384144
+" clip-path="url(#pffc3051ed0)" style="fill: #0e355e; stroke: #0e355e; stroke-width: 0.3"/>
+     <path d="M 407.86 207.747225
+L 422.26 207.747225
+L 422.26 207.110306
+L 407.86 207.110306
+L 407.86 207.747225
+" clip-path="url(#pffc3051ed0)" style="fill: #0e365e; stroke: #0e365e; stroke-width: 0.3"/>
+     <path d="M 407.86 207.110306
+L 422.26 207.110306
+L 422.26 206.473388
+L 407.86 206.473388
+L 407.86 207.110306
+" clip-path="url(#pffc3051ed0)" style="fill: #0e375e; stroke: #0e375e; stroke-width: 0.3"/>
+     <path d="M 407.86 206.473388
+L 422.26 206.473388
+L 422.26 205.836469
+L 407.86 205.836469
+L 407.86 206.473388
+" clip-path="url(#pffc3051ed0)" style="fill: #0f385f; stroke: #0f385f; stroke-width: 0.3"/>
+     <path d="M 407.86 205.836469
+L 422.26 205.836469
+L 422.26 205.19955
+L 407.86 205.19955
+L 407.86 205.836469
+" clip-path="url(#pffc3051ed0)" style="fill: #0f395f; stroke: #0f395f; stroke-width: 0.3"/>
+     <path d="M 407.86 205.19955
+L 422.26 205.19955
+L 422.26 204.562631
+L 407.86 204.562631
+L 407.86 205.19955
+" clip-path="url(#pffc3051ed0)" style="fill: #0f3b5f; stroke: #0f3b5f; stroke-width: 0.3"/>
+     <path d="M 407.86 204.562631
+L 422.26 204.562631
+L 422.26 203.925713
+L 407.86 203.925713
+L 407.86 204.562631
+" clip-path="url(#pffc3051ed0)" style="fill: #0f3c5f; stroke: #0f3c5f; stroke-width: 0.3"/>
+     <path d="M 407.86 203.925713
+L 422.26 203.925713
+L 422.26 203.288794
+L 407.86 203.288794
+L 407.86 203.925713
+" clip-path="url(#pffc3051ed0)" style="fill: #103d5f; stroke: #103d5f; stroke-width: 0.3"/>
+     <path d="M 407.86 203.288794
+L 422.26 203.288794
+L 422.26 202.651875
+L 407.86 202.651875
+L 407.86 203.288794
+" clip-path="url(#pffc3051ed0)" style="fill: #103e5f; stroke: #103e5f; stroke-width: 0.3"/>
+     <path d="M 407.86 202.651875
+L 422.26 202.651875
+L 422.26 202.014956
+L 407.86 202.014956
+L 407.86 202.651875
+" clip-path="url(#pffc3051ed0)" style="fill: #103f60; stroke: #103f60; stroke-width: 0.3"/>
+     <path d="M 407.86 202.014956
+L 422.26 202.014956
+L 422.26 201.378038
+L 407.86 201.378038
+L 407.86 202.014956
+" clip-path="url(#pffc3051ed0)" style="fill: #104060; stroke: #104060; stroke-width: 0.3"/>
+     <path d="M 407.86 201.378038
+L 422.26 201.378038
+L 422.26 200.741119
+L 407.86 200.741119
+L 407.86 201.378038
+" clip-path="url(#pffc3051ed0)" style="fill: #114160; stroke: #114160; stroke-width: 0.3"/>
+     <path d="M 407.86 200.741119
+L 422.26 200.741119
+L 422.26 200.1042
+L 407.86 200.1042
+L 407.86 200.741119
+" clip-path="url(#pffc3051ed0)" style="fill: #114260; stroke: #114260; stroke-width: 0.3"/>
+     <path d="M 407.86 200.1042
+L 422.26 200.1042
+L 422.26 199.467281
+L 407.86 199.467281
+L 407.86 200.1042
+" clip-path="url(#pffc3051ed0)" style="fill: #114360; stroke: #114360; stroke-width: 0.3"/>
+     <path d="M 407.86 199.467281
+L 422.26 199.467281
+L 422.26 198.830363
+L 407.86 198.830363
+L 407.86 199.467281
+" clip-path="url(#pffc3051ed0)" style="fill: #114460; stroke: #114460; stroke-width: 0.3"/>
+     <path d="M 407.86 198.830363
+L 422.26 198.830363
+L 422.26 198.193444
+L 407.86 198.193444
+L 407.86 198.830363
+" clip-path="url(#pffc3051ed0)" style="fill: #124561; stroke: #124561; stroke-width: 0.3"/>
+     <path d="M 407.86 198.193444
+L 422.26 198.193444
+L 422.26 197.556525
+L 407.86 197.556525
+L 407.86 198.193444
+" clip-path="url(#pffc3051ed0)" style="fill: #124661; stroke: #124661; stroke-width: 0.3"/>
+     <path d="M 407.86 197.556525
+L 422.26 197.556525
+L 422.26 196.919606
+L 407.86 196.919606
+L 407.86 197.556525
+" clip-path="url(#pffc3051ed0)" style="fill: #124761; stroke: #124761; stroke-width: 0.3"/>
+     <path d="M 407.86 196.919606
+L 422.26 196.919606
+L 422.26 196.282688
+L 407.86 196.282688
+L 407.86 196.919606
+" clip-path="url(#pffc3051ed0)" style="fill: #124861; stroke: #124861; stroke-width: 0.3"/>
+     <path d="M 407.86 196.282688
+L 422.26 196.282688
+L 422.26 195.645769
+L 407.86 195.645769
+L 407.86 196.282688
+" clip-path="url(#pffc3051ed0)" style="fill: #134961; stroke: #134961; stroke-width: 0.3"/>
+     <path d="M 407.86 195.645769
+L 422.26 195.645769
+L 422.26 195.00885
+L 407.86 195.00885
+L 407.86 195.645769
+" clip-path="url(#pffc3051ed0)" style="fill: #134a61; stroke: #134a61; stroke-width: 0.3"/>
+     <path d="M 407.86 195.00885
+L 422.26 195.00885
+L 422.26 194.371931
+L 407.86 194.371931
+L 407.86 195.00885
+" clip-path="url(#pffc3051ed0)" style="fill: #134b61; stroke: #134b61; stroke-width: 0.3"/>
+     <path d="M 407.86 194.371931
+L 422.26 194.371931
+L 422.26 193.735013
+L 407.86 193.735013
+L 407.86 194.371931
+" clip-path="url(#pffc3051ed0)" style="fill: #144c62; stroke: #144c62; stroke-width: 0.3"/>
+     <path d="M 407.86 193.735013
+L 422.26 193.735013
+L 422.26 193.098094
+L 407.86 193.098094
+L 407.86 193.735013
+" clip-path="url(#pffc3051ed0)" style="fill: #144d62; stroke: #144d62; stroke-width: 0.3"/>
+     <path d="M 407.86 193.098094
+L 422.26 193.098094
+L 422.26 192.461175
+L 407.86 192.461175
+L 407.86 193.098094
+" clip-path="url(#pffc3051ed0)" style="fill: #144e62; stroke: #144e62; stroke-width: 0.3"/>
+     <path d="M 407.86 192.461175
+L 422.26 192.461175
+L 422.26 191.824256
+L 407.86 191.824256
+L 407.86 192.461175
+" clip-path="url(#pffc3051ed0)" style="fill: #154f62; stroke: #154f62; stroke-width: 0.3"/>
+     <path d="M 407.86 191.824256
+L 422.26 191.824256
+L 422.26 191.187338
+L 407.86 191.187338
+L 407.86 191.824256
+" clip-path="url(#pffc3051ed0)" style="fill: #154f62; stroke: #154f62; stroke-width: 0.3"/>
+     <path d="M 407.86 191.187338
+L 422.26 191.187338
+L 422.26 190.550419
+L 407.86 190.550419
+L 407.86 191.187338
+" clip-path="url(#pffc3051ed0)" style="fill: #165062; stroke: #165062; stroke-width: 0.3"/>
+     <path d="M 407.86 190.550419
+L 422.26 190.550419
+L 422.26 189.9135
+L 407.86 189.9135
+L 407.86 190.550419
+" clip-path="url(#pffc3051ed0)" style="fill: #165162; stroke: #165162; stroke-width: 0.3"/>
+     <path d="M 407.86 189.9135
+L 422.26 189.9135
+L 422.26 189.276581
+L 407.86 189.276581
+L 407.86 189.9135
+" clip-path="url(#pffc3051ed0)" style="fill: #175262; stroke: #175262; stroke-width: 0.3"/>
+     <path d="M 407.86 189.276581
+L 422.26 189.276581
+L 422.26 188.639663
+L 407.86 188.639663
+L 407.86 189.276581
+" clip-path="url(#pffc3051ed0)" style="fill: #175362; stroke: #175362; stroke-width: 0.3"/>
+     <path d="M 407.86 188.639663
+L 422.26 188.639663
+L 422.26 188.002744
+L 407.86 188.002744
+L 407.86 188.639663
+" clip-path="url(#pffc3051ed0)" style="fill: #185462; stroke: #185462; stroke-width: 0.3"/>
+     <path d="M 407.86 188.002744
+L 422.26 188.002744
+L 422.26 187.365825
+L 407.86 187.365825
+L 407.86 188.002744
+" clip-path="url(#pffc3051ed0)" style="fill: #185562; stroke: #185562; stroke-width: 0.3"/>
+     <path d="M 407.86 187.365825
+L 422.26 187.365825
+L 422.26 186.728906
+L 407.86 186.728906
+L 407.86 187.365825
+" clip-path="url(#pffc3051ed0)" style="fill: #195662; stroke: #195662; stroke-width: 0.3"/>
+     <path d="M 407.86 186.728906
+L 422.26 186.728906
+L 422.26 186.091988
+L 407.86 186.091988
+L 407.86 186.728906
+" clip-path="url(#pffc3051ed0)" style="fill: #195762; stroke: #195762; stroke-width: 0.3"/>
+     <path d="M 407.86 186.091988
+L 422.26 186.091988
+L 422.26 185.455069
+L 407.86 185.455069
+L 407.86 186.091988
+" clip-path="url(#pffc3051ed0)" style="fill: #1a5762; stroke: #1a5762; stroke-width: 0.3"/>
+     <path d="M 407.86 185.455069
+L 422.26 185.455069
+L 422.26 184.81815
+L 407.86 184.81815
+L 407.86 185.455069
+" clip-path="url(#pffc3051ed0)" style="fill: #1b5862; stroke: #1b5862; stroke-width: 0.3"/>
+     <path d="M 407.86 184.81815
+L 422.26 184.81815
+L 422.26 184.181231
+L 407.86 184.181231
+L 407.86 184.81815
+" clip-path="url(#pffc3051ed0)" style="fill: #1b5962; stroke: #1b5962; stroke-width: 0.3"/>
+     <path d="M 407.86 184.181231
+L 422.26 184.181231
+L 422.26 183.544312
+L 407.86 183.544312
+L 407.86 184.181231
+" clip-path="url(#pffc3051ed0)" style="fill: #1c5a62; stroke: #1c5a62; stroke-width: 0.3"/>
+     <path d="M 407.86 183.544312
+L 422.26 183.544312
+L 422.26 182.907394
+L 407.86 182.907394
+L 407.86 183.544312
+" clip-path="url(#pffc3051ed0)" style="fill: #1d5b62; stroke: #1d5b62; stroke-width: 0.3"/>
+     <path d="M 407.86 182.907394
+L 422.26 182.907394
+L 422.26 182.270475
+L 407.86 182.270475
+L 407.86 182.907394
+" clip-path="url(#pffc3051ed0)" style="fill: #1e5c62; stroke: #1e5c62; stroke-width: 0.3"/>
+     <path d="M 407.86 182.270475
+L 422.26 182.270475
+L 422.26 181.633556
+L 407.86 181.633556
+L 407.86 182.270475
+" clip-path="url(#pffc3051ed0)" style="fill: #1e5d62; stroke: #1e5d62; stroke-width: 0.3"/>
+     <path d="M 407.86 181.633556
+L 422.26 181.633556
+L 422.26 180.996637
+L 407.86 180.996637
+L 407.86 181.633556
+" clip-path="url(#pffc3051ed0)" style="fill: #1f5d61; stroke: #1f5d61; stroke-width: 0.3"/>
+     <path d="M 407.86 180.996637
+L 422.26 180.996637
+L 422.26 180.359719
+L 407.86 180.359719
+L 407.86 180.996637
+" clip-path="url(#pffc3051ed0)" style="fill: #205e61; stroke: #205e61; stroke-width: 0.3"/>
+     <path d="M 407.86 180.359719
+L 422.26 180.359719
+L 422.26 179.7228
+L 407.86 179.7228
+L 407.86 180.359719
+" clip-path="url(#pffc3051ed0)" style="fill: #215f61; stroke: #215f61; stroke-width: 0.3"/>
+     <path d="M 407.86 179.7228
+L 422.26 179.7228
+L 422.26 179.085881
+L 407.86 179.085881
+L 407.86 179.7228
+" clip-path="url(#pffc3051ed0)" style="fill: #226061; stroke: #226061; stroke-width: 0.3"/>
+     <path d="M 407.86 179.085881
+L 422.26 179.085881
+L 422.26 178.448962
+L 407.86 178.448962
+L 407.86 179.085881
+" clip-path="url(#pffc3051ed0)" style="fill: #236060; stroke: #236060; stroke-width: 0.3"/>
+     <path d="M 407.86 178.448962
+L 422.26 178.448962
+L 422.26 177.812044
+L 407.86 177.812044
+L 407.86 178.448962
+" clip-path="url(#pffc3051ed0)" style="fill: #246160; stroke: #246160; stroke-width: 0.3"/>
+     <path d="M 407.86 177.812044
+L 422.26 177.812044
+L 422.26 177.175125
+L 407.86 177.175125
+L 407.86 177.812044
+" clip-path="url(#pffc3051ed0)" style="fill: #256260; stroke: #256260; stroke-width: 0.3"/>
+     <path d="M 407.86 177.175125
+L 422.26 177.175125
+L 422.26 176.538206
+L 407.86 176.538206
+L 407.86 177.175125
+" clip-path="url(#pffc3051ed0)" style="fill: #26635f; stroke: #26635f; stroke-width: 0.3"/>
+     <path d="M 407.86 176.538206
+L 422.26 176.538206
+L 422.26 175.901288
+L 407.86 175.901288
+L 407.86 176.538206
+" clip-path="url(#pffc3051ed0)" style="fill: #27635f; stroke: #27635f; stroke-width: 0.3"/>
+     <path d="M 407.86 175.901288
+L 422.26 175.901288
+L 422.26 175.264369
+L 407.86 175.264369
+L 407.86 175.901288
+" clip-path="url(#pffc3051ed0)" style="fill: #28645f; stroke: #28645f; stroke-width: 0.3"/>
+     <path d="M 407.86 175.264369
+L 422.26 175.264369
+L 422.26 174.62745
+L 407.86 174.62745
+L 407.86 175.264369
+" clip-path="url(#pffc3051ed0)" style="fill: #2a655e; stroke: #2a655e; stroke-width: 0.3"/>
+     <path d="M 407.86 174.62745
+L 422.26 174.62745
+L 422.26 173.990531
+L 407.86 173.990531
+L 407.86 174.62745
+" clip-path="url(#pffc3051ed0)" style="fill: #2b655e; stroke: #2b655e; stroke-width: 0.3"/>
+     <path d="M 407.86 173.990531
+L 422.26 173.990531
+L 422.26 173.353612
+L 407.86 173.353612
+L 407.86 173.990531
+" clip-path="url(#pffc3051ed0)" style="fill: #2c665d; stroke: #2c665d; stroke-width: 0.3"/>
+     <path d="M 407.86 173.353612
+L 422.26 173.353612
+L 422.26 172.716694
+L 407.86 172.716694
+L 407.86 173.353612
+" clip-path="url(#pffc3051ed0)" style="fill: #2d675d; stroke: #2d675d; stroke-width: 0.3"/>
+     <path d="M 407.86 172.716694
+L 422.26 172.716694
+L 422.26 172.079775
+L 407.86 172.079775
+L 407.86 172.716694
+" clip-path="url(#pffc3051ed0)" style="fill: #2f675c; stroke: #2f675c; stroke-width: 0.3"/>
+     <path d="M 407.86 172.079775
+L 422.26 172.079775
+L 422.26 171.442856
+L 407.86 171.442856
+L 407.86 172.079775
+" clip-path="url(#pffc3051ed0)" style="fill: #30685c; stroke: #30685c; stroke-width: 0.3"/>
+     <path d="M 407.86 171.442856
+L 422.26 171.442856
+L 422.26 170.805937
+L 407.86 170.805937
+L 407.86 171.442856
+" clip-path="url(#pffc3051ed0)" style="fill: #31695b; stroke: #31695b; stroke-width: 0.3"/>
+     <path d="M 407.86 170.805937
+L 422.26 170.805937
+L 422.26 170.169019
+L 407.86 170.169019
+L 407.86 170.805937
+" clip-path="url(#pffc3051ed0)" style="fill: #33695a; stroke: #33695a; stroke-width: 0.3"/>
+     <path d="M 407.86 170.169019
+L 422.26 170.169019
+L 422.26 169.5321
+L 407.86 169.5321
+L 407.86 170.169019
+" clip-path="url(#pffc3051ed0)" style="fill: #346a5a; stroke: #346a5a; stroke-width: 0.3"/>
+     <path d="M 407.86 169.5321
+L 422.26 169.5321
+L 422.26 168.895181
+L 407.86 168.895181
+L 407.86 169.5321
+" clip-path="url(#pffc3051ed0)" style="fill: #356a59; stroke: #356a59; stroke-width: 0.3"/>
+     <path d="M 407.86 168.895181
+L 422.26 168.895181
+L 422.26 168.258263
+L 407.86 168.258263
+L 407.86 168.895181
+" clip-path="url(#pffc3051ed0)" style="fill: #376b58; stroke: #376b58; stroke-width: 0.3"/>
+     <path d="M 407.86 168.258263
+L 422.26 168.258263
+L 422.26 167.621344
+L 407.86 167.621344
+L 407.86 168.258263
+" clip-path="url(#pffc3051ed0)" style="fill: #386c58; stroke: #386c58; stroke-width: 0.3"/>
+     <path d="M 407.86 167.621344
+L 422.26 167.621344
+L 422.26 166.984425
+L 407.86 166.984425
+L 407.86 167.621344
+" clip-path="url(#pffc3051ed0)" style="fill: #3a6c57; stroke: #3a6c57; stroke-width: 0.3"/>
+     <path d="M 407.86 166.984425
+L 422.26 166.984425
+L 422.26 166.347506
+L 407.86 166.347506
+L 407.86 166.984425
+" clip-path="url(#pffc3051ed0)" style="fill: #3b6d56; stroke: #3b6d56; stroke-width: 0.3"/>
+     <path d="M 407.86 166.347506
+L 422.26 166.347506
+L 422.26 165.710588
+L 407.86 165.710588
+L 407.86 166.347506
+" clip-path="url(#pffc3051ed0)" style="fill: #3c6d56; stroke: #3c6d56; stroke-width: 0.3"/>
+     <path d="M 407.86 165.710588
+L 422.26 165.710588
+L 422.26 165.073669
+L 407.86 165.073669
+L 407.86 165.710588
+" clip-path="url(#pffc3051ed0)" style="fill: #3e6e55; stroke: #3e6e55; stroke-width: 0.3"/>
+     <path d="M 407.86 165.073669
+L 422.26 165.073669
+L 422.26 164.43675
+L 407.86 164.43675
+L 407.86 165.073669
+" clip-path="url(#pffc3051ed0)" style="fill: #3f6e54; stroke: #3f6e54; stroke-width: 0.3"/>
+     <path d="M 407.86 164.43675
+L 422.26 164.43675
+L 422.26 163.799831
+L 407.86 163.799831
+L 407.86 164.43675
+" clip-path="url(#pffc3051ed0)" style="fill: #416f53; stroke: #416f53; stroke-width: 0.3"/>
+     <path d="M 407.86 163.799831
+L 422.26 163.799831
+L 422.26 163.162913
+L 407.86 163.162913
+L 407.86 163.799831
+" clip-path="url(#pffc3051ed0)" style="fill: #426f52; stroke: #426f52; stroke-width: 0.3"/>
+     <path d="M 407.86 163.162913
+L 422.26 163.162913
+L 422.26 162.525994
+L 407.86 162.525994
+L 407.86 163.162913
+" clip-path="url(#pffc3051ed0)" style="fill: #447052; stroke: #447052; stroke-width: 0.3"/>
+     <path d="M 407.86 162.525994
+L 422.26 162.525994
+L 422.26 161.889075
+L 407.86 161.889075
+L 407.86 162.525994
+" clip-path="url(#pffc3051ed0)" style="fill: #457051; stroke: #457051; stroke-width: 0.3"/>
+     <path d="M 407.86 161.889075
+L 422.26 161.889075
+L 422.26 161.252156
+L 407.86 161.252156
+L 407.86 161.889075
+" clip-path="url(#pffc3051ed0)" style="fill: #477150; stroke: #477150; stroke-width: 0.3"/>
+     <path d="M 407.86 161.252156
+L 422.26 161.252156
+L 422.26 160.615238
+L 407.86 160.615238
+L 407.86 161.252156
+" clip-path="url(#pffc3051ed0)" style="fill: #48714f; stroke: #48714f; stroke-width: 0.3"/>
+     <path d="M 407.86 160.615238
+L 422.26 160.615238
+L 422.26 159.978319
+L 407.86 159.978319
+L 407.86 160.615238
+" clip-path="url(#pffc3051ed0)" style="fill: #4a724e; stroke: #4a724e; stroke-width: 0.3"/>
+     <path d="M 407.86 159.978319
+L 422.26 159.978319
+L 422.26 159.3414
+L 407.86 159.3414
+L 407.86 159.978319
+" clip-path="url(#pffc3051ed0)" style="fill: #4c724d; stroke: #4c724d; stroke-width: 0.3"/>
+     <path d="M 407.86 159.3414
+L 422.26 159.3414
+L 422.26 158.704481
+L 407.86 158.704481
+L 407.86 159.3414
+" clip-path="url(#pffc3051ed0)" style="fill: #4d734d; stroke: #4d734d; stroke-width: 0.3"/>
+     <path d="M 407.86 158.704481
+L 422.26 158.704481
+L 422.26 158.067563
+L 407.86 158.067563
+L 407.86 158.704481
+" clip-path="url(#pffc3051ed0)" style="fill: #4f734c; stroke: #4f734c; stroke-width: 0.3"/>
+     <path d="M 407.86 158.067563
+L 422.26 158.067563
+L 422.26 157.430644
+L 407.86 157.430644
+L 407.86 158.067563
+" clip-path="url(#pffc3051ed0)" style="fill: #50744b; stroke: #50744b; stroke-width: 0.3"/>
+     <path d="M 407.86 157.430644
+L 422.26 157.430644
+L 422.26 156.793725
+L 407.86 156.793725
+L 407.86 157.430644
+" clip-path="url(#pffc3051ed0)" style="fill: #52744a; stroke: #52744a; stroke-width: 0.3"/>
+     <path d="M 407.86 156.793725
+L 422.26 156.793725
+L 422.26 156.156806
+L 407.86 156.156806
+L 407.86 156.793725
+" clip-path="url(#pffc3051ed0)" style="fill: #537549; stroke: #537549; stroke-width: 0.3"/>
+     <path d="M 407.86 156.156806
+L 422.26 156.156806
+L 422.26 155.519888
+L 407.86 155.519888
+L 407.86 156.156806
+" clip-path="url(#pffc3051ed0)" style="fill: #557548; stroke: #557548; stroke-width: 0.3"/>
+     <path d="M 407.86 155.519888
+L 422.26 155.519888
+L 422.26 154.882969
+L 407.86 154.882969
+L 407.86 155.519888
+" clip-path="url(#pffc3051ed0)" style="fill: #577647; stroke: #577647; stroke-width: 0.3"/>
+     <path d="M 407.86 154.882969
+L 422.26 154.882969
+L 422.26 154.24605
+L 407.86 154.24605
+L 407.86 154.882969
+" clip-path="url(#pffc3051ed0)" style="fill: #587646; stroke: #587646; stroke-width: 0.3"/>
+     <path d="M 407.86 154.24605
+L 422.26 154.24605
+L 422.26 153.609131
+L 407.86 153.609131
+L 407.86 154.24605
+" clip-path="url(#pffc3051ed0)" style="fill: #5a7745; stroke: #5a7745; stroke-width: 0.3"/>
+     <path d="M 407.86 153.609131
+L 422.26 153.609131
+L 422.26 152.972213
+L 407.86 152.972213
+L 407.86 153.609131
+" clip-path="url(#pffc3051ed0)" style="fill: #5b7745; stroke: #5b7745; stroke-width: 0.3"/>
+     <path d="M 407.86 152.972213
+L 422.26 152.972213
+L 422.26 152.335294
+L 407.86 152.335294
+L 407.86 152.972213
+" clip-path="url(#pffc3051ed0)" style="fill: #5d7844; stroke: #5d7844; stroke-width: 0.3"/>
+     <path d="M 407.86 152.335294
+L 422.26 152.335294
+L 422.26 151.698375
+L 407.86 151.698375
+L 407.86 152.335294
+" clip-path="url(#pffc3051ed0)" style="fill: #5f7843; stroke: #5f7843; stroke-width: 0.3"/>
+     <path d="M 407.86 151.698375
+L 422.26 151.698375
+L 422.26 151.061456
+L 407.86 151.061456
+L 407.86 151.698375
+" clip-path="url(#pffc3051ed0)" style="fill: #607942; stroke: #607942; stroke-width: 0.3"/>
+     <path d="M 407.86 151.061456
+L 422.26 151.061456
+L 422.26 150.424537
+L 407.86 150.424537
+L 407.86 151.061456
+" clip-path="url(#pffc3051ed0)" style="fill: #627941; stroke: #627941; stroke-width: 0.3"/>
+     <path d="M 407.86 150.424537
+L 422.26 150.424537
+L 422.26 149.787619
+L 407.86 149.787619
+L 407.86 150.424537
+" clip-path="url(#pffc3051ed0)" style="fill: #637a40; stroke: #637a40; stroke-width: 0.3"/>
+     <path d="M 407.86 149.787619
+L 422.26 149.787619
+L 422.26 149.1507
+L 407.86 149.1507
+L 407.86 149.787619
+" clip-path="url(#pffc3051ed0)" style="fill: #657a3f; stroke: #657a3f; stroke-width: 0.3"/>
+     <path d="M 407.86 149.1507
+L 422.26 149.1507
+L 422.26 148.513781
+L 407.86 148.513781
+L 407.86 149.1507
+" clip-path="url(#pffc3051ed0)" style="fill: #677b3e; stroke: #677b3e; stroke-width: 0.3"/>
+     <path d="M 407.86 148.513781
+L 422.26 148.513781
+L 422.26 147.876863
+L 407.86 147.876863
+L 407.86 148.513781
+" clip-path="url(#pffc3051ed0)" style="fill: #687b3e; stroke: #687b3e; stroke-width: 0.3"/>
+     <path d="M 407.86 147.876863
+L 422.26 147.876863
+L 422.26 147.239944
+L 407.86 147.239944
+L 407.86 147.876863
+" clip-path="url(#pffc3051ed0)" style="fill: #6a7b3d; stroke: #6a7b3d; stroke-width: 0.3"/>
+     <path d="M 407.86 147.239944
+L 422.26 147.239944
+L 422.26 146.603025
+L 407.86 146.603025
+L 407.86 147.239944
+" clip-path="url(#pffc3051ed0)" style="fill: #6c7c3c; stroke: #6c7c3c; stroke-width: 0.3"/>
+     <path d="M 407.86 146.603025
+L 422.26 146.603025
+L 422.26 145.966106
+L 407.86 145.966106
+L 407.86 146.603025
+" clip-path="url(#pffc3051ed0)" style="fill: #6d7c3b; stroke: #6d7c3b; stroke-width: 0.3"/>
+     <path d="M 407.86 145.966106
+L 422.26 145.966106
+L 422.26 145.329188
+L 407.86 145.329188
+L 407.86 145.966106
+" clip-path="url(#pffc3051ed0)" style="fill: #6f7d3a; stroke: #6f7d3a; stroke-width: 0.3"/>
+     <path d="M 407.86 145.329188
+L 422.26 145.329188
+L 422.26 144.692269
+L 407.86 144.692269
+L 407.86 145.329188
+" clip-path="url(#pffc3051ed0)" style="fill: #717d39; stroke: #717d39; stroke-width: 0.3"/>
+     <path d="M 407.86 144.692269
+L 422.26 144.692269
+L 422.26 144.05535
+L 407.86 144.05535
+L 407.86 144.692269
+" clip-path="url(#pffc3051ed0)" style="fill: #737e38; stroke: #737e38; stroke-width: 0.3"/>
+     <path d="M 407.86 144.05535
+L 422.26 144.05535
+L 422.26 143.418431
+L 407.86 143.418431
+L 407.86 144.05535
+" clip-path="url(#pffc3051ed0)" style="fill: #747e38; stroke: #747e38; stroke-width: 0.3"/>
+     <path d="M 407.86 143.418431
+L 422.26 143.418431
+L 422.26 142.781513
+L 407.86 142.781513
+L 407.86 143.418431
+" clip-path="url(#pffc3051ed0)" style="fill: #767f37; stroke: #767f37; stroke-width: 0.3"/>
+     <path d="M 407.86 142.781513
+L 422.26 142.781513
+L 422.26 142.144594
+L 407.86 142.144594
+L 407.86 142.781513
+" clip-path="url(#pffc3051ed0)" style="fill: #787f36; stroke: #787f36; stroke-width: 0.3"/>
+     <path d="M 407.86 142.144594
+L 422.26 142.144594
+L 422.26 141.507675
+L 407.86 141.507675
+L 407.86 142.144594
+" clip-path="url(#pffc3051ed0)" style="fill: #798035; stroke: #798035; stroke-width: 0.3"/>
+     <path d="M 407.86 141.507675
+L 422.26 141.507675
+L 422.26 140.870756
+L 407.86 140.870756
+L 407.86 141.507675
+" clip-path="url(#pffc3051ed0)" style="fill: #7b8034; stroke: #7b8034; stroke-width: 0.3"/>
+     <path d="M 407.86 140.870756
+L 422.26 140.870756
+L 422.26 140.233837
+L 407.86 140.233837
+L 407.86 140.870756
+" clip-path="url(#pffc3051ed0)" style="fill: #7d8134; stroke: #7d8134; stroke-width: 0.3"/>
+     <path d="M 407.86 140.233837
+L 422.26 140.233837
+L 422.26 139.596919
+L 407.86 139.596919
+L 407.86 140.233837
+" clip-path="url(#pffc3051ed0)" style="fill: #7f8133; stroke: #7f8133; stroke-width: 0.3"/>
+     <path d="M 407.86 139.596919
+L 422.26 139.596919
+L 422.26 138.96
+L 407.86 138.96
+L 407.86 139.596919
+" clip-path="url(#pffc3051ed0)" style="fill: #818232; stroke: #818232; stroke-width: 0.3"/>
+     <path d="M 407.86 138.96
+L 422.26 138.96
+L 422.26 138.323081
+L 407.86 138.323081
+L 407.86 138.96
+" clip-path="url(#pffc3051ed0)" style="fill: #828231; stroke: #828231; stroke-width: 0.3"/>
+     <path d="M 407.86 138.323081
+L 422.26 138.323081
+L 422.26 137.686162
+L 407.86 137.686162
+L 407.86 138.323081
+" clip-path="url(#pffc3051ed0)" style="fill: #848331; stroke: #848331; stroke-width: 0.3"/>
+     <path d="M 407.86 137.686162
+L 422.26 137.686162
+L 422.26 137.049244
+L 407.86 137.049244
+L 407.86 137.686162
+" clip-path="url(#pffc3051ed0)" style="fill: #868330; stroke: #868330; stroke-width: 0.3"/>
+     <path d="M 407.86 137.049244
+L 422.26 137.049244
+L 422.26 136.412325
+L 407.86 136.412325
+L 407.86 137.049244
+" clip-path="url(#pffc3051ed0)" style="fill: #88842f; stroke: #88842f; stroke-width: 0.3"/>
+     <path d="M 407.86 136.412325
+L 422.26 136.412325
+L 422.26 135.775406
+L 407.86 135.775406
+L 407.86 136.412325
+" clip-path="url(#pffc3051ed0)" style="fill: #8a842f; stroke: #8a842f; stroke-width: 0.3"/>
+     <path d="M 407.86 135.775406
+L 422.26 135.775406
+L 422.26 135.138487
+L 407.86 135.138487
+L 407.86 135.775406
+" clip-path="url(#pffc3051ed0)" style="fill: #8c852e; stroke: #8c852e; stroke-width: 0.3"/>
+     <path d="M 407.86 135.138487
+L 422.26 135.138487
+L 422.26 134.501569
+L 407.86 134.501569
+L 407.86 135.138487
+" clip-path="url(#pffc3051ed0)" style="fill: #8e852e; stroke: #8e852e; stroke-width: 0.3"/>
+     <path d="M 407.86 134.501569
+L 422.26 134.501569
+L 422.26 133.86465
+L 407.86 133.86465
+L 407.86 134.501569
+" clip-path="url(#pffc3051ed0)" style="fill: #8f862d; stroke: #8f862d; stroke-width: 0.3"/>
+     <path d="M 407.86 133.86465
+L 422.26 133.86465
+L 422.26 133.227731
+L 407.86 133.227731
+L 407.86 133.86465
+" clip-path="url(#pffc3051ed0)" style="fill: #91862d; stroke: #91862d; stroke-width: 0.3"/>
+     <path d="M 407.86 133.227731
+L 422.26 133.227731
+L 422.26 132.590812
+L 407.86 132.590812
+L 407.86 133.227731
+" clip-path="url(#pffc3051ed0)" style="fill: #93872c; stroke: #93872c; stroke-width: 0.3"/>
+     <path d="M 407.86 132.590812
+L 422.26 132.590812
+L 422.26 131.953894
+L 407.86 131.953894
+L 407.86 132.590812
+" clip-path="url(#pffc3051ed0)" style="fill: #95872c; stroke: #95872c; stroke-width: 0.3"/>
+     <path d="M 407.86 131.953894
+L 422.26 131.953894
+L 422.26 131.316975
+L 407.86 131.316975
+L 407.86 131.953894
+" clip-path="url(#pffc3051ed0)" style="fill: #97882c; stroke: #97882c; stroke-width: 0.3"/>
+     <path d="M 407.86 131.316975
+L 422.26 131.316975
+L 422.26 130.680056
+L 407.86 130.680056
+L 407.86 131.316975
+" clip-path="url(#pffc3051ed0)" style="fill: #99882c; stroke: #99882c; stroke-width: 0.3"/>
+     <path d="M 407.86 130.680056
+L 422.26 130.680056
+L 422.26 130.043138
+L 407.86 130.043138
+L 407.86 130.680056
+" clip-path="url(#pffc3051ed0)" style="fill: #9b892b; stroke: #9b892b; stroke-width: 0.3"/>
+     <path d="M 407.86 130.043138
+L 422.26 130.043138
+L 422.26 129.406219
+L 407.86 129.406219
+L 407.86 130.043138
+" clip-path="url(#pffc3051ed0)" style="fill: #9d892b; stroke: #9d892b; stroke-width: 0.3"/>
+     <path d="M 407.86 129.406219
+L 422.26 129.406219
+L 422.26 128.7693
+L 407.86 128.7693
+L 407.86 129.406219
+" clip-path="url(#pffc3051ed0)" style="fill: #9f892b; stroke: #9f892b; stroke-width: 0.3"/>
+     <path d="M 407.86 128.7693
+L 422.26 128.7693
+L 422.26 128.132381
+L 407.86 128.132381
+L 407.86 128.7693
+" clip-path="url(#pffc3051ed0)" style="fill: #a18a2b; stroke: #a18a2b; stroke-width: 0.3"/>
+     <path d="M 407.86 128.132381
+L 422.26 128.132381
+L 422.26 127.495463
+L 407.86 127.495463
+L 407.86 128.132381
+" clip-path="url(#pffc3051ed0)" style="fill: #a38a2c; stroke: #a38a2c; stroke-width: 0.3"/>
+     <path d="M 407.86 127.495463
+L 422.26 127.495463
+L 422.26 126.858544
+L 407.86 126.858544
+L 407.86 127.495463
+" clip-path="url(#pffc3051ed0)" style="fill: #a58b2c; stroke: #a58b2c; stroke-width: 0.3"/>
+     <path d="M 407.86 126.858544
+L 422.26 126.858544
+L 422.26 126.221625
+L 407.86 126.221625
+L 407.86 126.858544
+" clip-path="url(#pffc3051ed0)" style="fill: #a78b2c; stroke: #a78b2c; stroke-width: 0.3"/>
+     <path d="M 407.86 126.221625
+L 422.26 126.221625
+L 422.26 125.584706
+L 407.86 125.584706
+L 407.86 126.221625
+" clip-path="url(#pffc3051ed0)" style="fill: #a98c2c; stroke: #a98c2c; stroke-width: 0.3"/>
+     <path d="M 407.86 125.584706
+L 422.26 125.584706
+L 422.26 124.947788
+L 407.86 124.947788
+L 407.86 125.584706
+" clip-path="url(#pffc3051ed0)" style="fill: #ab8c2d; stroke: #ab8c2d; stroke-width: 0.3"/>
+     <path d="M 407.86 124.947788
+L 422.26 124.947788
+L 422.26 124.310869
+L 407.86 124.310869
+L 407.86 124.947788
+" clip-path="url(#pffc3051ed0)" style="fill: #ad8c2d; stroke: #ad8c2d; stroke-width: 0.3"/>
+     <path d="M 407.86 124.310869
+L 422.26 124.310869
+L 422.26 123.67395
+L 407.86 123.67395
+L 407.86 124.310869
+" clip-path="url(#pffc3051ed0)" style="fill: #af8d2e; stroke: #af8d2e; stroke-width: 0.3"/>
+     <path d="M 407.86 123.67395
+L 422.26 123.67395
+L 422.26 123.037031
+L 407.86 123.037031
+L 407.86 123.67395
+" clip-path="url(#pffc3051ed0)" style="fill: #b18d2f; stroke: #b18d2f; stroke-width: 0.3"/>
+     <path d="M 407.86 123.037031
+L 422.26 123.037031
+L 422.26 122.400113
+L 407.86 122.400113
+L 407.86 123.037031
+" clip-path="url(#pffc3051ed0)" style="fill: #b38e2f; stroke: #b38e2f; stroke-width: 0.3"/>
+     <path d="M 407.86 122.400113
+L 422.26 122.400113
+L 422.26 121.763194
+L 407.86 121.763194
+L 407.86 122.400113
+" clip-path="url(#pffc3051ed0)" style="fill: #b58e30; stroke: #b58e30; stroke-width: 0.3"/>
+     <path d="M 407.86 121.763194
+L 422.26 121.763194
+L 422.26 121.126275
+L 407.86 121.126275
+L 407.86 121.763194
+" clip-path="url(#pffc3051ed0)" style="fill: #b78e31; stroke: #b78e31; stroke-width: 0.3"/>
+     <path d="M 407.86 121.126275
+L 422.26 121.126275
+L 422.26 120.489356
+L 407.86 120.489356
+L 407.86 121.126275
+" clip-path="url(#pffc3051ed0)" style="fill: #b98f32; stroke: #b98f32; stroke-width: 0.3"/>
+     <path d="M 407.86 120.489356
+L 422.26 120.489356
+L 422.26 119.852438
+L 407.86 119.852438
+L 407.86 120.489356
+" clip-path="url(#pffc3051ed0)" style="fill: #bb8f33; stroke: #bb8f33; stroke-width: 0.3"/>
+     <path d="M 407.86 119.852438
+L 422.26 119.852438
+L 422.26 119.215519
+L 407.86 119.215519
+L 407.86 119.852438
+" clip-path="url(#pffc3051ed0)" style="fill: #bd8f34; stroke: #bd8f34; stroke-width: 0.3"/>
+     <path d="M 407.86 119.215519
+L 422.26 119.215519
+L 422.26 118.5786
+L 407.86 118.5786
+L 407.86 119.215519
+" clip-path="url(#pffc3051ed0)" style="fill: #be9035; stroke: #be9035; stroke-width: 0.3"/>
+     <path d="M 407.86 118.5786
+L 422.26 118.5786
+L 422.26 117.941681
+L 407.86 117.941681
+L 407.86 118.5786
+" clip-path="url(#pffc3051ed0)" style="fill: #c09036; stroke: #c09036; stroke-width: 0.3"/>
+     <path d="M 407.86 117.941681
+L 422.26 117.941681
+L 422.26 117.304763
+L 407.86 117.304763
+L 407.86 117.941681
+" clip-path="url(#pffc3051ed0)" style="fill: #c29037; stroke: #c29037; stroke-width: 0.3"/>
+     <path d="M 407.86 117.304763
+L 422.26 117.304763
+L 422.26 116.667844
+L 407.86 116.667844
+L 407.86 117.304763
+" clip-path="url(#pffc3051ed0)" style="fill: #c49138; stroke: #c49138; stroke-width: 0.3"/>
+     <path d="M 407.86 116.667844
+L 422.26 116.667844
+L 422.26 116.030925
+L 407.86 116.030925
+L 407.86 116.667844
+" clip-path="url(#pffc3051ed0)" style="fill: #c6913a; stroke: #c6913a; stroke-width: 0.3"/>
+     <path d="M 407.86 116.030925
+L 422.26 116.030925
+L 422.26 115.394006
+L 407.86 115.394006
+L 407.86 116.030925
+" clip-path="url(#pffc3051ed0)" style="fill: #c8913b; stroke: #c8913b; stroke-width: 0.3"/>
+     <path d="M 407.86 115.394006
+L 422.26 115.394006
+L 422.26 114.757087
+L 407.86 114.757087
+L 407.86 115.394006
+" clip-path="url(#pffc3051ed0)" style="fill: #ca923c; stroke: #ca923c; stroke-width: 0.3"/>
+     <path d="M 407.86 114.757087
+L 422.26 114.757087
+L 422.26 114.120169
+L 407.86 114.120169
+L 407.86 114.757087
+" clip-path="url(#pffc3051ed0)" style="fill: #cb923e; stroke: #cb923e; stroke-width: 0.3"/>
+     <path d="M 407.86 114.120169
+L 422.26 114.120169
+L 422.26 113.48325
+L 407.86 113.48325
+L 407.86 114.120169
+" clip-path="url(#pffc3051ed0)" style="fill: #cd923f; stroke: #cd923f; stroke-width: 0.3"/>
+     <path d="M 407.86 113.48325
+L 422.26 113.48325
+L 422.26 112.846331
+L 407.86 112.846331
+L 407.86 113.48325
+" clip-path="url(#pffc3051ed0)" style="fill: #cf9340; stroke: #cf9340; stroke-width: 0.3"/>
+     <path d="M 407.86 112.846331
+L 422.26 112.846331
+L 422.26 112.209413
+L 407.86 112.209413
+L 407.86 112.846331
+" clip-path="url(#pffc3051ed0)" style="fill: #d19342; stroke: #d19342; stroke-width: 0.3"/>
+     <path d="M 407.86 112.209413
+L 422.26 112.209413
+L 422.26 111.572494
+L 407.86 111.572494
+L 407.86 112.209413
+" clip-path="url(#pffc3051ed0)" style="fill: #d29343; stroke: #d29343; stroke-width: 0.3"/>
+     <path d="M 407.86 111.572494
+L 422.26 111.572494
+L 422.26 110.935575
+L 407.86 110.935575
+L 407.86 111.572494
+" clip-path="url(#pffc3051ed0)" style="fill: #d49445; stroke: #d49445; stroke-width: 0.3"/>
+     <path d="M 407.86 110.935575
+L 422.26 110.935575
+L 422.26 110.298656
+L 407.86 110.298656
+L 407.86 110.935575
+" clip-path="url(#pffc3051ed0)" style="fill: #d69446; stroke: #d69446; stroke-width: 0.3"/>
+     <path d="M 407.86 110.298656
+L 422.26 110.298656
+L 422.26 109.661738
+L 407.86 109.661738
+L 407.86 110.298656
+" clip-path="url(#pffc3051ed0)" style="fill: #d89448; stroke: #d89448; stroke-width: 0.3"/>
+     <path d="M 407.86 109.661738
+L 422.26 109.661738
+L 422.26 109.024819
+L 407.86 109.024819
+L 407.86 109.661738
+" clip-path="url(#pffc3051ed0)" style="fill: #d9954a; stroke: #d9954a; stroke-width: 0.3"/>
+     <path d="M 407.86 109.024819
+L 422.26 109.024819
+L 422.26 108.3879
+L 407.86 108.3879
+L 407.86 109.024819
+" clip-path="url(#pffc3051ed0)" style="fill: #db954b; stroke: #db954b; stroke-width: 0.3"/>
+     <path d="M 407.86 108.3879
+L 422.26 108.3879
+L 422.26 107.750981
+L 407.86 107.750981
+L 407.86 108.3879
+" clip-path="url(#pffc3051ed0)" style="fill: #dd954d; stroke: #dd954d; stroke-width: 0.3"/>
+     <path d="M 407.86 107.750981
+L 422.26 107.750981
+L 422.26 107.114063
+L 407.86 107.114063
+L 407.86 107.750981
+" clip-path="url(#pffc3051ed0)" style="fill: #de964f; stroke: #de964f; stroke-width: 0.3"/>
+     <path d="M 407.86 107.114063
+L 422.26 107.114063
+L 422.26 106.477144
+L 407.86 106.477144
+L 407.86 107.114063
+" clip-path="url(#pffc3051ed0)" style="fill: #e09651; stroke: #e09651; stroke-width: 0.3"/>
+     <path d="M 407.86 106.477144
+L 422.26 106.477144
+L 422.26 105.840225
+L 407.86 105.840225
+L 407.86 106.477144
+" clip-path="url(#pffc3051ed0)" style="fill: #e19752; stroke: #e19752; stroke-width: 0.3"/>
+     <path d="M 407.86 105.840225
+L 422.26 105.840225
+L 422.26 105.203306
+L 407.86 105.203306
+L 407.86 105.840225
+" clip-path="url(#pffc3051ed0)" style="fill: #e39754; stroke: #e39754; stroke-width: 0.3"/>
+     <path d="M 407.86 105.203306
+L 422.26 105.203306
+L 422.26 104.566388
+L 407.86 104.566388
+L 407.86 105.203306
+" clip-path="url(#pffc3051ed0)" style="fill: #e49756; stroke: #e49756; stroke-width: 0.3"/>
+     <path d="M 407.86 104.566388
+L 422.26 104.566388
+L 422.26 103.929469
+L 407.86 103.929469
+L 407.86 104.566388
+" clip-path="url(#pffc3051ed0)" style="fill: #e69858; stroke: #e69858; stroke-width: 0.3"/>
+     <path d="M 407.86 103.929469
+L 422.26 103.929469
+L 422.26 103.29255
+L 407.86 103.29255
+L 407.86 103.929469
+" clip-path="url(#pffc3051ed0)" style="fill: #e7985a; stroke: #e7985a; stroke-width: 0.3"/>
+     <path d="M 407.86 103.29255
+L 422.26 103.29255
+L 422.26 102.655631
+L 407.86 102.655631
+L 407.86 103.29255
+" clip-path="url(#pffc3051ed0)" style="fill: #e9995c; stroke: #e9995c; stroke-width: 0.3"/>
+     <path d="M 407.86 102.655631
+L 422.26 102.655631
+L 422.26 102.018713
+L 407.86 102.018713
+L 407.86 102.655631
+" clip-path="url(#pffc3051ed0)" style="fill: #ea995e; stroke: #ea995e; stroke-width: 0.3"/>
+     <path d="M 407.86 102.018713
+L 422.26 102.018713
+L 422.26 101.381794
+L 407.86 101.381794
+L 407.86 102.018713
+" clip-path="url(#pffc3051ed0)" style="fill: #eb9a60; stroke: #eb9a60; stroke-width: 0.3"/>
+     <path d="M 407.86 101.381794
+L 422.26 101.381794
+L 422.26 100.744875
+L 407.86 100.744875
+L 407.86 101.381794
+" clip-path="url(#pffc3051ed0)" style="fill: #ed9a62; stroke: #ed9a62; stroke-width: 0.3"/>
+     <path d="M 407.86 100.744875
+L 422.26 100.744875
+L 422.26 100.107956
+L 407.86 100.107956
+L 407.86 100.744875
+" clip-path="url(#pffc3051ed0)" style="fill: #ee9b64; stroke: #ee9b64; stroke-width: 0.3"/>
+     <path d="M 407.86 100.107956
+L 422.26 100.107956
+L 422.26 99.471038
+L 407.86 99.471038
+L 407.86 100.107956
+" clip-path="url(#pffc3051ed0)" style="fill: #ef9b67; stroke: #ef9b67; stroke-width: 0.3"/>
+     <path d="M 407.86 99.471038
+L 422.26 99.471038
+L 422.26 98.834119
+L 407.86 98.834119
+L 407.86 99.471038
+" clip-path="url(#pffc3051ed0)" style="fill: #f09c69; stroke: #f09c69; stroke-width: 0.3"/>
+     <path d="M 407.86 98.834119
+L 422.26 98.834119
+L 422.26 98.1972
+L 407.86 98.1972
+L 407.86 98.834119
+" clip-path="url(#pffc3051ed0)" style="fill: #f19d6b; stroke: #f19d6b; stroke-width: 0.3"/>
+     <path d="M 407.86 98.1972
+L 422.26 98.1972
+L 422.26 97.560281
+L 407.86 97.560281
+L 407.86 98.1972
+" clip-path="url(#pffc3051ed0)" style="fill: #f29d6d; stroke: #f29d6d; stroke-width: 0.3"/>
+     <path d="M 407.86 97.560281
+L 422.26 97.560281
+L 422.26 96.923362
+L 407.86 96.923362
+L 407.86 97.560281
+" clip-path="url(#pffc3051ed0)" style="fill: #f39e70; stroke: #f39e70; stroke-width: 0.3"/>
+     <path d="M 407.86 96.923362
+L 422.26 96.923362
+L 422.26 96.286444
+L 407.86 96.286444
+L 407.86 96.923362
+" clip-path="url(#pffc3051ed0)" style="fill: #f49f72; stroke: #f49f72; stroke-width: 0.3"/>
+     <path d="M 407.86 96.286444
+L 422.26 96.286444
+L 422.26 95.649525
+L 407.86 95.649525
+L 407.86 96.286444
+" clip-path="url(#pffc3051ed0)" style="fill: #f59f74; stroke: #f59f74; stroke-width: 0.3"/>
+     <path d="M 407.86 95.649525
+L 422.26 95.649525
+L 422.26 95.012606
+L 407.86 95.012606
+L 407.86 95.649525
+" clip-path="url(#pffc3051ed0)" style="fill: #f6a077; stroke: #f6a077; stroke-width: 0.3"/>
+     <path d="M 407.86 95.012606
+L 422.26 95.012606
+L 422.26 94.375688
+L 407.86 94.375688
+L 407.86 95.012606
+" clip-path="url(#pffc3051ed0)" style="fill: #f7a179; stroke: #f7a179; stroke-width: 0.3"/>
+     <path d="M 407.86 94.375688
+L 422.26 94.375688
+L 422.26 93.738769
+L 407.86 93.738769
+L 407.86 94.375688
+" clip-path="url(#pffc3051ed0)" style="fill: #f8a17b; stroke: #f8a17b; stroke-width: 0.3"/>
+     <path d="M 407.86 93.738769
+L 422.26 93.738769
+L 422.26 93.10185
+L 407.86 93.10185
+L 407.86 93.738769
+" clip-path="url(#pffc3051ed0)" style="fill: #f8a27e; stroke: #f8a27e; stroke-width: 0.3"/>
+     <path d="M 407.86 93.10185
+L 422.26 93.10185
+L 422.26 92.464931
+L 407.86 92.464931
+L 407.86 93.10185
+" clip-path="url(#pffc3051ed0)" style="fill: #f9a380; stroke: #f9a380; stroke-width: 0.3"/>
+     <path d="M 407.86 92.464931
+L 422.26 92.464931
+L 422.26 91.828012
+L 407.86 91.828012
+L 407.86 92.464931
+" clip-path="url(#pffc3051ed0)" style="fill: #f9a382; stroke: #f9a382; stroke-width: 0.3"/>
+     <path d="M 407.86 91.828012
+L 422.26 91.828012
+L 422.26 91.191094
+L 407.86 91.191094
+L 407.86 91.828012
+" clip-path="url(#pffc3051ed0)" style="fill: #faa485; stroke: #faa485; stroke-width: 0.3"/>
+     <path d="M 407.86 91.191094
+L 422.26 91.191094
+L 422.26 90.554175
+L 407.86 90.554175
+L 407.86 91.191094
+" clip-path="url(#pffc3051ed0)" style="fill: #faa587; stroke: #faa587; stroke-width: 0.3"/>
+     <path d="M 407.86 90.554175
+L 422.26 90.554175
+L 422.26 89.917256
+L 407.86 89.917256
+L 407.86 90.554175
+" clip-path="url(#pffc3051ed0)" style="fill: #fba689; stroke: #fba689; stroke-width: 0.3"/>
+     <path d="M 407.86 89.917256
+L 422.26 89.917256
+L 422.26 89.280338
+L 407.86 89.280338
+L 407.86 89.917256
+" clip-path="url(#pffc3051ed0)" style="fill: #fba68c; stroke: #fba68c; stroke-width: 0.3"/>
+     <path d="M 407.86 89.280338
+L 422.26 89.280338
+L 422.26 88.643419
+L 407.86 88.643419
+L 407.86 89.280338
+" clip-path="url(#pffc3051ed0)" style="fill: #fca78e; stroke: #fca78e; stroke-width: 0.3"/>
+     <path d="M 407.86 88.643419
+L 422.26 88.643419
+L 422.26 88.0065
+L 407.86 88.0065
+L 407.86 88.643419
+" clip-path="url(#pffc3051ed0)" style="fill: #fca890; stroke: #fca890; stroke-width: 0.3"/>
+     <path d="M 407.86 88.0065
+L 422.26 88.0065
+L 422.26 87.369581
+L 407.86 87.369581
+L 407.86 88.0065
+" clip-path="url(#pffc3051ed0)" style="fill: #fca993; stroke: #fca993; stroke-width: 0.3"/>
+     <path d="M 407.86 87.369581
+L 422.26 87.369581
+L 422.26 86.732663
+L 407.86 86.732663
+L 407.86 87.369581
+" clip-path="url(#pffc3051ed0)" style="fill: #fca995; stroke: #fca995; stroke-width: 0.3"/>
+     <path d="M 407.86 86.732663
+L 422.26 86.732663
+L 422.26 86.095744
+L 407.86 86.095744
+L 407.86 86.732663
+" clip-path="url(#pffc3051ed0)" style="fill: #fdaa97; stroke: #fdaa97; stroke-width: 0.3"/>
+     <path d="M 407.86 86.095744
+L 422.26 86.095744
+L 422.26 85.458825
+L 407.86 85.458825
+L 407.86 86.095744
+" clip-path="url(#pffc3051ed0)" style="fill: #fdab9a; stroke: #fdab9a; stroke-width: 0.3"/>
+     <path d="M 407.86 85.458825
+L 422.26 85.458825
+L 422.26 84.821906
+L 407.86 84.821906
+L 407.86 85.458825
+" clip-path="url(#pffc3051ed0)" style="fill: #fdac9c; stroke: #fdac9c; stroke-width: 0.3"/>
+     <path d="M 407.86 84.821906
+L 422.26 84.821906
+L 422.26 84.184988
+L 407.86 84.184988
+L 407.86 84.821906
+" clip-path="url(#pffc3051ed0)" style="fill: #fdac9e; stroke: #fdac9e; stroke-width: 0.3"/>
+     <path d="M 407.86 84.184988
+L 422.26 84.184988
+L 422.26 83.548069
+L 407.86 83.548069
+L 407.86 84.184988
+" clip-path="url(#pffc3051ed0)" style="fill: #fdada0; stroke: #fdada0; stroke-width: 0.3"/>
+     <path d="M 407.86 83.548069
+L 422.26 83.548069
+L 422.26 82.91115
+L 407.86 82.91115
+L 407.86 83.548069
+" clip-path="url(#pffc3051ed0)" style="fill: #fdaea2; stroke: #fdaea2; stroke-width: 0.3"/>
+     <path d="M 407.86 82.91115
+L 422.26 82.91115
+L 422.26 82.274231
+L 407.86 82.274231
+L 407.86 82.91115
+" clip-path="url(#pffc3051ed0)" style="fill: #fdafa5; stroke: #fdafa5; stroke-width: 0.3"/>
+     <path d="M 407.86 82.274231
+L 422.26 82.274231
+L 422.26 81.637313
+L 407.86 81.637313
+L 407.86 82.274231
+" clip-path="url(#pffc3051ed0)" style="fill: #fdafa7; stroke: #fdafa7; stroke-width: 0.3"/>
+     <path d="M 407.86 81.637313
+L 422.26 81.637313
+L 422.26 81.000394
+L 407.86 81.000394
+L 407.86 81.637313
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb0a9; stroke: #fdb0a9; stroke-width: 0.3"/>
+     <path d="M 407.86 81.000394
+L 422.26 81.000394
+L 422.26 80.363475
+L 407.86 80.363475
+L 407.86 81.000394
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb1ab; stroke: #fdb1ab; stroke-width: 0.3"/>
+     <path d="M 407.86 80.363475
+L 422.26 80.363475
+L 422.26 79.726556
+L 407.86 79.726556
+L 407.86 80.363475
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb2ad; stroke: #fdb2ad; stroke-width: 0.3"/>
+     <path d="M 407.86 79.726556
+L 422.26 79.726556
+L 422.26 79.089638
+L 407.86 79.089638
+L 407.86 79.726556
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb2af; stroke: #fdb2af; stroke-width: 0.3"/>
+     <path d="M 407.86 79.089638
+L 422.26 79.089638
+L 422.26 78.452719
+L 407.86 78.452719
+L 407.86 79.089638
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb3b1; stroke: #fdb3b1; stroke-width: 0.3"/>
+     <path d="M 407.86 78.452719
+L 422.26 78.452719
+L 422.26 77.8158
+L 407.86 77.8158
+L 407.86 78.452719
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb4b4; stroke: #fdb4b4; stroke-width: 0.3"/>
+     <path d="M 407.86 77.8158
+L 422.26 77.8158
+L 422.26 77.178881
+L 407.86 77.178881
+L 407.86 77.8158
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb4b6; stroke: #fdb4b6; stroke-width: 0.3"/>
+     <path d="M 407.86 77.178881
+L 422.26 77.178881
+L 422.26 76.541962
+L 407.86 76.541962
+L 407.86 77.178881
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb5b8; stroke: #fdb5b8; stroke-width: 0.3"/>
+     <path d="M 407.86 76.541962
+L 422.26 76.541962
+L 422.26 75.905044
+L 407.86 75.905044
+L 407.86 76.541962
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb6ba; stroke: #fdb6ba; stroke-width: 0.3"/>
+     <path d="M 407.86 75.905044
+L 422.26 75.905044
+L 422.26 75.268125
+L 407.86 75.268125
+L 407.86 75.905044
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb7bc; stroke: #fdb7bc; stroke-width: 0.3"/>
+     <path d="M 407.86 75.268125
+L 422.26 75.268125
+L 422.26 74.631206
+L 407.86 74.631206
+L 407.86 75.268125
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb7be; stroke: #fdb7be; stroke-width: 0.3"/>
+     <path d="M 407.86 74.631206
+L 422.26 74.631206
+L 422.26 73.994288
+L 407.86 73.994288
+L 407.86 74.631206
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb8c0; stroke: #fdb8c0; stroke-width: 0.3"/>
+     <path d="M 407.86 73.994288
+L 422.26 73.994288
+L 422.26 73.357369
+L 407.86 73.357369
+L 407.86 73.994288
+" clip-path="url(#pffc3051ed0)" style="fill: #fdb9c2; stroke: #fdb9c2; stroke-width: 0.3"/>
+     <path d="M 407.86 73.357369
+L 422.26 73.357369
+L 422.26 72.72045
+L 407.86 72.72045
+L 407.86 73.357369
+" clip-path="url(#pffc3051ed0)" style="fill: #fdbac4; stroke: #fdbac4; stroke-width: 0.3"/>
+     <path d="M 407.86 72.72045
+L 422.26 72.72045
+L 422.26 72.083531
+L 407.86 72.083531
+L 407.86 72.72045
+" clip-path="url(#pffc3051ed0)" style="fill: #fdbac7; stroke: #fdbac7; stroke-width: 0.3"/>
+     <path d="M 407.86 72.083531
+L 422.26 72.083531
+L 422.26 71.446613
+L 407.86 71.446613
+L 407.86 72.083531
+" clip-path="url(#pffc3051ed0)" style="fill: #fdbbc9; stroke: #fdbbc9; stroke-width: 0.3"/>
+     <path d="M 407.86 71.446613
+L 422.26 71.446613
+L 422.26 70.809694
+L 407.86 70.809694
+L 407.86 71.446613
+" clip-path="url(#pffc3051ed0)" style="fill: #fdbccb; stroke: #fdbccb; stroke-width: 0.3"/>
+     <path d="M 407.86 70.809694
+L 422.26 70.809694
+L 422.26 70.172775
+L 407.86 70.172775
+L 407.86 70.809694
+" clip-path="url(#pffc3051ed0)" style="fill: #fdbccd; stroke: #fdbccd; stroke-width: 0.3"/>
+     <path d="M 407.86 70.172775
+L 422.26 70.172775
+L 422.26 69.535856
+L 407.86 69.535856
+L 407.86 70.172775
+" clip-path="url(#pffc3051ed0)" style="fill: #fcbdcf; stroke: #fcbdcf; stroke-width: 0.3"/>
+     <path d="M 407.86 69.535856
+L 422.26 69.535856
+L 422.26 68.898937
+L 407.86 68.898937
+L 407.86 69.535856
+" clip-path="url(#pffc3051ed0)" style="fill: #fcbed1; stroke: #fcbed1; stroke-width: 0.3"/>
+     <path d="M 407.86 68.898937
+L 422.26 68.898937
+L 422.26 68.262019
+L 407.86 68.262019
+L 407.86 68.898937
+" clip-path="url(#pffc3051ed0)" style="fill: #fcbfd3; stroke: #fcbfd3; stroke-width: 0.3"/>
+     <path d="M 407.86 68.262019
+L 422.26 68.262019
+L 422.26 67.6251
+L 407.86 67.6251
+L 407.86 68.262019
+" clip-path="url(#pffc3051ed0)" style="fill: #fcbfd6; stroke: #fcbfd6; stroke-width: 0.3"/>
+     <path d="M 407.86 67.6251
+L 422.26 67.6251
+L 422.26 66.988181
+L 407.86 66.988181
+L 407.86 67.6251
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc0d8; stroke: #fcc0d8; stroke-width: 0.3"/>
+     <path d="M 407.86 66.988181
+L 422.26 66.988181
+L 422.26 66.351263
+L 407.86 66.351263
+L 407.86 66.988181
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc1da; stroke: #fcc1da; stroke-width: 0.3"/>
+     <path d="M 407.86 66.351263
+L 422.26 66.351263
+L 422.26 65.714344
+L 407.86 65.714344
+L 407.86 66.351263
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc2dc; stroke: #fcc2dc; stroke-width: 0.3"/>
+     <path d="M 407.86 65.714344
+L 422.26 65.714344
+L 422.26 65.077425
+L 407.86 65.077425
+L 407.86 65.714344
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc3df; stroke: #fcc3df; stroke-width: 0.3"/>
+     <path d="M 407.86 65.077425
+L 422.26 65.077425
+L 422.26 64.440506
+L 407.86 64.440506
+L 407.86 65.077425
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc3e1; stroke: #fcc3e1; stroke-width: 0.3"/>
+     <path d="M 407.86 64.440506
+L 422.26 64.440506
+L 422.26 63.803588
+L 407.86 63.803588
+L 407.86 64.440506
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc4e3; stroke: #fcc4e3; stroke-width: 0.3"/>
+     <path d="M 407.86 63.803588
+L 422.26 63.803588
+L 422.26 63.166669
+L 407.86 63.166669
+L 407.86 63.803588
+" clip-path="url(#pffc3051ed0)" style="fill: #fcc5e5; stroke: #fcc5e5; stroke-width: 0.3"/>
+     <path d="M 407.86 63.166669
+L 422.26 63.166669
+L 422.26 62.52975
+L 407.86 62.52975
+L 407.86 63.166669
+" clip-path="url(#pffc3051ed0)" style="fill: #fbc6e8; stroke: #fbc6e8; stroke-width: 0.3"/>
+     <path d="M 407.86 62.52975
+L 422.26 62.52975
+L 422.26 61.892831
+L 407.86 61.892831
+L 407.86 62.52975
+" clip-path="url(#pffc3051ed0)" style="fill: #fbc6ea; stroke: #fbc6ea; stroke-width: 0.3"/>
+     <path d="M 407.86 61.892831
+L 422.26 61.892831
+L 422.26 61.255912
+L 407.86 61.255912
+L 407.86 61.892831
+" clip-path="url(#pffc3051ed0)" style="fill: #fbc7ec; stroke: #fbc7ec; stroke-width: 0.3"/>
+     <path d="M 407.86 61.255912
+L 422.26 61.255912
+L 422.26 60.618994
+L 407.86 60.618994
+L 407.86 61.255912
+" clip-path="url(#pffc3051ed0)" style="fill: #fbc8ef; stroke: #fbc8ef; stroke-width: 0.3"/>
+     <path d="M 407.86 60.618994
+L 422.26 60.618994
+L 422.26 59.982075
+L 407.86 59.982075
+L 407.86 60.618994
+" clip-path="url(#pffc3051ed0)" style="fill: #fbc9f1; stroke: #fbc9f1; stroke-width: 0.3"/>
+     <path d="M 407.86 59.982075
+L 422.26 59.982075
+L 422.26 59.345156
+L 407.86 59.345156
+L 407.86 59.982075
+" clip-path="url(#pffc3051ed0)" style="fill: #fbcaf3; stroke: #fbcaf3; stroke-width: 0.3"/>
+     <path d="M 407.86 59.345156
+L 422.26 59.345156
+L 422.26 58.708237
+L 407.86 58.708237
+L 407.86 59.345156
+" clip-path="url(#pffc3051ed0)" style="fill: #fbcaf6; stroke: #fbcaf6; stroke-width: 0.3"/>
+     <path d="M 407.86 58.708237
+L 422.26 58.708237
+L 422.26 58.071319
+L 407.86 58.071319
+L 407.86 58.708237
+" clip-path="url(#pffc3051ed0)" style="fill: #facbf8; stroke: #facbf8; stroke-width: 0.3"/>
+     <path d="M 407.86 58.071319
+L 422.26 58.071319
+L 422.26 57.4344
+L 407.86 57.4344
+L 407.86 58.071319
+" clip-path="url(#pffc3051ed0)" style="fill: #faccfa; stroke: #faccfa; stroke-width: 0.3"/>
+    </g>
+    <g id="matplotlib.axis_5"/>
+    <g id="matplotlib.axis_6">
+     <g id="ytick_19">
+      <g id="line2d_55">
+       <defs>
+        <path id="m2da2498750" d="M 0 0
+L 4 0
+" style="stroke: #000000; stroke-width: 0.6"/>
+       </defs>
+       <g>
+        <use xlink:href="#m2da2498750" x="422.26" y="220.4856" style="stroke: #000000; stroke-width: 0.6"/>
+       </g>
+      </g>
+      <g id="text_18">
+       <!-- 0 -->
+       <g transform="translate(428.26 224.130913) scale(0.1 -0.1)">
+        <use xlink:href="#TeXGyreHeros-Regular-30"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_20">
+      <g id="line2d_56">
+       <g>
+        <use xlink:href="#m2da2498750" x="422.26" y="130.80744" style="stroke: #000000; stroke-width: 0.6"/>
+       </g>
+      </g>
+      <g id="text_19">
+       <!-- 5 -->
+       <g transform="translate(428.26 134.452752) scale(0.1 -0.1)">
+        <use xlink:href="#TeXGyreHeros-Regular-35"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_21">
+      <g id="line2d_57">
+       <defs>
+        <path id="m5fbb11652a" d="M 0 0
+L 2 0
+" style="stroke: #000000; stroke-width: 0.48"/>
+       </defs>
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="202.549968" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_22">
+      <g id="line2d_58">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="184.614336" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_23">
+      <g id="line2d_59">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="166.678704" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_24">
+      <g id="line2d_60">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="148.743072" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_25">
+      <g id="line2d_61">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="112.871808" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_26">
+      <g id="line2d_62">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="94.936176" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_27">
+      <g id="line2d_63">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="77.000544" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="ytick_28">
+      <g id="line2d_64">
+       <g>
+        <use xlink:href="#m5fbb11652a" x="422.26" y="59.064912" style="stroke: #000000; stroke-width: 0.48"/>
+       </g>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- Progress -->
+      <g transform="translate(439.999062 118.956094) rotate(-270) scale(0.1 -0.1)">
+       <defs>
+        <path id="TeXGyreHeros-Regular-67" d="M 186 1645
+C 186 589 781 -96 1568 -96
+C 1990 -96 2285 83 2637 506
+L 2637 282
+C 2637 -608 2272 -947 1651 -947
+C 1229 -947 902 -794 838 -384
+L 294 -384
+C 352 -1018 845 -1395 1632 -1395
+C 2682 -1395 3130 -928 3130 550
+L 3130 3354
+L 2637 3354
+L 2637 2867
+C 2368 3264 2042 3450 1613 3450
+C 762 3450 186 2733 186 1645
+z
+M 742 1677
+C 742 2483 1101 2957 1670 2957
+C 2246 2957 2586 2470 2586 1658
+C 2586 858 2240 397 1677 397
+C 1094 397 742 864 742 1677
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#TeXGyreHeros-Regular-50"/>
+       <use xlink:href="#TeXGyreHeros-Regular-72" transform="translate(66.699997 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-6f" transform="translate(99.999985 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-67" transform="translate(155.599976 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-72" transform="translate(211.199966 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(244.499954 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-73" transform="translate(300.099945 0)"/>
+       <use xlink:href="#TeXGyreHeros-Regular-73" transform="translate(350.09993 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="LineCollection_1"/>
+    <g id="patch_16">
+     <path d="M 407.86 220.4856
+L 415.06 220.4856
+L 422.26 220.4856
+L 422.26 57.4344
+L 415.06 57.4344
+L 407.86 57.4344
+L 407.86 220.4856
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.6; stroke-linejoin: miter; stroke-linecap: square"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_21">
+   <!-- Where aliases act -->
+   <g transform="translate(183.937109 14.122344) scale(0.11 -0.11)">
+    <defs>
+     <path id="TeXGyreHeros-Bold-57" d="M 83 4666
+L 1402 0
+L 2266 0
+L 3027 3642
+L 3808 0
+L 4672 0
+L 5965 4666
+L 4947 4666
+L 4250 1165
+L 3494 4666
+L 2547 4666
+L 1824 1171
+L 1101 4666
+L 83 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-68" d="M 429 0
+L 1325 0
+L 1325 2074
+C 1325 2470 1613 2752 2016 2752
+C 2336 2752 2566 2579 2566 2112
+L 2566 0
+L 3462 0
+L 3462 2317
+C 3462 3123 2989 3514 2336 3514
+C 1894 3514 1574 3334 1325 2957
+L 1325 4666
+L 429 4666
+L 429 0
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-65" d="M 141 1683
+C 141 576 742 -58 1722 -58
+C 2496 -58 3123 294 3322 973
+L 2438 973
+C 2362 723 2080 627 1754 627
+C 1331 627 1062 819 1037 1491
+L 3354 1491
+L 3360 1600
+C 3360 2790 2758 3514 1741 3514
+C 749 3514 141 2842 141 1683
+z
+M 1050 2086
+C 1107 2566 1331 2829 1728 2829
+C 2112 2829 2381 2579 2426 2086
+L 1050 2086
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-72" d="M 403 0
+L 1299 0
+L 1299 1837
+C 1299 2362 1562 2624 2086 2624
+C 2182 2624 2246 2618 2368 2598
+L 2368 3507
+C 2317 3514 2285 3514 2259 3514
+C 1850 3514 1491 3245 1299 2778
+L 1299 3456
+L 403 3456
+L 403 0
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-20" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-61" d="M 179 934
+C 179 262 653 -58 1229 -58
+C 1613 -58 1965 109 2278 435
+C 2278 256 2298 102 2381 0
+L 3354 0
+L 3354 109
+C 3194 256 3149 352 3149 531
+L 3149 2451
+C 3149 3155 2669 3514 1734 3514
+C 800 3514 314 3117 256 2317
+L 1120 2317
+C 1165 2675 1312 2790 1754 2790
+C 2099 2790 2272 2675 2272 2445
+C 2272 2080 2003 2118 1555 2042
+L 1197 1978
+C 512 1856 179 1562 179 934
+z
+M 1075 1037
+C 1075 1299 1216 1395 1587 1466
+L 1894 1523
+C 2131 1568 2170 1581 2272 1632
+L 2272 1478
+C 2272 960 2016 666 1562 666
+C 1261 666 1075 781 1075 1037
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-6c" d="M 429 0
+L 1325 0
+L 1325 4666
+L 429 4666
+L 429 0
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-69" d="M 429 0
+L 1325 0
+L 1325 3456
+L 429 3456
+L 429 0
+z
+M 442 3872
+L 1338 3872
+L 1338 4768
+L 442 4768
+L 442 3872
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-73" d="M 186 1094
+C 211 339 768 -58 1818 -58
+C 2790 -58 3328 326 3328 1024
+L 3328 1069
+C 3328 1466 3104 1760 2650 1894
+L 1517 2221
+C 1267 2291 1203 2349 1203 2490
+C 1203 2682 1408 2810 1722 2810
+C 2150 2810 2362 2656 2368 2342
+L 3232 2342
+C 3219 3072 2656 3514 1728 3514
+C 851 3514 307 3072 307 2362
+C 307 1939 422 1709 1062 1510
+L 2131 1178
+C 2355 1107 2432 1037 2432 941
+C 2432 730 2182 646 1766 646
+C 1357 646 1139 723 1062 1094
+L 186 1094
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-63" d="M 218 1702
+C 218 563 813 -58 1837 -58
+C 2675 -58 3258 461 3341 1197
+L 2483 1197
+C 2368 838 2189 666 1843 666
+C 1389 666 1114 1030 1114 1702
+C 1114 2336 1280 2790 1843 2790
+C 2208 2790 2381 2618 2483 2163
+L 3341 2163
+C 3277 3008 2714 3514 1850 3514
+C 819 3514 218 2880 218 1702
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-74" d="M 90 2790
+L 531 2790
+L 531 742
+C 531 198 819 -26 1408 -26
+C 1606 -26 1766 -6 1926 0
+L 1926 627
+C 1837 614 1786 608 1722 608
+C 1485 608 1427 678 1427 986
+L 1427 2790
+L 1926 2790
+L 1926 3386
+L 1427 3386
+L 1427 4314
+L 531 4314
+L 531 3386
+L 90 3386
+L 90 2790
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#TeXGyreHeros-Bold-57"/>
+    <use xlink:href="#TeXGyreHeros-Bold-68" transform="translate(94.399994 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-65" transform="translate(155.499985 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-72" transform="translate(211.099976 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-65" transform="translate(249.999969 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-20" transform="translate(305.59996 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-61" transform="translate(333.399948 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-6c" transform="translate(388.999939 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-69" transform="translate(416.799927 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-61" transform="translate(444.599915 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-73" transform="translate(500.199905 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-65" transform="translate(555.799896 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-73" transform="translate(611.399887 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-20" transform="translate(666.999878 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-61" transform="translate(694.799866 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-63" transform="translate(750.399857 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-74" transform="translate(805.999847 0)"/>
+   </g>
+  </g>
+  <g id="text_22">
+   <!-- Left labels -->
+   <g transform="translate(31.402344 166.160078) rotate(-90) scale(0.11 -0.11)">
+    <defs>
+     <path id="TeXGyreHeros-Bold-4c" d="M 512 0
+L 3706 0
+L 3706 800
+L 1472 800
+L 1472 4666
+L 512 4666
+L 512 0
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-66" d="M 90 2790
+L 576 2790
+L 576 0
+L 1472 0
+L 1472 2790
+L 2003 2790
+L 2003 3386
+L 1472 3386
+L 1472 3725
+C 1472 3904 1549 3994 1715 3994
+C 1792 3994 1894 3987 1971 3974
+L 1971 4646
+C 1805 4659 1581 4666 1459 4666
+C 864 4666 576 4384 576 3802
+L 576 3386
+L 90 3386
+L 90 2790
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-62" d="M 378 0
+L 1274 0
+L 1274 397
+C 1491 102 1792 -58 2227 -58
+C 3053 -58 3680 640 3680 1683
+C 3680 2662 3136 3514 2227 3514
+C 1798 3514 1491 3354 1274 3008
+L 1274 4666
+L 378 4666
+L 378 0
+z
+M 1274 1741
+C 1274 2368 1581 2765 2029 2765
+C 2470 2765 2784 2362 2784 1722
+C 2784 1094 2470 691 2029 691
+C 1574 691 1274 1082 1274 1741
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#TeXGyreHeros-Bold-4c"/>
+    <use xlink:href="#TeXGyreHeros-Bold-65" transform="translate(61.099991 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-66" transform="translate(116.699982 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-74" transform="translate(149.999969 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-20" transform="translate(183.299957 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-6c" transform="translate(211.099945 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-61" transform="translate(238.899933 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-62" transform="translate(294.499924 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-65" transform="translate(355.599915 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-6c" transform="translate(411.199905 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-73" transform="translate(438.999893 0)"/>
+   </g>
+  </g>
+  <g id="text_23">
+   <!-- Right labels -->
+   <g transform="translate(461.115 170.13125) rotate(-90) scale(0.11 -0.11)">
+    <defs>
+     <path id="TeXGyreHeros-Bold-52" d="M 512 0
+L 1472 0
+L 1472 1850
+L 2573 1850
+C 2989 1850 3168 1683 3168 1293
+L 3155 800
+C 3155 365 3181 224 3302 0
+L 4333 0
+L 4333 173
+C 4186 256 4128 352 4128 557
+C 4102 1933 4077 1997 3482 2253
+C 4006 2458 4269 2835 4269 3405
+C 4269 4128 3840 4666 3014 4666
+L 512 4666
+L 512 0
+z
+M 1472 2650
+L 1472 3866
+L 2630 3866
+C 3155 3866 3309 3674 3309 3270
+C 3309 2854 3174 2650 2630 2650
+L 1472 2650
+z
+" transform="scale(0.015625)"/>
+     <path id="TeXGyreHeros-Bold-67" d="M 218 1690
+C 218 614 781 -58 1632 -58
+C 2035 -58 2278 64 2611 397
+L 2611 -115
+C 2611 -531 2298 -819 1850 -819
+C 1510 -819 1286 -678 1216 -416
+L 288 -416
+C 301 -979 870 -1395 1818 -1395
+C 2861 -1395 3462 -928 3462 -115
+L 3462 3456
+L 2611 3456
+L 2611 2925
+C 2342 3334 2048 3514 1651 3514
+C 832 3514 218 2758 218 1690
+z
+M 1114 1702
+C 1114 2355 1408 2765 1843 2765
+C 2291 2765 2624 2342 2624 1702
+C 2624 1075 2298 691 1830 691
+C 1408 691 1114 1075 1114 1702
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#TeXGyreHeros-Bold-52"/>
+    <use xlink:href="#TeXGyreHeros-Bold-69" transform="translate(72.199982 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-67" transform="translate(99.999969 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-68" transform="translate(161.09996 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-74" transform="translate(222.199951 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-20" transform="translate(255.499939 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-6c" transform="translate(283.299927 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-61" transform="translate(311.099915 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-62" transform="translate(366.699905 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-65" transform="translate(427.799896 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-6c" transform="translate(483.399887 0)"/>
+    <use xlink:href="#TeXGyreHeros-Bold-73" transform="translate(511.199875 0)"/>
+   </g>
+  </g>
+  <g id="text_24">
+   <!-- Time -->
+   <g transform="translate(218.985625 270.240937) scale(0.1 -0.1)">
+    <defs>
+     <path id="TeXGyreHeros-Regular-54" d="M 134 4141
+L 1670 4141
+L 1670 0
+L 2266 0
+L 2266 4141
+L 3795 4141
+L 3795 4666
+L 134 4666
+L 134 4141
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#TeXGyreHeros-Regular-54"/>
+    <use xlink:href="#TeXGyreHeros-Regular-69" transform="translate(61.099991 0)"/>
+    <use xlink:href="#TeXGyreHeros-Regular-6d" transform="translate(83.299988 0)"/>
+    <use xlink:href="#TeXGyreHeros-Regular-65" transform="translate(166.599976 0)"/>
+   </g>
+  </g>
+  <g id="text_25">
+   <!-- Signal -->
+   <g transform="translate(12.9725 152.854531) rotate(-90) scale(0.1 -0.1)">
+    <defs>
+     <path id="TeXGyreHeros-Regular-53" d="M 307 1517
+C 307 416 1050 -115 2150 -115
+C 3334 -115 3974 448 3974 1280
+C 3974 1856 3616 2278 2982 2451
+L 1811 2765
+C 1248 2912 1043 3098 1043 3456
+C 1043 3930 1459 4282 2086 4282
+C 2829 4282 3251 3942 3251 3334
+L 3814 3334
+C 3814 4250 3181 4781 2106 4781
+C 1082 4781 448 4218 448 3373
+C 448 2803 749 2445 1363 2285
+L 2522 1978
+C 3110 1824 3379 1587 3379 1222
+C 3379 710 2995 410 2189 410
+C 1306 410 870 851 870 1517
+L 307 1517
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#TeXGyreHeros-Regular-53"/>
+    <use xlink:href="#TeXGyreHeros-Regular-69" transform="translate(66.699997 0)"/>
+    <use xlink:href="#TeXGyreHeros-Regular-67" transform="translate(88.899994 0)"/>
+    <use xlink:href="#TeXGyreHeros-Regular-6e" transform="translate(144.499985 0)"/>
+    <use xlink:href="#TeXGyreHeros-Regular-61" transform="translate(200.099976 0)"/>
+    <use xlink:href="#TeXGyreHeros-Regular-6c" transform="translate(255.699966 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p20e8e39b88">
+   <rect x="64.33" y="34.44" width="331.53" height="209.04"/>
+  </clipPath>
+  <clipPath id="p19882f2ac8">
+   <rect x="87.5371" y="59.5248" width="89.5131" height="52.26"/>
+  </clipPath>
+  <clipPath id="pffc3051ed0">
+   <rect x="407.86" y="57.4344" width="14.4" height="163.0512"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -1,0 +1,1082 @@
+=============================
+Compatibility alias reference
+=============================
+
+UltraPlot's official documentation and function signatures exclusively use
+canonical parameter names. Alternative shorthand spellings (aliases) remain fully
+supported through silent, behind-the-scenes keyword translation.
+
+* **Context-dependent:** A single shorthand alias might map to different underlying
+  Matplotlib properties depending on the artist type.
+* **Silent translation:** Using aliases will not trigger deprecation warnings in
+  the current version, though these may be enabled in a future release.
+* **RC settings:** Entries marked ``rc (dotless)`` are generated from the rc registry.
+  To bypass compatibility aliases entirely, pass the canonical dotted spellings
+  through ``rc_kw``.
+
+Visual alias explorer
+---------------------
+
+Use the interactive diagram below to discover which aliases apply to different
+parts of your plot:
+
+* **Hover or Focus:** Target a labeled part of the figure to preview its aliases.
+* **Click:** Select a label to keep that area highlighted and filter the complete mapping table below.
+* **Learn More:** Click the API link in the detail panel to view the canonical documentation.
+
+
+.. raw:: html
+
+   <div class="uplt-alias-explorer" aria-label="Interactive UltraPlot alias map">
+     <div class="uplt-alias-summary" aria-live="polite">
+       <span><strong data-alias-total>0</strong> accepted spellings</span>
+       <span><strong data-alias-context-total>0</strong> contexts</span>
+       <span>one canonical API</span>
+     </div>
+
+     <div class="uplt-alias-map-layout">
+       <div class="uplt-alias-visual-column">
+        <div class="uplt-alias-map" aria-label="Annotated UltraPlot figure">
+         <svg viewBox="0 0 760 520" role="img" aria-labelledby="uplt-alias-map-title uplt-alias-map-desc">
+           <title id="uplt-alias-map-title">Alias locations on an UltraPlot figure</title>
+           <desc id="uplt-alias-map-desc">An annotated chart with interactive labels for figure layout, side titles, axes, plot data, artist style, legend, and colorbar aliases.</desc>
+           <image class="uplt-alias-real-figure" href="_static/alias-map.svg" x="20" y="16" width="720" height="427" preserveAspectRatio="xMidYMid meet"/>
+
+           <rect class="uplt-alias-target" data-alias-target="layout" x="20" y="16" width="720" height="427" rx="8"/>
+           <g class="uplt-alias-target" data-alias-target="titles">
+             <rect x="23" y="44" width="48" height="356" rx="5"/>
+             <rect x="688" y="44" width="48" height="356" rx="5"/>
+             <rect x="105" y="19" width="528" height="55" rx="5"/>
+           </g>
+           <rect class="uplt-alias-target" data-alias-target="axes" x="116" y="67" width="514" height="326" rx="5"/>
+           <path class="uplt-alias-target uplt-alias-target-line" data-alias-target="plot" d="M120 345 C192 170 236 359 326 286 S449 98 623 182"/>
+           <g class="uplt-alias-target" data-alias-target="style">
+             <circle cx="121" cy="338" r="13"/><circle cx="325" cy="279" r="13"/><circle cx="511" cy="119" r="13"/><circle cx="623" cy="174" r="13"/>
+           </g>
+           <rect class="uplt-alias-target" data-alias-target="legend" x="501" y="64" width="128" height="68" rx="4"/>
+           <rect class="uplt-alias-target" data-alias-target="colorbar" x="643" y="98" width="38" height="260" rx="4"/>
+           <rect class="uplt-alias-target" data-alias-target="inset" x="151" y="101" width="143" height="112" rx="4"/>
+
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(436.3 -38)" data-layout-key="layout" data-anchor-x="380" data-anchor-y="64" data-contexts="figure.init,gridspec,subplot,inset" data-targets="layout,inset" data-label="Figure &amp; layout" data-api="api/ultraplot.figure.Figure.html">
+             <path class="uplt-alias-wire" d="M29.0 52.5 L-56.3 102.0"/>
+             <rect width="146" height="54" rx="14"/><text x="73" y="22">Figure &amp;</text><text x="73" y="41">layout</text>
+           </g>
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(-34.9 -34.9)" data-layout-key="titles" data-anchor-x="71" data-anchor-y="64" data-contexts="axes.format,figure.format" data-targets="titles" data-label="Side titles &amp; labels" data-api="api/ultraplot.figure.Figure.html#ultraplot.figure.Figure.format">
+             <path class="uplt-alias-wire" d="M84.1 51.3 L105.9 98.9"/>
+             <rect width="146" height="54" rx="14"/><text x="73" y="22">Side titles</text><text x="73" y="41">&amp; labels</text>
+           </g>
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(106.5 469.8)" data-layout-key="axes" data-anchor-x="235" data-anchor-y="393" data-contexts="cartesian.format,geo.format,polar.format,taylor.format,projection" data-targets="axes" data-label="Axes &amp; projections" data-api="api/ultraplot.axes.CartesianAxes.html#ultraplot.axes.CartesianAxes.format">
+             <path class="uplt-alias-wire" d="M102.8 2.9 L128.5 -76.8"/>
+             <rect width="190" height="54" rx="14"/><text x="95" y="22">Axes &amp;</text><text x="95" y="41">projections</text>
+           </g>
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(450.3 297.1)" data-layout-key="plot" data-anchor-x="326" data-anchor-y="286" data-contexts="plot.*" data-targets="plot" data-label="Plot methods" data-api="api/ultraplot.axes.PlotAxes.html">
+             <path class="uplt-alias-wire" d="M2.9 12.6 L-124.3 -11.1"/>
+             <rect width="160" height="54" rx="14"/><text x="80" y="33">Plot methods</text>
+           </g>
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(625.2 -28)" data-layout-key="legend" data-anchor-x="610" data-anchor-y="64" data-contexts="legend" data-targets="legend" data-label="Legend" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.legend">
+             <path class="uplt-alias-wire" d="M35.2 52.1 L-15.2 92.0"/>
+             <rect width="134" height="54" rx="14"/><text x="67" y="33">Legend</text>
+           </g>
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(610.1 425.8)" data-layout-key="colorbar" data-anchor-x="662" data-anchor-y="358" data-contexts="colorbar" data-targets="colorbar" data-label="Colorbar" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.colorbar">
+             <path class="uplt-alias-wire" d="M63.2 3.0 L51.9 -67.8"/>
+             <rect width="134" height="54" rx="14"/><text x="67" y="33">Colorbar</text>
+           </g>
+           <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(-52.2 398.1)" data-layout-key="style" data-anchor-x="121" data-anchor-y="351" data-contexts="style.*" data-targets="style" data-label="Artist styling" data-api="api/ultraplot.axes.PlotAxes.html">
+             <path class="uplt-alias-wire" d="M107.1 1.8 L173.2 -47.1"/>
+             <rect width="146" height="54" rx="14"/><text x="73" y="33">Artist styling</text>
+           </g>
+         </svg>
+        </div>
+
+        <div class="uplt-alias-categories" aria-label="Alias categories">
+         <button type="button" data-contexts="figure.init,figure.format,gridspec,subplot,inset" data-targets="layout,inset,titles" data-label="Figure &amp; layout" data-api="api/ultraplot.figure.Figure.html"><span>▦</span>Figure &amp; layout</button>
+         <button type="button" data-contexts="axes.format,cartesian.format,geo.format,polar.format,taylor.format" data-targets="axes,titles" data-label="Axes formatting" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.format"><span>⌗</span>Axes formatting</button>
+         <button type="button" data-contexts="colorbar,legend" data-targets="colorbar,legend" data-label="Guides" data-api="api/ultraplot.axes.Axes.html"><span>◫</span>Guides</button>
+         <button type="button" data-contexts="plot.*" data-targets="plot" data-label="Plot methods" data-api="api/ultraplot.axes.PlotAxes.html"><span>⌁</span>Plot methods</button>
+         <button type="button" data-contexts="style.*" data-targets="style" data-label="Artist properties" data-api="api/ultraplot.axes.PlotAxes.html"><span>✦</span>Artist properties</button>
+         <button type="button" data-contexts="cycle,projection,scale.*" data-targets="axes,style" data-label="Constructors" data-api="api.html#constructor-functions"><span>⚙</span>Constructors</button>
+         <button type="button" data-contexts="rc (dotless)" data-targets="layout,axes,titles,plot,style,legend,colorbar,inset" data-label="Configuration" data-api="api/ultraplot.config.Configurator.html"><span>⋮</span>Configuration</button>
+        </div>
+
+        <div class="uplt-alias-filter">
+          <label for="uplt-alias-search">Find an accepted or canonical spelling</label>
+          <div>
+            <input id="uplt-alias-search" type="search" placeholder="Try lw, linewidth, proj, or title…" autocomplete="off"/>
+            <button type="button" data-alias-reset>Show all</button>
+          </div>
+          <p data-alias-filter-status aria-live="polite"></p>
+        </div>
+       </div>
+
+       <aside class="uplt-alias-detail" aria-live="polite">
+         <p class="uplt-alias-detail-help">Drag labels to arrange the map. Hover to preview aliases, or click to keep a selection.</p>
+         <h3 data-alias-detail-title>All aliases</h3>
+         <p data-alias-detail-copy>Select a labelled region or a category below.</p>
+         <div class="uplt-alias-preview" data-alias-preview></div>
+         <a class="uplt-alias-api-link" data-alias-api hidden>Open canonical API <span aria-hidden="true">→</span></a>
+       </aside>
+     </div>
+   </div>
+
+.. alias-table-start
+
+Function keyword aliases
+------------------------
+
+These mappings apply only in the listed call context.
+
+=================== ================= ==================
+Context             Accepted spelling Canonical spelling
+=================== ================= ==================
+figure.init         ref               refnum
+figure.init         aspect            refaspect
+figure.init         axwidth           refwidth
+figure.init         axheight          refheight
+figure.init         width             figwidth
+figure.init         height            figheight
+axes.format         ltitle            lefttitle
+axes.format         ctitle            centertitle
+axes.format         rtitle            righttitle
+axes.format         ultitle           upperlefttitle
+axes.format         uctitle           uppercentertitle
+axes.format         urtitle           upperrighttitle
+axes.format         lltitle           lowerlefttitle
+axes.format         lctitle           lowercentertitle
+axes.format         lrtitle           lowerrighttitle
+cartesian.format    xloc              xspineloc
+cartesian.format    yloc              yspineloc
+cartesian.format    xticklabels       xformatter
+cartesian.format    yticklabels       yformatter
+cartesian.format    xticks            xlocator
+cartesian.format    yticks            ylocator
+cartesian.format    xminorticks       xminorlocator
+cartesian.format    yminorticks       yminorlocator
+geo.format          lonlines          lonlocator
+geo.format          latlines          latlocator
+geo.format          lonminorlines     lonminorlocator
+geo.format          latminorlines     latminorlocator
+geo.format          lonlines_kw       lonlocator_kw
+geo.format          latlines_kw       latlocator_kw
+geo.format          lonminorlines_kw  lonminorlocator_kw
+geo.format          latminorlines_kw  latminorlocator_kw
+polar.format        thetalines        thetalocator
+polar.format        rlines            rlocator
+polar.format        thetaminorlines   thetaminorlocator
+polar.format        rminorlines       rminorlocator
+polar.format        thetalabels       thetaformatter
+polar.format        rlabels           rformatter
+taylor.format       corrlines         corrlocator
+taylor.format       corrticks         corrlocator
+figure.format       figtitle          suptitle
+figure.format       llabels           leftlabels
+figure.format       rowlabels         leftlabels
+figure.format       rlabels           rightlabels
+figure.format       blabels           bottomlabels
+figure.format       tlabels           toplabels
+figure.format       collabels         toplabels
+colorbar            location          loc
+colorbar            grid              drawedges
+colorbar            edges             drawedges
+colorbar            length            shrink
+colorbar            title             label
+colorbar            labelloc          labellocation
+colorbar            locator           ticks
+colorbar            formatter         format
+colorbar            ticklabels        format
+colorbar            minorlocator      minorticks
+colorbar            c                 color
+colorbar            lw                linewidth
+colorbar            tickdir           tickdirection
+colorbar            frame             frameon
+legend              location          loc
+legend              ncol              ncols
+legend              frame             frameon
+gridspec            wratios           width_ratios
+gridspec            hratios           height_ratios
+subplot             proj              projection
+subplot             proj_kw           projection_kw
+inset               proj              projection
+cycle               N                 samples
+projection          lon_0             lon0
+projection          lat_0             lat0
+scale.log           basex             base
+scale.log           basey             base
+scale.log           nonposx           nonpos
+scale.log           nonposy           nonpos
+scale.log           subsx             subs
+scale.log           subsy             subs
+scale.symlog        basex             base
+scale.symlog        basey             base
+scale.symlog        linthreshx        linthresh
+scale.symlog        linthreshy        linthresh
+scale.symlog        linscalex         linscale
+scale.symlog        linscaley         linscale
+scale.symlog        subsx             subs
+scale.symlog        subsy             subs
+plot.labels         fmt               formatter
+plot.text           c                 color
+plot.text           colors            color
+plot.text           size              fontsize
+plot.contour_labels c                 colors
+plot.contour_labels color             colors
+plot.contour_labels size              fontsize
+plot.error_bars     bars              barstds
+plot.error_bars     barstd            barstds
+plot.error_bars     barpctile         barpctiles
+plot.error_bars     boxes             boxstds
+plot.error_bars     boxstd            boxstds
+plot.error_bars     boxpctile         boxpctiles
+plot.error_shading  shade             shadestds
+plot.error_shading  shadestd          shadestds
+plot.error_shading  shadepctile       shadepctiles
+plot.error_shading  fade              fadestds
+plot.error_shading  fadestd           fadestds
+plot.error_shading  fadepctile        fadepctiles
+plot.colormap       c                 colors
+plot.colormap       color             colors
+plot.levels         N                 levels
+plot.stacked        stack             stacked
+plot.statistics     mean              means
+plot.statistics     median            medians
+plot.boxplot        showmeans         means
+plot.boxplot        filled            fill
+plot.violinplot     showmeans         means
+plot.violinplot     showmedians       medians
+plot.hist           width             rwidth
+plot.hist           stack             stacked
+plot.hist           filled            fill
+plot.pie            labelpad          labeldistance
+=================== ================= ==================
+
+Artist property aliases
+-----------------------
+
+These are Matplotlib-style shorthand properties accepted while styling artists.
+
+================ ================= ==================
+Context          Accepted spelling Canonical spelling
+================ ================= ==================
+style.rgba       r                 red
+style.rgba       g                 green
+style.rgba       b                 blue
+style.rgba       a                 alpha
+style.hsla       h                 hue
+style.hsla       s                 saturation
+style.hsla       c                 saturation
+style.hsla       chroma            saturation
+style.hsla       l                 luminance
+style.hsla       a                 alpha
+style.patch      a                 alpha
+style.patch      alphas            alpha
+style.patch      fa                alpha
+style.patch      facealpha         alpha
+style.patch      facealphas        alpha
+style.patch      fillalpha         alpha
+style.patch      fillalphas        alpha
+style.patch      c                 color
+style.patch      colors            color
+style.patch      ec                edgecolor
+style.patch      edgecolors        edgecolor
+style.patch      fc                facecolor
+style.patch      facecolors        facecolor
+style.patch      fillcolor         facecolor
+style.patch      fillcolors        facecolor
+style.patch      h                 hatch
+style.patch      hatching          hatch
+style.patch      ls                linestyle
+style.patch      linestyles        linestyle
+style.patch      lw                linewidth
+style.patch      linewidths        linewidth
+style.patch      ew                linewidth
+style.patch      edgewidth         linewidth
+style.patch      edgewidths        linewidth
+style.patch      z                 zorder
+style.patch      zorders           zorder
+style.line       a                 alpha
+style.line       alphas            alpha
+style.line       c                 color
+style.line       colors            color
+style.line       d                 dashes
+style.line       dash              dashes
+style.line       ds                drawstyle
+style.line       drawstyles        drawstyle
+style.line       fs                fillstyle
+style.line       fillstyles        fillstyle
+style.line       mfs               fillstyle
+style.line       markerfillstyle   fillstyle
+style.line       markerfillstyles  fillstyle
+style.line       ls                linestyle
+style.line       linestyles        linestyle
+style.line       lw                linewidth
+style.line       linewidths        linewidth
+style.line       m                 marker
+style.line       markers           marker
+style.line       s                 markersize
+style.line       ms                markersize
+style.line       markersizes       markersize
+style.line       ew                markeredgewidth
+style.line       edgewidth         markeredgewidth
+style.line       edgewidths        markeredgewidth
+style.line       mew               markeredgewidth
+style.line       markeredgewidths  markeredgewidth
+style.line       ec                markeredgecolor
+style.line       edgecolor         markeredgecolor
+style.line       edgecolors        markeredgecolor
+style.line       mec               markeredgecolor
+style.line       markeredgecolors  markeredgecolor
+style.line       fc                markerfacecolor
+style.line       facecolor         markerfacecolor
+style.line       facecolors        markerfacecolor
+style.line       fillcolor         markerfacecolor
+style.line       fillcolors        markerfacecolor
+style.line       mc                markerfacecolor
+style.line       markercolor       markerfacecolor
+style.line       markercolors      markerfacecolor
+style.line       mfc               markerfacecolor
+style.line       markerfacecolors  markerfacecolor
+style.line       z                 zorder
+style.line       zorders           zorder
+style.collection a                 alpha
+style.collection alphas            alpha
+style.collection c                 colors
+style.collection color             colors
+style.collection ec                edgecolors
+style.collection edgecolor         edgecolors
+style.collection mec               edgecolors
+style.collection markeredgecolor   edgecolors
+style.collection markeredgecolors  edgecolors
+style.collection fc                facecolors
+style.collection facecolor         facecolors
+style.collection fillcolor         facecolors
+style.collection fillcolors        facecolors
+style.collection mc                facecolors
+style.collection markercolor       facecolors
+style.collection markercolors      facecolors
+style.collection mfc               facecolors
+style.collection markerfacecolor   facecolors
+style.collection markerfacecolors  facecolors
+style.collection ls                linestyles
+style.collection linestyle         linestyles
+style.collection lw                linewidths
+style.collection linewidth         linewidths
+style.collection ew                linewidths
+style.collection edgewidth         linewidths
+style.collection edgewidths        linewidths
+style.collection mew               linewidths
+style.collection markeredgewidth   linewidths
+style.collection markeredgewidths  linewidths
+style.collection m                 marker
+style.collection markers           marker
+style.collection s                 sizes
+style.collection ms                sizes
+style.collection markersize        sizes
+style.collection markersizes       sizes
+style.collection z                 zorder
+style.collection zorders           zorder
+style.text       c                 color
+style.text       fontcolor         color
+style.text       family            fontfamily
+style.text       name              fontfamily
+style.text       fontname          fontfamily
+style.text       size              fontsize
+style.text       stretch           fontstretch
+style.text       style             fontstyle
+style.text       variant           fontvariant
+style.text       weight            fontweight
+style.text       fp                fontproperties
+style.text       font              fontproperties
+style.text       font_properties   fontproperties
+style.text       z                 zorder
+style.text       zorders           zorder
+================ ================= ==================
+
+Dotless rc aliases
+------------------
+
+Use the dotted canonical spelling through ``rc_kw`` when avoiding the accepted shorthand.
+
+============ ================================= ==================================
+Context      Accepted spelling                 Canonical spelling
+============ ================================= ==================================
+rc (dotless) _internalclassic_mode             _internal.classic_mode
+rc (dotless) abcbbox                           abc.bbox
+rc (dotless) abcbboxalpha                      abc.bboxalpha
+rc (dotless) abcbboxcolor                      abc.bboxcolor
+rc (dotless) abcbboxpad                        abc.bboxpad
+rc (dotless) abcbboxstyle                      abc.bboxstyle
+rc (dotless) abcborder                         abc.border
+rc (dotless) abcborderwidth                    abc.borderwidth
+rc (dotless) abccolor                          abc.color
+rc (dotless) abcformat                         abc.format
+rc (dotless) abcloc                            abc.loc
+rc (dotless) abcsize                           abc.size
+rc (dotless) abcstyle                          abc.style
+rc (dotless) abctitlepad                       abc.titlepad
+rc (dotless) abcweight                         abc.weight
+rc (dotless) aggpathchunksize                  agg.path.chunksize
+rc (dotless) animationbitrate                  animation.bitrate
+rc (dotless) animationcodec                    animation.codec
+rc (dotless) animationconvert_args             animation.convert_args
+rc (dotless) animationconvert_path             animation.convert_path
+rc (dotless) animationembed_limit              animation.embed_limit
+rc (dotless) animationffmpeg_args              animation.ffmpeg_args
+rc (dotless) animationffmpeg_path              animation.ffmpeg_path
+rc (dotless) animationframe_format             animation.frame_format
+rc (dotless) animationhtml                     animation.html
+rc (dotless) animationwriter                   animation.writer
+rc (dotless) axes3dautomargin                  axes3d.automargin
+rc (dotless) axes3dgrid                        axes3d.grid
+rc (dotless) axes3dmouserotationstyle          axes3d.mouserotationstyle
+rc (dotless) axes3dtrackballborder             axes3d.trackballborder
+rc (dotless) axes3dtrackballsize               axes3d.trackballsize
+rc (dotless) axes3dxaxispanecolor              axes3d.xaxis.panecolor
+rc (dotless) axes3dyaxispanecolor              axes3d.yaxis.panecolor
+rc (dotless) axes3dzaxispanecolor              axes3d.zaxis.panecolor
+rc (dotless) axesalpha                         axes.alpha
+rc (dotless) axesautolimit_mode                axes.autolimit_mode
+rc (dotless) axesaxisbelow                     axes.axisbelow
+rc (dotless) axesedgecolor                     axes.edgecolor
+rc (dotless) axesfacealpha                     axes.facealpha
+rc (dotless) axesfacecolor                     axes.facecolor
+rc (dotless) axesformatterlimits               axes.formatter.limits
+rc (dotless) axesformattermin_exponent         axes.formatter.min_exponent
+rc (dotless) axesformatteroffset_threshold     axes.formatter.offset_threshold
+rc (dotless) axesformattertimerotation         axes.formatter.timerotation
+rc (dotless) axesformatteruse_locale           axes.formatter.use_locale
+rc (dotless) axesformatteruse_mathtext         axes.formatter.use_mathtext
+rc (dotless) axesformatteruseoffset            axes.formatter.useoffset
+rc (dotless) axesformatterzerotrim             axes.formatter.zerotrim
+rc (dotless) axesgrid                          axes.grid
+rc (dotless) axesgridaxis                      axes.grid.axis
+rc (dotless) axesgridwhich                     axes.grid.which
+rc (dotless) axesinbounds                      axes.inbounds
+rc (dotless) axeslabelcolor                    axes.labelcolor
+rc (dotless) axeslabelpad                      axes.labelpad
+rc (dotless) axeslabelsize                     axes.labelsize
+rc (dotless) axeslabelweight                   axes.labelweight
+rc (dotless) axeslinewidth                     axes.linewidth
+rc (dotless) axesmargin                        axes.margin
+rc (dotless) axesprop_cycle                    axes.prop_cycle
+rc (dotless) axesspinesbottom                  axes.spines.bottom
+rc (dotless) axesspinesleft                    axes.spines.left
+rc (dotless) axesspinesright                   axes.spines.right
+rc (dotless) axesspinestop                     axes.spines.top
+rc (dotless) axessticky_edges                  axes.sticky_edges
+rc (dotless) axestitlecolor                    axes.titlecolor
+rc (dotless) axestitlelocation                 axes.titlelocation
+rc (dotless) axestitlepad                      axes.titlepad
+rc (dotless) axestitlesize                     axes.titlesize
+rc (dotless) axestitleweight                   axes.titleweight
+rc (dotless) axestitley                        axes.titley
+rc (dotless) axesunicode_minus                 axes.unicode_minus
+rc (dotless) axesxmargin                       axes.xmargin
+rc (dotless) axesymargin                       axes.ymargin
+rc (dotless) axeszmargin                       axes.zmargin
+rc (dotless) barbar_labels                     bar.bar_labels
+rc (dotless) bordersalpha                      borders.alpha
+rc (dotless) borderscolor                      borders.color
+rc (dotless) borderslinewidth                  borders.linewidth
+rc (dotless) bordersrasterized                 borders.rasterized
+rc (dotless) borderszorder                     borders.zorder
+rc (dotless) bottomlabelcolor                  bottomlabel.color
+rc (dotless) bottomlabelpad                    bottomlabel.pad
+rc (dotless) bottomlabelrotation               bottomlabel.rotation
+rc (dotless) bottomlabelsharedpad              bottomlabel.sharedpad
+rc (dotless) bottomlabelsize                   bottomlabel.size
+rc (dotless) bottomlabelweight                 bottomlabel.weight
+rc (dotless) boxplotbootstrap                  boxplot.bootstrap
+rc (dotless) boxplotboxpropscolor              boxplot.boxprops.color
+rc (dotless) boxplotboxpropslinestyle          boxplot.boxprops.linestyle
+rc (dotless) boxplotboxpropslinewidth          boxplot.boxprops.linewidth
+rc (dotless) boxplotcappropscolor              boxplot.capprops.color
+rc (dotless) boxplotcappropslinestyle          boxplot.capprops.linestyle
+rc (dotless) boxplotcappropslinewidth          boxplot.capprops.linewidth
+rc (dotless) boxplotflierpropscolor            boxplot.flierprops.color
+rc (dotless) boxplotflierpropslinestyle        boxplot.flierprops.linestyle
+rc (dotless) boxplotflierpropslinewidth        boxplot.flierprops.linewidth
+rc (dotless) boxplotflierpropsmarker           boxplot.flierprops.marker
+rc (dotless) boxplotflierpropsmarkeredgecolor  boxplot.flierprops.markeredgecolor
+rc (dotless) boxplotflierpropsmarkeredgewidth  boxplot.flierprops.markeredgewidth
+rc (dotless) boxplotflierpropsmarkerfacecolor  boxplot.flierprops.markerfacecolor
+rc (dotless) boxplotflierpropsmarkersize       boxplot.flierprops.markersize
+rc (dotless) boxplotmeanline                   boxplot.meanline
+rc (dotless) boxplotmeanpropscolor             boxplot.meanprops.color
+rc (dotless) boxplotmeanpropslinestyle         boxplot.meanprops.linestyle
+rc (dotless) boxplotmeanpropslinewidth         boxplot.meanprops.linewidth
+rc (dotless) boxplotmeanpropsmarker            boxplot.meanprops.marker
+rc (dotless) boxplotmeanpropsmarkeredgecolor   boxplot.meanprops.markeredgecolor
+rc (dotless) boxplotmeanpropsmarkerfacecolor   boxplot.meanprops.markerfacecolor
+rc (dotless) boxplotmeanpropsmarkersize        boxplot.meanprops.markersize
+rc (dotless) boxplotmedianpropscolor           boxplot.medianprops.color
+rc (dotless) boxplotmedianpropslinestyle       boxplot.medianprops.linestyle
+rc (dotless) boxplotmedianpropslinewidth       boxplot.medianprops.linewidth
+rc (dotless) boxplotnotch                      boxplot.notch
+rc (dotless) boxplotpatchartist                boxplot.patchartist
+rc (dotless) boxplotshowbox                    boxplot.showbox
+rc (dotless) boxplotshowcaps                   boxplot.showcaps
+rc (dotless) boxplotshowfliers                 boxplot.showfliers
+rc (dotless) boxplotshowmeans                  boxplot.showmeans
+rc (dotless) boxplotvertical                   boxplot.vertical
+rc (dotless) boxplotwhiskerpropscolor          boxplot.whiskerprops.color
+rc (dotless) boxplotwhiskerpropslinestyle      boxplot.whiskerprops.linestyle
+rc (dotless) boxplotwhiskerpropslinewidth      boxplot.whiskerprops.linewidth
+rc (dotless) boxplotwhiskers                   boxplot.whiskers
+rc (dotless) cartopyautoextent                 cartopy.autoextent
+rc (dotless) cartopycircular                   cartopy.circular
+rc (dotless) cftimemax_display_ticks           cftime.max_display_ticks
+rc (dotless) cftimeresolution                  cftime.resolution
+rc (dotless) cftimetime_resolution_format      cftime.time_resolution_format
+rc (dotless) cftimetime_unit                   cftime.time_unit
+rc (dotless) chordend                          chord.end
+rc (dotless) chordendspace                     chord.endspace
+rc (dotless) chordorder                        chord.order
+rc (dotless) chordr_lim                        chord.r_lim
+rc (dotless) chordspace                        chord.space
+rc (dotless) chordstart                        chord.start
+rc (dotless) chordticks_interval               chord.ticks_interval
+rc (dotless) cmapautodiverging                 cmap.autodiverging
+rc (dotless) cmapcyclic                        cmap.cyclic
+rc (dotless) cmapdiscrete                      cmap.discrete
+rc (dotless) cmapdiverging                     cmap.diverging
+rc (dotless) cmapedgefix                       cmap.edgefix
+rc (dotless) cmapinbounds                      cmap.inbounds
+rc (dotless) cmaplevels                        cmap.levels
+rc (dotless) cmaplistedthresh                  cmap.listedthresh
+rc (dotless) cmaplut                           cmap.lut
+rc (dotless) cmapqualitative                   cmap.qualitative
+rc (dotless) cmaprobust                        cmap.robust
+rc (dotless) cmapsequential                    cmap.sequential
+rc (dotless) coastalpha                        coast.alpha
+rc (dotless) coastcolor                        coast.color
+rc (dotless) coastlinewidth                    coast.linewidth
+rc (dotless) coastrasterized                   coast.rasterized
+rc (dotless) coastzorder                       coast.zorder
+rc (dotless) colorbarcenter_levels             colorbar.center_levels
+rc (dotless) colorbaredgecolor                 colorbar.edgecolor
+rc (dotless) colorbarextend                    colorbar.extend
+rc (dotless) colorbarfacecolor                 colorbar.facecolor
+rc (dotless) colorbarfancybox                  colorbar.fancybox
+rc (dotless) colorbarframealpha                colorbar.framealpha
+rc (dotless) colorbarframeon                   colorbar.frameon
+rc (dotless) colorbargrid                      colorbar.grid
+rc (dotless) colorbarinsetextend               colorbar.insetextend
+rc (dotless) colorbarinsetlength               colorbar.insetlength
+rc (dotless) colorbarinsetpad                  colorbar.insetpad
+rc (dotless) colorbarinsetwidth                colorbar.insetwidth
+rc (dotless) colorbarlabelrotation             colorbar.labelrotation
+rc (dotless) colorbarlength                    colorbar.length
+rc (dotless) colorbarloc                       colorbar.loc
+rc (dotless) colorbaroutline                   colorbar.outline
+rc (dotless) colorbarrasterize                 colorbar.rasterize
+rc (dotless) colorbarrasterized                colorbar.rasterized
+rc (dotless) colorbarshadow                    colorbar.shadow
+rc (dotless) colorbarwidth                     colorbar.width
+rc (dotless) contouralgorithm                  contour.algorithm
+rc (dotless) contourcorner_mask                contour.corner_mask
+rc (dotless) contourlinewidth                  contour.linewidth
+rc (dotless) contournegative_linestyle         contour.negative_linestyle
+rc (dotless) curved_quiverarrows_at_end        curved_quiver.arrows_at_end
+rc (dotless) curved_quiverarrowsize            curved_quiver.arrowsize
+rc (dotless) curved_quiverarrowstyle           curved_quiver.arrowstyle
+rc (dotless) curved_quiverdensity              curved_quiver.density
+rc (dotless) curved_quivergrains               curved_quiver.grains
+rc (dotless) curved_quiverscale                curved_quiver.scale
+rc (dotless) dateautoformatterday              date.autoformatter.day
+rc (dotless) dateautoformatterhour             date.autoformatter.hour
+rc (dotless) dateautoformattermicrosecond      date.autoformatter.microsecond
+rc (dotless) dateautoformatterminute           date.autoformatter.minute
+rc (dotless) dateautoformattermonth            date.autoformatter.month
+rc (dotless) dateautoformattersecond           date.autoformatter.second
+rc (dotless) dateautoformatteryear             date.autoformatter.year
+rc (dotless) dateconverter                     date.converter
+rc (dotless) dateepoch                         date.epoch
+rc (dotless) dateinterval_multiples            date.interval_multiples
+rc (dotless) docstringhardcopy                 docstring.hardcopy
+rc (dotless) errorbarcapsize                   errorbar.capsize
+rc (dotless) externalshrink                    external.shrink
+rc (dotless) figureautolayout                  figure.autolayout
+rc (dotless) figureconstrained_layouth_pad     figure.constrained_layout.h_pad
+rc (dotless) figureconstrained_layouthspace    figure.constrained_layout.hspace
+rc (dotless) figureconstrained_layoutuse       figure.constrained_layout.use
+rc (dotless) figureconstrained_layoutw_pad     figure.constrained_layout.w_pad
+rc (dotless) figureconstrained_layoutwspace    figure.constrained_layout.wspace
+rc (dotless) figuredpi                         figure.dpi
+rc (dotless) figureedgecolor                   figure.edgecolor
+rc (dotless) figurefacecolor                   figure.facecolor
+rc (dotless) figurefigsize                     figure.figsize
+rc (dotless) figureframeon                     figure.frameon
+rc (dotless) figurehooks                       figure.hooks
+rc (dotless) figurelabelsize                   figure.labelsize
+rc (dotless) figurelabelweight                 figure.labelweight
+rc (dotless) figuremax_open_warning            figure.max_open_warning
+rc (dotless) figureraise_window                figure.raise_window
+rc (dotless) figuresubplotbottom               figure.subplot.bottom
+rc (dotless) figuresubplothspace               figure.subplot.hspace
+rc (dotless) figuresubplotleft                 figure.subplot.left
+rc (dotless) figuresubplotright                figure.subplot.right
+rc (dotless) figuresubplottop                  figure.subplot.top
+rc (dotless) figuresubplotwspace               figure.subplot.wspace
+rc (dotless) figuretitlesize                   figure.titlesize
+rc (dotless) figuretitleweight                 figure.titleweight
+rc (dotless) fontcursive                       font.cursive
+rc (dotless) fontfamily                        font.family
+rc (dotless) fontfantasy                       font.fantasy
+rc (dotless) fontlarge                         font.large
+rc (dotless) fontlargesize                     font.largesize
+rc (dotless) fontmonospace                     font.monospace
+rc (dotless) fontname                          font.name
+rc (dotless) fontsans-serif                    font.sans-serif
+rc (dotless) fontserif                         font.serif
+rc (dotless) fontsize                          font.size
+rc (dotless) fontsmall                         font.small
+rc (dotless) fontsmallsize                     font.smallsize
+rc (dotless) fontstretch                       font.stretch
+rc (dotless) fontstyle                         font.style
+rc (dotless) fontvariant                       font.variant
+rc (dotless) fontweight                        font.weight
+rc (dotless) formatterlimits                   formatter.limits
+rc (dotless) formatterlog                      formatter.log
+rc (dotless) formattermin_exponent             formatter.min_exponent
+rc (dotless) formatteroffset_threshold         formatter.offset_threshold
+rc (dotless) formattertimerotation             formatter.timerotation
+rc (dotless) formatteruse_locale               formatter.use_locale
+rc (dotless) formatteruse_mathtext             formatter.use_mathtext
+rc (dotless) formatteruse_offset               formatter.use_offset
+rc (dotless) formatterzerotrim                 formatter.zerotrim
+rc (dotless) geoaxesedgecolor                  geoaxes.edgecolor
+rc (dotless) geoaxesfacealpha                  geoaxes.facealpha
+rc (dotless) geoaxesfacecolor                  geoaxes.facecolor
+rc (dotless) geoaxeslinewidth                  geoaxes.linewidth
+rc (dotless) geobackend                        geo.backend
+rc (dotless) geochoroplethcountry_reso         geo.choropleth.country_reso
+rc (dotless) geochoroplethcountry_territories  geo.choropleth.country_territories
+rc (dotless) geochoroplethzorder               geo.choropleth.zorder
+rc (dotless) geoextent                         geo.extent
+rc (dotless) geogridalpha                      geogrid.alpha
+rc (dotless) geogridcolor                      geogrid.color
+rc (dotless) geogridlabelpad                   geogrid.labelpad
+rc (dotless) geogridlabels                     geogrid.labels
+rc (dotless) geogridlabelsize                  geogrid.labelsize
+rc (dotless) geogridlatmax                     geogrid.latmax
+rc (dotless) geogridlatstep                    geogrid.latstep
+rc (dotless) geogridlinestyle                  geogrid.linestyle
+rc (dotless) geogridlinewidth                  geogrid.linewidth
+rc (dotless) geogridlonstep                    geogrid.lonstep
+rc (dotless) georound                          geo.round
+rc (dotless) graphaspect                       graph.aspect
+rc (dotless) graphdraw_edges                   graph.draw_edges
+rc (dotless) graphdraw_grid                    graph.draw_grid
+rc (dotless) graphdraw_labels                  graph.draw_labels
+rc (dotless) graphdraw_nodes                   graph.draw_nodes
+rc (dotless) graphdraw_spines                  graph.draw_spines
+rc (dotless) graphfacecolor                    graph.facecolor
+rc (dotless) graphrescale                      graph.rescale
+rc (dotless) gridalpha                         grid.alpha
+rc (dotless) gridbelow                         grid.below
+rc (dotless) gridcheckoverlap                  grid.checkoverlap
+rc (dotless) gridcolor                         grid.color
+rc (dotless) griddmslabels                     grid.dmslabels
+rc (dotless) gridgeolabels                     grid.geolabels
+rc (dotless) gridinlinelabels                  grid.inlinelabels
+rc (dotless) gridlabelcolor                    grid.labelcolor
+rc (dotless) gridlabelpad                      grid.labelpad
+rc (dotless) gridlabels                        grid.labels
+rc (dotless) gridlabelsize                     grid.labelsize
+rc (dotless) gridlabelweight                   grid.labelweight
+rc (dotless) gridlatinline                     grid.latinline
+rc (dotless) gridlinestyle                     grid.linestyle
+rc (dotless) gridlinewidth                     grid.linewidth
+rc (dotless) gridloninline                     grid.loninline
+rc (dotless) gridminoralpha                    gridminor.alpha
+rc (dotless) gridminorcolor                    gridminor.color
+rc (dotless) gridminorlatstep                  gridminor.latstep
+rc (dotless) gridminorlinestyle                gridminor.linestyle
+rc (dotless) gridminorlinewidth                gridminor.linewidth
+rc (dotless) gridminorlonstep                  gridminor.lonstep
+rc (dotless) gridminorstyle                    gridminor.style
+rc (dotless) gridminorwidth                    gridminor.width
+rc (dotless) gridnsteps                        grid.nsteps
+rc (dotless) gridpad                           grid.pad
+rc (dotless) gridratio                         grid.ratio
+rc (dotless) gridrotatelabels                  grid.rotatelabels
+rc (dotless) gridstyle                         grid.style
+rc (dotless) gridwidth                         grid.width
+rc (dotless) gridwidthratio                    grid.widthratio
+rc (dotless) hatchcolor                        hatch.color
+rc (dotless) hatchlinewidth                    hatch.linewidth
+rc (dotless) histbins                          hist.bins
+rc (dotless) imageaspect                       image.aspect
+rc (dotless) imagecmap                         image.cmap
+rc (dotless) imagecomposite_image              image.composite_image
+rc (dotless) imagediscrete                     image.discrete
+rc (dotless) imageedgefix                      image.edgefix
+rc (dotless) imageinbounds                     image.inbounds
+rc (dotless) imageinterpolation                image.interpolation
+rc (dotless) imageinterpolation_stage          image.interpolation_stage
+rc (dotless) imagelevels                       image.levels
+rc (dotless) imagelut                          image.lut
+rc (dotless) imageorigin                       image.origin
+rc (dotless) imageresample                     image.resample
+rc (dotless) innerbordersalpha                 innerborders.alpha
+rc (dotless) innerborderscolor                 innerborders.color
+rc (dotless) innerborderslinewidth             innerborders.linewidth
+rc (dotless) innerborderszorder                innerborders.zorder
+rc (dotless) kdepoints                         kde.points
+rc (dotless) keymapback                        keymap.back
+rc (dotless) keymapcopy                        keymap.copy
+rc (dotless) keymapforward                     keymap.forward
+rc (dotless) keymapfullscreen                  keymap.fullscreen
+rc (dotless) keymapgrid                        keymap.grid
+rc (dotless) keymapgrid_minor                  keymap.grid_minor
+rc (dotless) keymaphelp                        keymap.help
+rc (dotless) keymaphome                        keymap.home
+rc (dotless) keymappan                         keymap.pan
+rc (dotless) keymapquit                        keymap.quit
+rc (dotless) keymapquit_all                    keymap.quit_all
+rc (dotless) keymapsave                        keymap.save
+rc (dotless) keymapxscale                      keymap.xscale
+rc (dotless) keymapyscale                      keymap.yscale
+rc (dotless) keymapzoom                        keymap.zoom
+rc (dotless) labelcolor                        label.color
+rc (dotless) labelpad                          label.pad
+rc (dotless) labelsize                         label.size
+rc (dotless) labelweight                       label.weight
+rc (dotless) lakesalpha                        lakes.alpha
+rc (dotless) lakescolor                        lakes.color
+rc (dotless) lakesrasterized                   lakes.rasterized
+rc (dotless) lakeszorder                       lakes.zorder
+rc (dotless) landalpha                         land.alpha
+rc (dotless) landcolor                         land.color
+rc (dotless) landrasterized                    land.rasterized
+rc (dotless) landzorder                        land.zorder
+rc (dotless) leftlabelcolor                    leftlabel.color
+rc (dotless) leftlabelpad                      leftlabel.pad
+rc (dotless) leftlabelrotation                 leftlabel.rotation
+rc (dotless) leftlabelsharedpad                leftlabel.sharedpad
+rc (dotless) leftlabelsize                     leftlabel.size
+rc (dotless) leftlabelweight                   leftlabel.weight
+rc (dotless) legendborderaxespad               legend.borderaxespad
+rc (dotless) legendborderpad                   legend.borderpad
+rc (dotless) legendcatalpha                    legend.cat.alpha
+rc (dotless) legendcatline                     legend.cat.line
+rc (dotless) legendcatlinestyle                legend.cat.linestyle
+rc (dotless) legendcatlinewidth                legend.cat.linewidth
+rc (dotless) legendcatmarker                   legend.cat.marker
+rc (dotless) legendcatmarkeredgecolor          legend.cat.markeredgecolor
+rc (dotless) legendcatmarkeredgewidth          legend.cat.markeredgewidth
+rc (dotless) legendcatmarkersize               legend.cat.markersize
+rc (dotless) legendcolumnspacing               legend.columnspacing
+rc (dotless) legendedgecolor                   legend.edgecolor
+rc (dotless) legendfacecolor                   legend.facecolor
+rc (dotless) legendfancybox                    legend.fancybox
+rc (dotless) legendfontsize                    legend.fontsize
+rc (dotless) legendframealpha                  legend.framealpha
+rc (dotless) legendframeon                     legend.frameon
+rc (dotless) legendgeoalpha                    legend.geo.alpha
+rc (dotless) legendgeocountry_proj             legend.geo.country_proj
+rc (dotless) legendgeocountry_reso             legend.geo.country_reso
+rc (dotless) legendgeocountry_territories      legend.geo.country_territories
+rc (dotless) legendgeoedgecolor                legend.geo.edgecolor
+rc (dotless) legendgeofacecolor                legend.geo.facecolor
+rc (dotless) legendgeofill                     legend.geo.fill
+rc (dotless) legendgeohandlesize               legend.geo.handlesize
+rc (dotless) legendgeolinewidth                legend.geo.linewidth
+rc (dotless) legendhandleheight                legend.handleheight
+rc (dotless) legendhandlelength                legend.handlelength
+rc (dotless) legendhandletextpad               legend.handletextpad
+rc (dotless) legendlabelcolor                  legend.labelcolor
+rc (dotless) legendlabelspacing                legend.labelspacing
+rc (dotless) legendloc                         legend.loc
+rc (dotless) legendmarkerscale                 legend.markerscale
+rc (dotless) legendnumalpha                    legend.num.alpha
+rc (dotless) legendnumcmap                     legend.num.cmap
+rc (dotless) legendnumedgecolor                legend.num.edgecolor
+rc (dotless) legendnumformat                   legend.num.format
+rc (dotless) legendnumlinewidth                legend.num.linewidth
+rc (dotless) legendnumn                        legend.num.n
+rc (dotless) legendnumpoints                   legend.numpoints
+rc (dotless) legendscatterpoints               legend.scatterpoints
+rc (dotless) legendshadow                      legend.shadow
+rc (dotless) legendsizealpha                   legend.size.alpha
+rc (dotless) legendsizearea                    legend.size.area
+rc (dotless) legendsizecolor                   legend.size.color
+rc (dotless) legendsizeformat                  legend.size.format
+rc (dotless) legendsizemarker                  legend.size.marker
+rc (dotless) legendsizemarkeredgecolor         legend.size.markeredgecolor
+rc (dotless) legendsizemarkeredgewidth         legend.size.markeredgewidth
+rc (dotless) legendsizeminsize                 legend.size.minsize
+rc (dotless) legendsizescale                   legend.size.scale
+rc (dotless) legendtitle_fontsize              legend.title_fontsize
+rc (dotless) linesantialiased                  lines.antialiased
+rc (dotless) linescolor                        lines.color
+rc (dotless) linesdash_capstyle                lines.dash_capstyle
+rc (dotless) linesdash_joinstyle               lines.dash_joinstyle
+rc (dotless) linesdashdot_pattern              lines.dashdot_pattern
+rc (dotless) linesdashed_pattern               lines.dashed_pattern
+rc (dotless) linesdotted_pattern               lines.dotted_pattern
+rc (dotless) lineslinestyle                    lines.linestyle
+rc (dotless) lineslinewidth                    lines.linewidth
+rc (dotless) linesmarker                       lines.marker
+rc (dotless) linesmarkeredgecolor              lines.markeredgecolor
+rc (dotless) linesmarkeredgewidth              lines.markeredgewidth
+rc (dotless) linesmarkerfacecolor              lines.markerfacecolor
+rc (dotless) linesmarkersize                   lines.markersize
+rc (dotless) linesscale_dashes                 lines.scale_dashes
+rc (dotless) linessolid_capstyle               lines.solid_capstyle
+rc (dotless) linessolid_joinstyle              lines.solid_joinstyle
+rc (dotless) lollipopmarkersize                lollipop.markersize
+rc (dotless) lollipopstemcolor                 lollipop.stemcolor
+rc (dotless) lollipopstemlinestyle             lollipop.stemlinestyle
+rc (dotless) lollipopstemwidth                 lollipop.stemwidth
+rc (dotless) macosxwindow_mode                 macosx.window_mode
+rc (dotless) markersfillstyle                  markers.fillstyle
+rc (dotless) mathtextbf                        mathtext.bf
+rc (dotless) mathtextbfit                      mathtext.bfit
+rc (dotless) mathtextcal                       mathtext.cal
+rc (dotless) mathtextcm_symbols                mathtext.cm_symbols
+rc (dotless) mathtextdefault                   mathtext.default
+rc (dotless) mathtextfallback                  mathtext.fallback
+rc (dotless) mathtextfontset                   mathtext.fontset
+rc (dotless) mathtextit                        mathtext.it
+rc (dotless) mathtextrm                        mathtext.rm
+rc (dotless) mathtextsf                        mathtext.sf
+rc (dotless) mathtexttt                        mathtext.tt
+rc (dotless) metacolor                         meta.color
+rc (dotless) metaedgecolor                     meta.edgecolor
+rc (dotless) metalinewidth                     meta.linewidth
+rc (dotless) metawidth                         meta.width
+rc (dotless) navigationpreview                 navigation.preview
+rc (dotless) oceanalpha                        ocean.alpha
+rc (dotless) oceancolor                        ocean.color
+rc (dotless) oceanrasterized                   ocean.rasterized
+rc (dotless) oceanzorder                       ocean.zorder
+rc (dotless) patchantialiased                  patch.antialiased
+rc (dotless) patchedgecolor                    patch.edgecolor
+rc (dotless) patchfacecolor                    patch.facecolor
+rc (dotless) patchforce_edgecolor              patch.force_edgecolor
+rc (dotless) patchlinewidth                    patch.linewidth
+rc (dotless) patheffects                       path.effects
+rc (dotless) pathsimplify                      path.simplify
+rc (dotless) pathsimplify_threshold            path.simplify_threshold
+rc (dotless) pathsketch                        path.sketch
+rc (dotless) pathsnap                          path.snap
+rc (dotless) pcolormeshsnap                    pcolormesh.snap
+rc (dotless) pcolorshading                     pcolor.shading
+rc (dotless) pdfcompression                    pdf.compression
+rc (dotless) pdffonttype                       pdf.fonttype
+rc (dotless) pdfinheritcolor                   pdf.inheritcolor
+rc (dotless) pdfuse14corefonts                 pdf.use14corefonts
+rc (dotless) pgfpreamble                       pgf.preamble
+rc (dotless) pgfrcfonts                        pgf.rcfonts
+rc (dotless) pgftexsystem                      pgf.texsystem
+rc (dotless) phylogenyalign_leaf_label         phylogeny.align_leaf_label
+rc (dotless) phylogenyend                      phylogeny.end
+rc (dotless) phylogenyformat                   phylogeny.format
+rc (dotless) phylogenyignore_branch_length     phylogeny.ignore_branch_length
+rc (dotless) phylogenyladderize                phylogeny.ladderize
+rc (dotless) phylogenyleaf_label_rmargin       phylogeny.leaf_label_rmargin
+rc (dotless) phylogenyleaf_label_size          phylogeny.leaf_label_size
+rc (dotless) phylogenyouter                    phylogeny.outer
+rc (dotless) phylogenyr_lim                    phylogeny.r_lim
+rc (dotless) phylogenyreverse                  phylogeny.reverse
+rc (dotless) phylogenystart                    phylogeny.start
+rc (dotless) polaraxesgrid                     polaraxes.grid
+rc (dotless) psdistillerres                    ps.distiller.res
+rc (dotless) psfonttype                        ps.fonttype
+rc (dotless) pspapersize                       ps.papersize
+rc (dotless) psuseafm                          ps.useafm
+rc (dotless) psusedistiller                    ps.usedistiller
+rc (dotless) radarbg_color                     radar.bg_color
+rc (dotless) radarcircular                     radar.circular
+rc (dotless) radarfill                         radar.fill
+rc (dotless) radargrid_interval_ratio          radar.grid_interval_ratio
+rc (dotless) radarmarker_size                  radar.marker_size
+rc (dotless) radarr_lim                        radar.r_lim
+rc (dotless) radarshow_grid_label              radar.show_grid_label
+rc (dotless) radarvmax                         radar.vmax
+rc (dotless) radarvmin                         radar.vmin
+rc (dotless) ribbonflowalpha                   ribbon.flow.alpha
+rc (dotless) ribbonflowcurvature               ribbon.flow.curvature
+rc (dotless) ribbonnodewidth                   ribbon.nodewidth
+rc (dotless) ribbonrowheightratio              ribbon.rowheightratio
+rc (dotless) ribbontopic_label_box             ribbon.topic_label_box
+rc (dotless) ribbontopic_label_offset          ribbon.topic_label_offset
+rc (dotless) ribbontopic_label_size            ribbon.topic_label_size
+rc (dotless) ribbontopic_labels                ribbon.topic_labels
+rc (dotless) ribbonxmargin                     ribbon.xmargin
+rc (dotless) ribbonymargin                     ribbon.ymargin
+rc (dotless) rightlabelcolor                   rightlabel.color
+rc (dotless) rightlabelpad                     rightlabel.pad
+rc (dotless) rightlabelrotation                rightlabel.rotation
+rc (dotless) rightlabelsharedpad               rightlabel.sharedpad
+rc (dotless) rightlabelsize                    rightlabel.size
+rc (dotless) rightlabelweight                  rightlabel.weight
+rc (dotless) riversalpha                       rivers.alpha
+rc (dotless) riverscolor                       rivers.color
+rc (dotless) riverslinewidth                   rivers.linewidth
+rc (dotless) riversrasterized                  rivers.rasterized
+rc (dotless) riverszorder                      rivers.zorder
+rc (dotless) sankeyalign                       sankey.align
+rc (dotless) sankeyconnect                     sankey.connect
+rc (dotless) sankeyflow_label_pos              sankey.flow_label_pos
+rc (dotless) sankeyflow_labels                 sankey.flow_labels
+rc (dotless) sankeyflow_sort                   sankey.flow_sort
+rc (dotless) sankeyflowalpha                   sankey.flow.alpha
+rc (dotless) sankeyflowcurvature               sankey.flow.curvature
+rc (dotless) sankeymargin                      sankey.margin
+rc (dotless) sankeynode_label_offset           sankey.node_label_offset
+rc (dotless) sankeynode_label_outside          sankey.node_label_outside
+rc (dotless) sankeynode_labels                 sankey.node_labels
+rc (dotless) sankeynodefacecolor               sankey.node.facecolor
+rc (dotless) sankeynodepad                     sankey.nodepad
+rc (dotless) sankeynodewidth                   sankey.nodewidth
+rc (dotless) sankeyother_label                 sankey.other_label
+rc (dotless) sankeypathlabel                   sankey.pathlabel
+rc (dotless) sankeypathlengths                 sankey.pathlengths
+rc (dotless) sankeyrotation                    sankey.rotation
+rc (dotless) sankeytrunklength                 sankey.trunklength
+rc (dotless) savefigbbox                       savefig.bbox
+rc (dotless) savefigdirectory                  savefig.directory
+rc (dotless) savefigdpi                        savefig.dpi
+rc (dotless) savefigedgecolor                  savefig.edgecolor
+rc (dotless) savefigfacecolor                  savefig.facecolor
+rc (dotless) savefigformat                     savefig.format
+rc (dotless) savefigorientation                savefig.orientation
+rc (dotless) savefigpad_inches                 savefig.pad_inches
+rc (dotless) savefigtransparent                savefig.transparent
+rc (dotless) scatteredgecolors                 scatter.edgecolors
+rc (dotless) scattermarker                     scatter.marker
+rc (dotless) subplotsalign                     subplots.align
+rc (dotless) subplotsaxpad                     subplots.axpad
+rc (dotless) subplotsaxwidth                   subplots.axwidth
+rc (dotless) subplotsequalspace                subplots.equalspace
+rc (dotless) subplotsgroupspace                subplots.groupspace
+rc (dotless) subplotsinnerpad                  subplots.innerpad
+rc (dotless) subplotsouterpad                  subplots.outerpad
+rc (dotless) subplotspad                       subplots.pad
+rc (dotless) subplotspanelpad                  subplots.panelpad
+rc (dotless) subplotspanelwidth                subplots.panelwidth
+rc (dotless) subplotspixelsnap                 subplots.pixelsnap
+rc (dotless) subplotsrefwidth                  subplots.refwidth
+rc (dotless) subplotsshare                     subplots.share
+rc (dotless) subplotsspan                      subplots.span
+rc (dotless) subplotstight                     subplots.tight
+rc (dotless) suptitlecolor                     suptitle.color
+rc (dotless) suptitlepad                       suptitle.pad
+rc (dotless) suptitlesize                      suptitle.size
+rc (dotless) suptitleweight                    suptitle.weight
+rc (dotless) svgfonttype                       svg.fonttype
+rc (dotless) svghashsalt                       svg.hashsalt
+rc (dotless) svgid                             svg.id
+rc (dotless) svgimage_inline                   svg.image_inline
+rc (dotless) textalign                         text.align
+rc (dotless) textalignarrows                   text.align.arrows
+rc (dotless) textalignmaxiter                  text.align.maxiter
+rc (dotless) textalignpad                      text.align.pad
+rc (dotless) textantialiased                   text.antialiased
+rc (dotless) textborderstyle                   text.borderstyle
+rc (dotless) textcolor                         text.color
+rc (dotless) textcurvedavoid_overlap           text.curved.avoid_overlap
+rc (dotless) textcurvedcurvature_pad           text.curved.curvature_pad
+rc (dotless) textcurvedellipsis                text.curved.ellipsis
+rc (dotless) textcurvedmin_advance             text.curved.min_advance
+rc (dotless) textcurvedoverlap_tol             text.curved.overlap_tol
+rc (dotless) textcurvedupright                 text.curved.upright
+rc (dotless) texthinting                       text.hinting
+rc (dotless) texthinting_factor                text.hinting_factor
+rc (dotless) textkerning_factor                text.kerning_factor
+rc (dotless) textlabelsize                     text.labelsize
+rc (dotless) textlatexpreamble                 text.latex.preamble
+rc (dotless) textparse_math                    text.parse_math
+rc (dotless) texttitlesize                     text.titlesize
+rc (dotless) textusetex                        text.usetex
+rc (dotless) tickcolor                         tick.color
+rc (dotless) tickdir                           tick.dir
+rc (dotless) ticklabelcolor                    tick.labelcolor
+rc (dotless) ticklabelpad                      tick.labelpad
+rc (dotless) ticklabelsize                     tick.labelsize
+rc (dotless) ticklabelweight                   tick.labelweight
+rc (dotless) ticklen                           tick.len
+rc (dotless) ticklenratio                      tick.lenratio
+rc (dotless) ticklinewidth                     tick.linewidth
+rc (dotless) tickminor                         tick.minor
+rc (dotless) tickpad                           tick.pad
+rc (dotless) tickratio                         tick.ratio
+rc (dotless) tickwidth                         tick.width
+rc (dotless) tickwidthratio                    tick.widthratio
+rc (dotless) titleabove                        title.above
+rc (dotless) titlebbox                         title.bbox
+rc (dotless) titlebboxalpha                    title.bboxalpha
+rc (dotless) titlebboxcolor                    title.bboxcolor
+rc (dotless) titlebboxpad                      title.bboxpad
+rc (dotless) titlebboxstyle                    title.bboxstyle
+rc (dotless) titleborder                       title.border
+rc (dotless) titleborderwidth                  title.borderwidth
+rc (dotless) titlecolor                        title.color
+rc (dotless) titleloc                          title.loc
+rc (dotless) titlepad                          title.pad
+rc (dotless) titlesize                         title.size
+rc (dotless) titleweight                       title.weight
+rc (dotless) tkwindow_focus                    tk.window_focus
+rc (dotless) toplabelcolor                     toplabel.color
+rc (dotless) toplabelpad                       toplabel.pad
+rc (dotless) toplabelrotation                  toplabel.rotation
+rc (dotless) toplabelsharedpad                 toplabel.sharedpad
+rc (dotless) toplabelsize                      toplabel.size
+rc (dotless) toplabelweight                    toplabel.weight
+rc (dotless) ultraplotcheck_for_latest_version ultraplot.check_for_latest_version
+rc (dotless) ultraploteager_import             ultraplot.eager_import
+rc (dotless) webaggaddress                     webagg.address
+rc (dotless) webaggopen_in_browser             webagg.open_in_browser
+rc (dotless) webaggport                        webagg.port
+rc (dotless) webaggport_retries                webagg.port_retries
+rc (dotless) xaxislabellocation                xaxis.labellocation
+rc (dotless) xtickalignment                    xtick.alignment
+rc (dotless) xtickbottom                       xtick.bottom
+rc (dotless) xtickcolor                        xtick.color
+rc (dotless) xtickdirection                    xtick.direction
+rc (dotless) xticklabelbottom                  xtick.labelbottom
+rc (dotless) xticklabelcolor                   xtick.labelcolor
+rc (dotless) xticklabelsize                    xtick.labelsize
+rc (dotless) xticklabeltop                     xtick.labeltop
+rc (dotless) xtickmajorbottom                  xtick.major.bottom
+rc (dotless) xtickmajorpad                     xtick.major.pad
+rc (dotless) xtickmajorsize                    xtick.major.size
+rc (dotless) xtickmajortop                     xtick.major.top
+rc (dotless) xtickmajorwidth                   xtick.major.width
+rc (dotless) xtickminorbottom                  xtick.minor.bottom
+rc (dotless) xtickminorndivs                   xtick.minor.ndivs
+rc (dotless) xtickminorpad                     xtick.minor.pad
+rc (dotless) xtickminorsize                    xtick.minor.size
+rc (dotless) xtickminortop                     xtick.minor.top
+rc (dotless) xtickminorvisible                 xtick.minor.visible
+rc (dotless) xtickminorwidth                   xtick.minor.width
+rc (dotless) xticktop                          xtick.top
+rc (dotless) yaxislabellocation                yaxis.labellocation
+rc (dotless) ytickalignment                    ytick.alignment
+rc (dotless) ytickcolor                        ytick.color
+rc (dotless) ytickdirection                    ytick.direction
+rc (dotless) yticklabelcolor                   ytick.labelcolor
+rc (dotless) yticklabelleft                    ytick.labelleft
+rc (dotless) yticklabelright                   ytick.labelright
+rc (dotless) yticklabelsize                    ytick.labelsize
+rc (dotless) ytickleft                         ytick.left
+rc (dotless) ytickmajorleft                    ytick.major.left
+rc (dotless) ytickmajorpad                     ytick.major.pad
+rc (dotless) ytickmajorright                   ytick.major.right
+rc (dotless) ytickmajorsize                    ytick.major.size
+rc (dotless) ytickmajorwidth                   ytick.major.width
+rc (dotless) ytickminorleft                    ytick.minor.left
+rc (dotless) ytickminorndivs                   ytick.minor.ndivs
+rc (dotless) ytickminorpad                     ytick.minor.pad
+rc (dotless) ytickminorright                   ytick.minor.right
+rc (dotless) ytickminorsize                    ytick.minor.size
+rc (dotless) ytickminorvisible                 ytick.minor.visible
+rc (dotless) ytickminorwidth                   ytick.minor.width
+rc (dotless) ytickright                        ytick.right
+============ ================================= ==================================
+
+.. alias-table-end
+
+Supplying a legacy and canonical spelling together is an error. For example,
+``ax.format(xlocator=5, xticks=10)`` does not silently choose one value.

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -177,7 +177,7 @@ figure.format       collabels         toplabels
 colorbar            location          loc
 colorbar            grid              drawedges
 colorbar            edges             drawedges
-colorbar            length            shrink
+colorbar            shrink            length
 colorbar            title             label
 colorbar            labelloc          labellocation
 colorbar            locator           ticks

--- a/docs/aliases.rst
+++ b/docs/aliases.rst
@@ -2,42 +2,21 @@
 Compatibility alias reference
 =============================
 
-UltraPlot's official documentation and function signatures exclusively use
-canonical parameter names. Alternative shorthand spellings (aliases) remain fully
-supported through silent, behind-the-scenes keyword translation.
-
-* **Context-dependent:** A single shorthand alias might map to different underlying
-  Matplotlib properties depending on the artist type.
-* **Silent translation:** Using aliases will not trigger deprecation warnings in
-  the current version, though these may be enabled in a future release.
-* **RC settings:** Entries marked ``rc (dotless)`` are generated from the rc registry.
-  To bypass compatibility aliases entirely, pass the canonical dotted spellings
-  through ``rc_kw``.
+The names shown in UltraPlot's documentation and function signatures are the
+canonical spellings. Shorthand aliases remain supported without warnings.
+Some aliases have different meanings depending on the plotting method or artist.
 
 Visual alias explorer
 ---------------------
 
-Use the interactive diagram below to discover which aliases apply to different
-parts of your plot:
-
-* **Hover or Focus:** Target a labeled part of the figure to preview its aliases.
-* **Click:** Select a label to keep that area highlighted and filter the complete mapping table below.
-* **Learn More:** Click the API link in the detail panel to view the canonical documentation.
-
+Select a label on the figure to see its aliases. Hover to preview; drag to
+reposition a label.
 
 .. raw:: html
 
    <div class="uplt-alias-explorer" aria-label="Interactive UltraPlot alias map">
-     <div class="uplt-alias-summary" aria-live="polite">
-       <span><strong data-alias-total>0</strong> accepted spellings</span>
-       <span><strong data-alias-context-total>0</strong> contexts</span>
-       <span>one canonical API</span>
-     </div>
-
-     <div class="uplt-alias-map-layout">
-       <div class="uplt-alias-visual-column">
         <div class="uplt-alias-map" aria-label="Annotated UltraPlot figure">
-         <svg viewBox="0 0 760 520" role="img" aria-labelledby="uplt-alias-map-title uplt-alias-map-desc">
+         <svg viewBox="-70 -60 850 620" role="img" aria-labelledby="uplt-alias-map-title uplt-alias-map-desc">
            <title id="uplt-alias-map-title">Alias locations on an UltraPlot figure</title>
            <desc id="uplt-alias-map-desc">An annotated chart with interactive labels for figure layout, side titles, axes, plot data, artist style, legend, and colorbar aliases.</desc>
            <image class="uplt-alias-real-figure" href="_static/alias-map.svg" x="20" y="16" width="720" height="427" preserveAspectRatio="xMidYMid meet"/>
@@ -59,64 +38,68 @@ parts of your plot:
 
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(436.3 -38)" data-layout-key="layout" data-anchor-x="380" data-anchor-y="64" data-contexts="figure.init,gridspec,subplot,inset" data-targets="layout,inset" data-label="Figure &amp; layout" data-api="api/ultraplot.figure.Figure.html">
              <path class="uplt-alias-wire" d="M29.0 52.5 L-56.3 102.0"/>
-             <rect width="146" height="54" rx="14"/><text x="73" y="22">Figure &amp;</text><text x="73" y="41">layout</text>
+             <rect width="146" height="54" rx="3"/><text x="73" y="22">Figure &amp;</text><text x="73" y="41">layout</text>
            </g>
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(-34.9 -34.9)" data-layout-key="titles" data-anchor-x="71" data-anchor-y="64" data-contexts="axes.format,figure.format" data-targets="titles" data-label="Side titles &amp; labels" data-api="api/ultraplot.figure.Figure.html#ultraplot.figure.Figure.format">
              <path class="uplt-alias-wire" d="M84.1 51.3 L105.9 98.9"/>
-             <rect width="146" height="54" rx="14"/><text x="73" y="22">Side titles</text><text x="73" y="41">&amp; labels</text>
+             <rect width="146" height="54" rx="3"/><text x="73" y="22">Side titles</text><text x="73" y="41">&amp; labels</text>
            </g>
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(106.5 469.8)" data-layout-key="axes" data-anchor-x="235" data-anchor-y="393" data-contexts="cartesian.format,geo.format,polar.format,taylor.format,projection" data-targets="axes" data-label="Axes &amp; projections" data-api="api/ultraplot.axes.CartesianAxes.html#ultraplot.axes.CartesianAxes.format">
              <path class="uplt-alias-wire" d="M102.8 2.9 L128.5 -76.8"/>
-             <rect width="190" height="54" rx="14"/><text x="95" y="22">Axes &amp;</text><text x="95" y="41">projections</text>
+             <rect width="190" height="54" rx="3"/><text x="95" y="22">Axes &amp;</text><text x="95" y="41">projections</text>
            </g>
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(450.3 297.1)" data-layout-key="plot" data-anchor-x="326" data-anchor-y="286" data-contexts="plot.*" data-targets="plot" data-label="Plot methods" data-api="api/ultraplot.axes.PlotAxes.html">
              <path class="uplt-alias-wire" d="M2.9 12.6 L-124.3 -11.1"/>
-             <rect width="160" height="54" rx="14"/><text x="80" y="33">Plot methods</text>
+             <rect width="160" height="54" rx="3"/><text x="80" y="33">Plot methods</text>
            </g>
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(625.2 -28)" data-layout-key="legend" data-anchor-x="610" data-anchor-y="64" data-contexts="legend" data-targets="legend" data-label="Legend" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.legend">
              <path class="uplt-alias-wire" d="M35.2 52.1 L-15.2 92.0"/>
-             <rect width="134" height="54" rx="14"/><text x="67" y="33">Legend</text>
+             <rect width="134" height="54" rx="3"/><text x="67" y="33">Legend</text>
            </g>
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(610.1 425.8)" data-layout-key="colorbar" data-anchor-x="662" data-anchor-y="358" data-contexts="colorbar" data-targets="colorbar" data-label="Colorbar" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.colorbar">
              <path class="uplt-alias-wire" d="M63.2 3.0 L51.9 -67.8"/>
-             <rect width="134" height="54" rx="14"/><text x="67" y="33">Colorbar</text>
+             <rect width="134" height="54" rx="3"/><text x="67" y="33">Colorbar</text>
            </g>
            <g class="uplt-alias-node" role="button" tabindex="0" transform="translate(-52.2 398.1)" data-layout-key="style" data-anchor-x="121" data-anchor-y="351" data-contexts="style.*" data-targets="style" data-label="Artist styling" data-api="api/ultraplot.axes.PlotAxes.html">
              <path class="uplt-alias-wire" d="M107.1 1.8 L173.2 -47.1"/>
-             <rect width="146" height="54" rx="14"/><text x="73" y="33">Artist styling</text>
+             <rect width="146" height="54" rx="3"/><text x="73" y="33">Artist styling</text>
            </g>
          </svg>
         </div>
 
         <div class="uplt-alias-categories" aria-label="Alias categories">
-         <button type="button" data-contexts="figure.init,figure.format,gridspec,subplot,inset" data-targets="layout,inset,titles" data-label="Figure &amp; layout" data-api="api/ultraplot.figure.Figure.html"><span>▦</span>Figure &amp; layout</button>
-         <button type="button" data-contexts="axes.format,cartesian.format,geo.format,polar.format,taylor.format" data-targets="axes,titles" data-label="Axes formatting" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.format"><span>⌗</span>Axes formatting</button>
-         <button type="button" data-contexts="colorbar,legend" data-targets="colorbar,legend" data-label="Guides" data-api="api/ultraplot.axes.Axes.html"><span>◫</span>Guides</button>
-         <button type="button" data-contexts="plot.*" data-targets="plot" data-label="Plot methods" data-api="api/ultraplot.axes.PlotAxes.html"><span>⌁</span>Plot methods</button>
-         <button type="button" data-contexts="style.*" data-targets="style" data-label="Artist properties" data-api="api/ultraplot.axes.PlotAxes.html"><span>✦</span>Artist properties</button>
-         <button type="button" data-contexts="cycle,projection,scale.*" data-targets="axes,style" data-label="Constructors" data-api="api.html#constructor-functions"><span>⚙</span>Constructors</button>
-         <button type="button" data-contexts="rc (dotless)" data-targets="layout,axes,titles,plot,style,legend,colorbar,inset" data-label="Configuration" data-api="api/ultraplot.config.Configurator.html"><span>⋮</span>Configuration</button>
+         <button type="button" data-alias-color="layout" data-contexts="figure.init,gridspec,subplot,inset" data-targets="layout,inset" data-label="Figure &amp; layout" data-api="api/ultraplot.figure.Figure.html">Figure &amp; layout</button>
+         <button type="button" data-alias-color="titles" data-contexts="axes.format,figure.format" data-targets="titles" data-label="Side titles &amp; labels" data-api="api/ultraplot.figure.Figure.html#ultraplot.figure.Figure.format">Side titles &amp; labels</button>
+         <button type="button" data-alias-color="axes" data-contexts="cartesian.format,geo.format,polar.format,taylor.format,projection" data-targets="axes" data-label="Axes &amp; projections" data-api="api/ultraplot.axes.CartesianAxes.html#ultraplot.axes.CartesianAxes.format">Axes &amp; projections</button>
+         <button type="button" data-alias-color="plot" data-contexts="plot.*" data-targets="plot" data-label="Plot methods" data-api="api/ultraplot.axes.PlotAxes.html">Plot methods</button>
+         <button type="button" data-alias-color="legend" data-contexts="legend" data-targets="legend" data-label="Legend" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.legend">Legend</button>
+         <button type="button" data-alias-color="colorbar" data-contexts="colorbar" data-targets="colorbar" data-label="Colorbar" data-api="api/ultraplot.axes.Axes.html#ultraplot.axes.Axes.colorbar">Colorbar</button>
+         <button type="button" data-alias-color="style" data-contexts="style.*" data-targets="style" data-label="Artist styling" data-api="api/ultraplot.axes.PlotAxes.html">Artist styling</button>
+         <button type="button" data-contexts="cycle,projection,scale.*" data-targets="axes,style" data-label="Constructors" data-api="api.html#constructor-functions">Constructors</button>
+         <button type="button" data-contexts="rc (dotless)" data-targets="layout,axes,titles,plot,style,legend,colorbar,inset" data-label="Configuration" data-api="api/ultraplot.config.Configurator.html">Configuration</button>
         </div>
 
-        <div class="uplt-alias-filter">
-          <label for="uplt-alias-search">Find an accepted or canonical spelling</label>
-          <div>
-            <input id="uplt-alias-search" type="search" placeholder="Try lw, linewidth, proj, or title…" autocomplete="off"/>
-            <button type="button" data-alias-reset>Show all</button>
-          </div>
-          <p data-alias-filter-status aria-live="polite"></p>
-        </div>
-       </div>
-
-       <aside class="uplt-alias-detail" aria-live="polite">
-         <p class="uplt-alias-detail-help">Drag labels to arrange the map. Hover to preview aliases, or click to keep a selection.</p>
+     <section class="uplt-alias-detail" aria-label="Alias details" aria-live="polite">
+       <div class="uplt-alias-detail-heading">
          <h3 data-alias-detail-title>All aliases</h3>
-         <p data-alias-detail-copy>Select a labelled region or a category below.</p>
-         <div class="uplt-alias-preview" data-alias-preview></div>
-         <a class="uplt-alias-api-link" data-alias-api hidden>Open canonical API <span aria-hidden="true">→</span></a>
-       </aside>
+         <p data-alias-detail-copy>Select a label or category to explore its aliases.</p>
+         <a class="uplt-alias-api-link" data-alias-api hidden>View API documentation <span aria-hidden="true">→</span></a>
+       </div>
+       <div class="uplt-alias-preview" data-alias-preview></div>
+     </section>
+
+     <div class="uplt-alias-filter">
+       <label for="uplt-alias-search">Find an alias</label>
+       <div class="uplt-alias-search-row">
+         <input id="uplt-alias-search" type="search" placeholder="Search names, e.g. shrink or length" autocomplete="off"/>
+         <button type="button" data-alias-reset>Show all</button>
+       </div>
+       <p class="uplt-alias-filter-status" data-alias-filter-status aria-live="polite"></p>
      </div>
    </div>
+
+Entries marked ``rc (dotless)`` are configuration aliases. Use canonical dotted
+names through ``rc_kw`` to bypass their translation.
 
 .. alias-table-start
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -550,11 +550,11 @@ htmlhelp_basename = "ultraplotdoc"
 
 
 if HAVE_ULTRAPLOT_THEME_EXT:
-    html_css_files = []
-    html_js_files = []
+    html_css_files = ["alias-explorer-v3.css"]
+    html_js_files = ["alias-explorer-v3.js"]
 else:
-    html_css_files = ["custom.css"]
-    html_js_files = ["custom.js"]
+    html_css_files = ["custom.css", "alias-explorer-v3.css"]
+    html_js_files = ["custom.js", "alias-explorer-v3.js"]
 
 # -- Options for LaTeX output ------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ For more details, check the full :doc:`User guide <usage>` and :doc:`API Referen
    :hidden:
 
    api
+   aliases
    lazy_loading
    external-links
    whats_new

--- a/docs/subplots.py
+++ b/docs/subplots.py
@@ -555,7 +555,7 @@ with uplt.rc.context(fontsize="12px"):  # depends on rc['figure.dpi']
         label="colorbar",
         width="2em",
         extendsize="3em",
-        shrink=0.8,
+        length=0.8,
     )
     pax = axs[2].panel_axes("r", width="5en")
 axs.format(

--- a/tools/generate_alias_figure.py
+++ b/tools/generate_alias_figure.py
@@ -57,7 +57,7 @@ def main():
             points,
             location="right",
             label="Progress",
-            shrink=0.78,
+            length=0.78,
             ticks=[0, 5, 10],
         )
         inset = ax.inset([0.07, 0.63, 0.27, 0.25])

--- a/tools/generate_alias_figure.py
+++ b/tools/generate_alias_figure.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate the real UltraPlot figure used by the alias explorer."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import ultraplot as uplt  # noqa: E402
+
+
+def main():
+    output = ROOT / "docs" / "_static" / "alias-map.svg"
+    preview = Path("/tmp/ultraplot-alias-map.png")
+    x = np.linspace(0, 10, 100)
+    baseline = 0.32 * np.sin(1.15 * x) + 0.07 * x
+    comparison = 0.25 * np.cos(0.9 * x + 0.5) + 0.055 * x + 0.18
+
+    with uplt.rc.context(
+        {
+            "font.size": 10,
+            "axes.grid": True,
+            "svg.hashsalt": "ultraplot-alias-map",
+        }
+    ):
+        fig, ax = uplt.subplots(refwidth=4.6, refheight=2.9)
+        ax.plot(
+            x,
+            baseline,
+            color="#168f83",
+            linewidth=2.2,
+            label="Observed",
+        )
+        ax.plot(
+            x,
+            comparison,
+            color="#3976d3",
+            linewidth=2.0,
+            linestyle="--",
+            label="Reference",
+        )
+        points = ax.scatter(
+            x[::10],
+            baseline[::10],
+            c=x[::10],
+            cmap="batlow",
+            s=28,
+            edgecolor="white",
+            linewidth=0.7,
+            zorder=3,
+        )
+        ax.legend(location="upper right", frameon=True, ncols=1)
+        ax.colorbar(
+            points,
+            location="right",
+            label="Progress",
+            shrink=0.78,
+            ticks=[0, 5, 10],
+        )
+        inset = ax.inset([0.07, 0.63, 0.27, 0.25])
+        inset.plot(
+            x[:35],
+            baseline[:35],
+            color="#168f83",
+            linewidth=1.3,
+        )
+        inset.format(
+            title="Inset",
+            xlocator=[],
+            ylocator=[],
+            grid=False,
+        )
+        ax.format(
+            xlabel="Time",
+            ylabel="Signal",
+            lefttitle="Primary title",
+            righttitle="Context",
+            xlocator=2,
+            ylocator=0.25,
+            grid=True,
+            gridalpha=0.18,
+        )
+        fig.format(
+            suptitle="Where aliases act",
+            leftlabels=["Left labels"],
+            rightlabels=["Right labels"],
+        )
+        fig.savefig(output, transparent=False, metadata={"Date": None})
+        source = output.read_text()
+        output.write_text("\n".join(line.rstrip() for line in source.splitlines()) + "\n")
+        fig.savefig(preview, dpi=180, transparent=False)
+        uplt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_alias_reference.py
+++ b/tools/generate_alias_reference.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate or verify the compatibility-alias reference table."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ultraplot.internals.kwargs import (  # noqa: E402
+    _alias_registry,
+    _format_alias_reference,
+)
+
+
+OUTPUT = ROOT / "docs" / "aliases.rst"
+SCRIPT = ROOT / "docs" / "_static" / "alias-explorer-v3.js"
+START = ".. alias-table-start"
+END = ".. alias-table-end"
+
+
+def _validate_visual_contexts(source):
+    """Ensure every registry context is reachable from the visual explorer."""
+    values = re.findall(r'data-contexts="([^"]+)"', source)
+    patterns = {
+        pattern.strip()
+        for value in values
+        for pattern in value.split(",")
+        if pattern.strip()
+    }
+    expected = {*_alias_registry, "rc (dotless)"}
+
+    def covered(context):
+        return context in patterns or any(
+            pattern.endswith(".*") and context.startswith(pattern[:-1])
+            for pattern in patterns
+        )
+
+    missing = sorted(context for context in expected if not covered(context))
+    if missing:
+        raise RuntimeError(
+            "Visual alias explorer is missing contexts: " + ", ".join(missing)
+        )
+
+
+def _validate_api_targets():
+    """Ensure every alias row can link to a canonical public API entry."""
+    source = SCRIPT.read_text()
+    _, marker, rest = source.partition("const apiTargets = {")
+    if not marker:
+        raise RuntimeError(f"Missing apiTargets mapping in {SCRIPT}.")
+    mapping, marker, _ = rest.partition("\n  };")
+    if not marker:
+        raise RuntimeError(f"Could not parse apiTargets mapping in {SCRIPT}.")
+    matches = re.findall(
+        r'^\s*(?:"([^"]+)"|([A-Za-z][\w]*)):\s*"', mapping, re.MULTILINE
+    )
+    contexts = {quoted or bare for quoted, bare in matches}
+    expected = {*_alias_registry, "rc (dotless)"}
+    missing = sorted(expected - contexts)
+    if missing:
+        raise RuntimeError(
+            "Alias API link mapping is missing contexts: " + ", ".join(missing)
+        )
+
+
+def _render(source):
+    before, marker, rest = source.partition(START)
+    if not marker:
+        raise RuntimeError(f"Missing {START!r} marker in {OUTPUT}.")
+    _, marker, after = rest.partition(END)
+    if not marker:
+        raise RuntimeError(f"Missing {END!r} marker in {OUTPUT}.")
+    table = _format_alias_reference()
+    return f"{before}{START}\n\n{table}\n\n{END}{after}"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    source = OUTPUT.read_text()
+    _validate_visual_contexts(source)
+    _validate_api_targets()
+    rendered = _render(source)
+    if args.check:
+        if source != rendered:
+            raise SystemExit("Alias reference is stale; regenerate it.")
+    else:
+        OUTPUT.write_text(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/serve_alias_docs.py
+++ b/tools/serve_alias_docs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Serve the local docs preview and retain draggable alias-map positions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+LAYOUT_KEYS = {"layout", "titles", "axes", "plot", "legend", "colorbar", "style"}
+
+
+def _valid_layout(payload):
+    if not isinstance(payload, dict) or payload.get("version") != 1:
+        return False
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, dict) or set(nodes) != LAYOUT_KEYS:
+        return False
+    for value in nodes.values():
+        if not isinstance(value, list) or len(value) != 2:
+            return False
+        if not all(isinstance(item, (int, float)) for item in value):
+            return False
+        if not all(-250 <= item <= 1_000 for item in value):
+            return False
+    return True
+
+
+def make_handler(directory, draft_path):
+    class AliasDocsHandler(SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(directory), **kwargs)
+
+        def do_GET(self):
+            if urlsplit(self.path).path != "/__alias_layout":
+                return super().do_GET()
+            payload = draft_path.read_bytes() if draft_path.exists() else b'{"version":1,"nodes":{}}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_POST(self):
+            if urlsplit(self.path).path != "/__alias_layout":
+                self.send_error(404)
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+                if not 0 < length <= 16_384:
+                    raise ValueError("invalid payload size")
+                payload = json.loads(self.rfile.read(length))
+                if not _valid_layout(payload):
+                    raise ValueError("invalid alias layout")
+                temporary = draft_path.with_suffix(".tmp")
+                temporary.write_text(json.dumps(payload, indent=2) + "\n")
+                temporary.replace(draft_path)
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                self.send_error(400, str(error))
+                return
+            self.send_response(204)
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+
+    return AliasDocsHandler
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--directory", type=Path, required=True)
+    parser.add_argument("--draft", type=Path, required=True)
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+    handler = make_handler(args.directory.resolve(), args.draft.resolve())
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+    print(f"Serving alias docs at http://127.0.0.1:{args.port}/aliases.html")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/ultraplot/_subplots.py
+++ b/ultraplot/_subplots.py
@@ -13,7 +13,14 @@ import numpy as np
 from . import axes as paxes
 from . import constructor
 from . import gridspec as pgridspec
-from .internals import _not_none, _pop_params, warnings
+from .internals import (
+    _alias_kwargs,
+    _canonicalize_kwargs,
+    _figure_format_alias_scopes,
+    _not_none,
+    _pop_params,
+    warnings,
+)
 
 if TYPE_CHECKING:
     from .figure import Figure
@@ -69,11 +76,10 @@ class SubplotManager:
             constructor._warn_basemap_deprecated()
         return backend
 
+    @_alias_kwargs("subplot")
     def parse_proj(
         self,
-        proj=None,
         projection=None,
-        proj_kw=None,
         projection_kw=None,
         backend=None,
         basemap=None,
@@ -83,8 +89,8 @@ class SubplotManager:
         Translate user-input projection into a registered matplotlib axes class.
         """
         # Parse arguments
-        proj = _not_none(proj=proj, projection=projection, default="cartesian")
-        proj_kw = _not_none(proj_kw=proj_kw, projection_kw=projection_kw, default={})
+        proj = _not_none(projection, "cartesian")
+        proj_kw = projection_kw or {}
         backend = self.parse_backend(backend, basemap)
         if isinstance(proj, str):
             proj = proj.lower()
@@ -270,15 +276,14 @@ class SubplotManager:
             self.subplot_dict[ax.number] = ax
         return ax
 
+    @_alias_kwargs("subplot")
     def add_subplots(
         self,
         array=None,
         nrows=1,
         ncols=1,
         order="C",
-        proj=None,
         projection=None,
-        proj_kw=None,
         projection_kw=None,
         backend=None,
         basemap=None,
@@ -288,6 +293,8 @@ class SubplotManager:
         The driver function for adding multiple subplots.
         """
         fig = self.figure
+        kwargs = _canonicalize_kwargs(_figure_format_alias_scopes, kwargs)
+        kwargs = _canonicalize_kwargs("gridspec", kwargs)
 
         # Helper to normalize per-axes arguments into {num: value} dicts.
         # Accepts 'string', {1: 'string1', (2, 3): 'string2'}, or lists.
@@ -346,14 +353,18 @@ class SubplotManager:
         naxs = len(nums)
         if any(num < 0 or not isinstance(num, Integral) for num in nums.flat):
             raise ValueError(f"Expected array of positive integers. Got {array}.")
-        proj = _not_none(projection=projection, proj=proj)
+        proj = projection
         proj = _axes_dict(naxs, proj, kw=False, default="cartesian")
-        proj_kw = _not_none(projection_kw=projection_kw, proj_kw=proj_kw) or {}
+        proj_kw = projection_kw or {}
         proj_kw = _axes_dict(naxs, proj_kw, kw=True)
         backend = self.parse_backend(backend, basemap)
         backend = _axes_dict(naxs, backend, kw=False)
         axes_kw = {
-            num: {"proj": proj[num], "proj_kw": proj_kw[num], "backend": backend[num]}
+            num: {
+                "projection": proj[num],
+                "projection_kw": proj_kw[num],
+                "backend": backend[num],
+            }
             for num in proj
         }
         for key in ("gridspec_kw", "subplot_kw"):

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -1249,7 +1249,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         col: Optional[int] = None,
         rows: Optional[Union[int, Tuple[int, int]]] = None,
         cols: Optional[Union[int, Tuple[int, int]]] = None,
-        shrink: Optional[Union[float, str]] = None,
+        length: Optional[Union[float, str]] = None,
         label=None,
         reverse=False,
         rotation=None,
@@ -1299,7 +1299,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             col=col,
             rows=rows,
             cols=cols,
-            shrink=shrink,
+            length=length,
             label=label,
             reverse=reverse,
             rotation=rotation,
@@ -2010,7 +2010,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         loc=None,
         bbox_to_anchor=None,
         width=None,
-        shrink=None,
+        length=None,
         frameon=None,
         label=None,
         labelsize=None,
@@ -2027,7 +2027,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         """
         # Basic colorbar properties
         frame_enabled = _not_none(frameon, rc["colorbar.frameon"])
-        length = _not_none(shrink, rc["colorbar.insetlength"])
+        length = _not_none(length, rc["colorbar.insetlength"])
         width = _not_none(width, rc["colorbar.insetwidth"])
         pad = _not_none(pad, rc["colorbar.insetpad"])
         length_raw = length
@@ -2126,7 +2126,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         loc=None,
         align=None,
         width=None,
-        shrink=None,
+        length=None,
         space=None,
         pad=None,
         tickloc=None,
@@ -2137,7 +2137,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         """
         Return the axes and adjusted keyword args for a side colorbar on an inset axes.
         """
-        length = _not_none(shrink, rc["colorbar.length"])
+        length = _not_none(length, rc["colorbar.length"])
         width = _not_none(width, rc["colorbar.width"])
         pad = _not_none(space, pad, rc["subplots.panelpad"])
         side = _translate_loc(loc, "panel")
@@ -3618,9 +3618,10 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                 "filled"            ``'fill'``
                 ==================  =======================================
 
-            shrink : float or unit-spec, default: :rc:`colorbar.length` or :rc:`colorbar.insetlength`
-                The colorbar length. For outer colorbars, units are relative to the axes
-                width or height (default is :rcraw:`colorbar.length`). For inset
+            length : float or unit-spec, default: :rc:`colorbar.length` or :rc:`colorbar.insetlength`
+                The colorbar length (also accepted as ``shrink``). For outer colorbars,
+                units are relative to the axes width or height (default is
+                :rcraw:`colorbar.length`). For inset
                 colorbars, floats interpreted as em-widths and strings interpreted
                 by `~ultraplot.utils.units` (default is :rcraw:`colorbar.insetlength`).
             width : unit-spec, default: :rc:`colorbar.width` or :rc:`colorbar.insetwidth`
@@ -3629,7 +3630,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                 interpreted as em-widths (default is :rcraw:`colorbar.insetwidth`).
                 Strings are interpreted by `~ultraplot.utils.units`.
             %(axes.colorbar_space)s
-                Has no visible effect if `shrink` is ``1``.
+                Has no visible effect if `length` is ``1``.
             bbox_to_anchor : 2-tuple, 4-tuple, or `matplotlib.transforms.Bbox`, optional
                 For inset colorbars, anchor the full colorbar footprint using the
                 same semantics as `~matplotlib.axes.Axes.legend`. The colorbar

--- a/ultraplot/axes/base.py
+++ b/ultraplot/axes/base.py
@@ -55,6 +55,9 @@ from ..colorbar import (
 )
 from ..config import rc
 from ..internals import (
+    _alias_kwargs,
+    _canonicalize_kwargs,
+    _format_alias_scopes,
     _kwargs_to_args,
     _not_none,
     _pop_kwargs,
@@ -86,7 +89,7 @@ ABC_STRING = "abcdefghijklmnopqrstuvwxyz"
 
 # Projection docstring
 _proj_docstring = """
-proj, projection :
+projection :
 str, `cartopy.crs.Projection`, or `~mpl_toolkits.basemap.Basemap`, optional
     The map projection specification(s). If ``'cart'`` or ``'cartesian'``
     (the default), a `~ultraplot.axes.CartesianAxes` is created. If ``'polar'``,
@@ -97,7 +100,7 @@ str, `cartopy.crs.Projection`, or `~mpl_toolkits.basemap.Basemap`, optional
     instance, or a projection name listed in :ref:`this table <proj_table>`).
 """
 _proj_kw_docstring = """
-proj_kw, projection_kw : dict-like, optional
+projection_kw : dict-like, optional
     Keyword arguments passed to `~mpl_toolkits.basemap.Basemap` or
     cartopy `~cartopy.crs.Projection` classes on instantiation.
 """
@@ -365,9 +368,7 @@ titleabove : bool, default: :rc:`title.above`
 abctitlepad : float, default: :rc:`abc.titlepad`
     The horizontal padding between a-b-c labels and titles in the same location.
     %(units.pt)s
-ltitle, ctitle, rtitle, ultitle, uctitle, urtitle, lltitle, lctitle, lrtitle : str or sequence, optional
-    Shorthands for the below keywords.
-    lefttitle, centertitle, righttitle, upperlefttitle, uppercentertitle, upperrighttitle : str or sequence, optional
+lefttitle, centertitle, righttitle, upperlefttitle, uppercentertitle, upperrighttitle : str or sequence, optional
 lowerlefttitle, lowercentertitle, lowerrighttitle : str or sequence, optional
     Additional titles in specific positions (see `title` for details). This works as
     an alternative to the ``ax.format(title='Title', titleloc=loc)`` workflow and
@@ -378,9 +379,6 @@ a, alpha, fc, facecolor, ec, edgecolor, lw, linewidth, ls, linestyle : default:
     shorthands. Their defaults values are the ``'axes'`` properties.
 """
 _figure_format_docstring = """
-rowlabels, collabels, llabels, tlabels, rlabels, blabels
-    Aliases for `leftlabels` and `toplabels`, and for `leftlabels`,
-    `toplabels`, `rightlabels`, and `bottomlabels`, respectively.
 leftlabels, toplabels, rightlabels, bottomlabels : sequence of str, optional
     Labels for the subplots lying along the left, top, right, and
     bottom edges of the figure. The length of each list must match
@@ -396,8 +394,6 @@ leftlabelsharedpad, toplabelsharedpad, rightlabelsharedpad, bottomlabelsharedpad
     %(units.pt)s
 leftlabels_kw, toplabels_kw, rightlabels_kw, bottomlabels_kw : dict-like, optional
     Additional settings used to update the labels with ``text.update()``.
-figtitle
-    Alias for `suptitle`.
 suptitle : str, optional
     The figure "super" title, centered between the left edge of the leftmost
     subplot and the right edge of the rightmost subplot.
@@ -485,15 +481,14 @@ norm_kw : dict-like, optional
 vmin, vmax : float, optional
     Ignored if `mappable` is a `~matplotlib.cm.ScalarMappable`. These are the minimum
     and maximum colorbar values. Passed to `~ultraplot.constructor.Norm`.
-label, title : str, optional
-    The colorbar label. The `title` keyword is also accepted for
-    consistency with `~matplotlib.axes.Axes.legend`.
+label : str, optional
+    The colorbar label.
 reverse : bool, optional
     Whether to reverse the direction of the colorbar. This is done automatically
     when descending levels are used with `~ultraplot.colors.DiscreteNorm`.
 rotation : float, default: 0
     The tick label rotation.
-grid, edges, drawedges : bool, default: :rc:`colorbar.grid`
+drawedges : bool, default: :rc:`colorbar.grid`
     Whether to draw "grid" dividers between each distinct color.
 extend : {'neither', 'both', 'min', 'max'}, optional
     Direction for drawing colorbar "extensions" (i.e. color keys for out-of-bounds
@@ -509,36 +504,35 @@ extendsize : unit-spec, default: :rc:`colorbar.extend` or :rc:`colorbar.insetext
 extendrect : bool, default: False
     Whether to draw colorbar "extensions" as rectangles. If ``False`` then
     the extensions are drawn as triangles.
-locator, ticks : locator-spec, optional
+ticks : locator-spec, optional
     Used to determine the colorbar tick positions. Passed to the
     `~ultraplot.constructor.Locator` constructor function. By default
     `~matplotlib.ticker.AutoLocator` is used for continuous color levels
     and `~ultraplot.ticker.DiscreteLocator` is used for discrete color levels.
 locator_kw : dict-like, optional
     Keyword arguments passed to `matplotlib.ticker.Locator` class.
-minorlocator, minorticks
-    As with `locator`, `ticks` but for the minor ticks. By default
+minorticks
+    As with `ticks` but for the minor ticks. By default
     `~matplotlib.ticker.AutoMinorLocator` is used for continuous color levels
     and `~ultraplot.ticker.DiscreteLocator` is used for discrete color levels.
 minorlocator_kw
     As with `locator_kw`, but for the minor ticks.
-format, formatter, ticklabels : formatter-spec, optional
+format : formatter-spec, optional
     The tick label format. Passed to the `~ultraplot.constructor.Formatter`
     constructor function.
 formatter_kw : dict-like, optional
     Keyword arguments passed to `matplotlib.ticker.Formatter` class.
-frame, frameon : bool, optional
+frameon : bool, optional
     For inset colorbars, indicates whether to draw a background "frame",
     just like `~matplotlib.axes.Axes.legend`. Defaults to
-    :rc:`colorbar.frameon` for inset colorbars. For outer colorbars, this is a
-    backwards-compatible alias for `outline`; when omitted, outer colorbars
-    still default to :rc:`colorbar.outline`.
+    :rc:`colorbar.frameon` for inset colorbars. For outer colorbars it controls
+    the outline when `outline` is omitted.
 tickminor : bool, optional
     Whether to add minor ticks using `~matplotlib.colorbar.ColorbarBase.minorticks_on`.
 tickloc, ticklocation : {'bottom', 'top', 'left', 'right'}, optional
     Where to draw tick marks on the colorbar. Default is toward the outside
     of the subplot for outer colorbars and ``'bottom'`` for inset colorbars.
-tickdir, tickdirection : {'out', 'in', 'inout'}, default: :rc:`tick.dir`
+tickdirection : {'out', 'in', 'inout'}, default: :rc:`tick.dir`
     Direction of major and minor colorbar ticks.
 ticklen : unit-spec, default: :rc:`tick.len`
     Major tick lengths for the colorbar ticks.
@@ -551,7 +545,7 @@ tickwidthratio : float, default: :rc:`tick.widthratio`
     Relative scaling of `tickwidth` used to determine minor tick widths.
 ticklabelcolor, ticklabelsize, ticklabelweight: default: :rc:`tick.labelcolor`, :rc:`tick.labelsize`, :rc:`tick.labelweight`.
     The font color, size, and weight for colorbar tick labels
-labelloc, labellocation : {'bottom', 'top', 'left', 'right'}
+labellocation : {'bottom', 'top', 'left', 'right'}
     The colorbar label location. Inherits from `tickloc` by default. Default is toward
     the outside of the subplot for outer colorbars and ``'bottom'`` for inset colorbars.
 labelcolor, labelsize, labelweight: default: :rc:`label.color`, :rc:`label.size`, and :rc:`label.weight`.
@@ -559,7 +553,7 @@ labelcolor, labelsize, labelweight: default: :rc:`label.color`, :rc:`label.size`
 a, alpha, framealpha, fc, facecolor, framecolor, ec, edgecolor, ew, edgewidth : default: :rc:`colorbar.framealpha`, :rc:`colorbar.framecolor`
     For inset colorbars only. Controls the transparency and color of
     the background frame.
-lw, linewidth, c, color : optional
+linewidth, color : optional
     Controls the line width and edge color for both the colorbar
     outline and the level dividers.
 %(axes.edgefix)s
@@ -618,12 +612,11 @@ labels : list of str, optional
 -<https://matplotlib.org/stable/tutorials/intermediate/legend_guide.html>`__.
 """
 _legend_kwargs_docstring = """
-frame, frameon : bool, optional
+frameon : bool, optional
     Toggles the legend frame. For centered-row legends, a frame
     independent from matplotlib's built-in legend frame is created.
-ncol, ncols : int, optional
-    The number of columns. `ncols` is an alias, added
-    for consistency with `~matplotlib.pyplot.subplots`.
+ncols : int, optional
+    The number of columns.
 order : {'C', 'F'}, optional
     Whether legend handles are drawn in row-major (``'C'``) or column-major
     (``'F'``) order. Analagous to `numpy.array` ordering. The matplotlib
@@ -973,6 +966,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         autoshare = _not_none(autoshare, True)
 
         # Remove format-related args and initialize
+        kwargs = _canonicalize_kwargs(_format_alias_scopes, kwargs)
         rc_kw, rc_mode = _pop_rc(kwargs)
         kw_format = _pop_props(kwargs, "patch")  # background properties
         if "zorder" in kw_format:  # special case: refers to the entire axes
@@ -1066,12 +1060,12 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         # features which is necessary on first run. Default otherwise is mode '2'
         self.format(rc_kw=rc_kw, rc_mode=1, skip_figure=True, **kw_format)
 
+    @_alias_kwargs("inset")
     def _add_inset_axes(
         self,
         bounds,
         transform=None,
         *,
-        proj=None,
         projection=None,
         zoom=None,
         zoom_kw=None,
@@ -1090,7 +1084,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         zorder = _not_none(zorder, 4)
 
         # Parse projection and inherit from the current axes by default
-        proj = _not_none(proj=proj, projection=projection)
+        proj = projection
         if proj is None:
             if self._name in ("cartopy", "basemap"):
                 proj = copy.copy(self.projection)
@@ -1239,6 +1233,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         return ax
 
     @warnings._rename_kwargs("0.10", rasterize="rasterized")
+    @_alias_kwargs("colorbar")
     def _add_colorbar(
         self,
         mappable,
@@ -1249,7 +1244,6 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         space: Optional[Union[float, str]] = None,
         pad: Optional[Union[float, str]] = None,
         width: Optional[Union[float, str]] = None,
-        length: Optional[Union[float, str]] = None,
         span: Optional[Union[int, Tuple[int, int]]] = None,
         row: Optional[int] = None,
         col: Optional[int] = None,
@@ -1257,47 +1251,35 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         cols: Optional[Union[int, Tuple[int, int]]] = None,
         shrink: Optional[Union[float, str]] = None,
         label=None,
-        title=None,
         reverse=False,
         rotation=None,
-        grid=None,
-        edges=None,
         drawedges=None,
         extend=None,
         extendsize=None,
         extendfrac=None,
         ticks=None,
-        locator=None,
         locator_kw=None,
         format=None,
-        formatter=None,
-        ticklabels=None,
         formatter_kw=None,
         minorticks=None,
-        minorlocator=None,
         minorlocator_kw=None,
         tickminor=None,
         ticklen=None,
         ticklenratio=None,
-        tickdir=None,
         tickdirection=None,
         tickwidth=None,
         tickwidthratio=None,
         ticklabelsize=None,
         ticklabelweight=None,
         ticklabelcolor=None,
-        labelloc=None,
         labellocation=None,
         labelsize=None,
         labelweight=None,
         labelcolor=None,
-        c=None,
         color=None,
-        lw=None,
         linewidth=None,
         edgefix=None,
         rasterized=None,
-        frame: Optional[bool] = None,
         frameon: Optional[bool] = None,
         outline: Union[bool, None] = None,
         labelrotation: Union[str, float] = None,
@@ -1312,7 +1294,6 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             space=space,
             pad=pad,
             width=width,
-            length=length,
             span=span,
             row=row,
             col=col,
@@ -1320,47 +1301,35 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             cols=cols,
             shrink=shrink,
             label=label,
-            title=title,
             reverse=reverse,
             rotation=rotation,
-            grid=grid,
-            edges=edges,
             drawedges=drawedges,
             extend=extend,
             extendsize=extendsize,
             extendfrac=extendfrac,
             ticks=ticks,
-            locator=locator,
             locator_kw=locator_kw,
             format=format,
-            formatter=formatter,
-            ticklabels=ticklabels,
             formatter_kw=formatter_kw,
             minorticks=minorticks,
-            minorlocator=minorlocator,
             minorlocator_kw=minorlocator_kw,
             tickminor=tickminor,
             ticklen=ticklen,
             ticklenratio=ticklenratio,
-            tickdir=tickdir,
             tickdirection=tickdirection,
             tickwidth=tickwidth,
             tickwidthratio=tickwidthratio,
             ticklabelsize=ticklabelsize,
             ticklabelweight=ticklabelweight,
             ticklabelcolor=ticklabelcolor,
-            labelloc=labelloc,
             labellocation=labellocation,
             labelsize=labelsize,
             labelweight=labelweight,
             labelcolor=labelcolor,
-            c=c,
             color=color,
-            lw=lw,
             linewidth=linewidth,
             edgefix=edgefix,
             rasterized=rasterized,
-            frame=frame,
             frameon=frameon,
             outline=outline,
             labelrotation=labelrotation,
@@ -1368,6 +1337,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             **kwargs,
         )
 
+    @_alias_kwargs("legend")
     def _add_legend(
         self,
         handles=None,
@@ -1378,9 +1348,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         width=None,
         pad=None,
         space=None,
-        frame=None,
         frameon=None,
-        ncol=None,
         ncols=None,
         alphabetize=False,
         center=None,
@@ -1410,9 +1378,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
             width=width,
             pad=pad,
             space=space,
-            frame=frame,
             frameon=frameon,
-            ncol=ncol,
             ncols=ncols,
             alphabetize=alphabetize,
             center=center,
@@ -2044,9 +2010,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         loc=None,
         bbox_to_anchor=None,
         width=None,
-        length=None,
         shrink=None,
-        frame=None,
         frameon=None,
         label=None,
         labelsize=None,
@@ -2062,12 +2026,8 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         Return the axes and adjusted keyword args for an inset colorbar.
         """
         # Basic colorbar properties
-        frame_enabled = _not_none(
-            frame=frame, frameon=frameon, default=rc["colorbar.frameon"]
-        )
-        length = _not_none(
-            length=length, shrink=shrink, default=rc["colorbar.insetlength"]
-        )  # noqa: E501
+        frame_enabled = _not_none(frameon, rc["colorbar.frameon"])
+        length = _not_none(shrink, rc["colorbar.insetlength"])
         width = _not_none(width, rc["colorbar.insetwidth"])
         pad = _not_none(pad, rc["colorbar.insetpad"])
         length_raw = length
@@ -2166,7 +2126,6 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         loc=None,
         align=None,
         width=None,
-        length=None,
         shrink=None,
         space=None,
         pad=None,
@@ -2178,7 +2137,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         """
         Return the axes and adjusted keyword args for a side colorbar on an inset axes.
         """
-        length = _not_none(length=length, shrink=shrink, default=rc["colorbar.length"])
+        length = _not_none(shrink, rc["colorbar.length"])
         width = _not_none(width, rc["colorbar.width"])
         pad = _not_none(space, pad, rc["subplots.panelpad"])
         side = _translate_loc(loc, "panel")
@@ -3291,29 +3250,22 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                     ax.yaxis.label = label
 
     @docstring._snippet_manager
+    @_alias_kwargs("axes.format")
+    @_alias_kwargs("figure.format")
     def format(
         self,
         *,
         title=None,
         title_kw=None,
         abc_kw=None,
-        ltitle=None,
         lefttitle=None,
-        ctitle=None,
         centertitle=None,
-        rtitle=None,
         righttitle=None,
-        ultitle=None,
         upperlefttitle=None,
-        uctitle=None,
         uppercentertitle=None,
-        urtitle=None,
         upperrighttitle=None,
-        lltitle=None,
         lowerlefttitle=None,
-        lctitle=None,
         lowercentertitle=None,
-        lrtitle=None,
         lowerrighttitle=None,
         share_xlabels=None,
         share_ylabels=None,
@@ -3375,51 +3327,15 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                 self._abc_pad = units(pad)
             self._update_abc(**abc_kw)
             self._update_title(None, title, **title_kw)
-            self._update_title(
-                "left",
-                _not_none(ltitle=ltitle, lefttitle=lefttitle),
-                **title_kw,
-            )
-            self._update_title(
-                "center",
-                _not_none(ctitle=ctitle, centertitle=centertitle),
-                **title_kw,
-            )
-            self._update_title(
-                "right",
-                _not_none(rtitle=rtitle, righttitle=righttitle),
-                **title_kw,
-            )
-            self._update_title(
-                "upper left",
-                _not_none(ultitle=ultitle, upperlefttitle=upperlefttitle),
-                **title_kw,
-            )
-            self._update_title(
-                "upper center",
-                _not_none(uctitle=uctitle, uppercentertitle=uppercentertitle),
-                **title_kw,
-            )
-            self._update_title(
-                "upper right",
-                _not_none(urtitle=urtitle, upperrighttitle=upperrighttitle),
-                **title_kw,
-            )
-            self._update_title(
-                "lower left",
-                _not_none(lltitle=lltitle, lowerlefttitle=lowerlefttitle),
-                **title_kw,
-            )
-            self._update_title(
-                "lower center",
-                _not_none(lctitle=lctitle, lowercentertitle=lowercentertitle),
-                **title_kw,
-            )
-            self._update_title(
-                "lower right",
-                _not_none(lrtitle=lrtitle, lowerrighttitle=lowerrighttitle),
-                **title_kw,
-            )
+            self._update_title("left", lefttitle, **title_kw)
+            self._update_title("center", centertitle, **title_kw)
+            self._update_title("right", righttitle, **title_kw)
+            self._update_title("upper left", upperlefttitle, **title_kw)
+            self._update_title("upper center", uppercentertitle, **title_kw)
+            self._update_title("upper right", upperrighttitle, **title_kw)
+            self._update_title("lower left", lowerlefttitle, **title_kw)
+            self._update_title("lower center", lowercentertitle, **title_kw)
+            self._update_title("lower right", lowerrighttitle, **title_kw)
 
             # Update the axes style
             # NOTE: This will also raise an error if unknown args are encountered
@@ -3674,14 +3590,15 @@ class Axes(_ExternalModeMixin, maxes.Axes):
 
     @docstring._obfuscate_params
     @docstring._snippet_manager
-    def colorbar(self, mappable, values=None, loc=None, location=None, **kwargs):
+    @_alias_kwargs("colorbar")
+    def colorbar(self, mappable, values=None, loc=None, **kwargs):
         """
         Add an inset colorbar or an outer colorbar along the edge of the axes.
 
         Parameters
         ----------
         %(axes.colorbar_args)s
-            loc, location : int or str, default: :rc:`colorbar.loc`
+            loc : int or str, default: :rc:`colorbar.loc`
                 The colorbar location. Valid location keys are shown in the below table.
 
                 .. _colorbar_table:
@@ -3701,10 +3618,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                 "filled"            ``'fill'``
                 ==================  =======================================
 
-            shrink
-                Alias for `length`. This is included for consistency with
-                `matplotlib.figure.Figure.colorbar`.
-            length : float or unit-spec, default: :rc:`colorbar.length` or :rc:`colorbar.insetlength`
+            shrink : float or unit-spec, default: :rc:`colorbar.length` or :rc:`colorbar.insetlength`
                 The colorbar length. For outer colorbars, units are relative to the axes
                 width or height (default is :rcraw:`colorbar.length`). For inset
                 colorbars, floats interpreted as em-widths and strings interpreted
@@ -3715,7 +3629,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
                 interpreted as em-widths (default is :rcraw:`colorbar.insetwidth`).
                 Strings are interpreted by `~ultraplot.utils.units`.
             %(axes.colorbar_space)s
-                Has no visible effect if `length` is ``1``.
+                Has no visible effect if `shrink` is ``1``.
             bbox_to_anchor : 2-tuple, 4-tuple, or `matplotlib.transforms.Bbox`, optional
                 For inset colorbars, anchor the full colorbar footprint using the
                 same semantics as `~matplotlib.axes.Axes.legend`. The colorbar
@@ -3734,7 +3648,6 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         # infer align setting from keywords stored on object.
         orientation = kwargs.get("orientation", None)
         kwargs = guides._flush_guide_kw(mappable, "colorbar", kwargs)
-        loc = _not_none(loc=loc, location=location)
         if orientation is not None:  # possibly infer loc from orientation
             if orientation not in ("vertical", "horizontal"):
                 raise ValueError(
@@ -3756,12 +3669,12 @@ class Axes(_ExternalModeMixin, maxes.Axes):
 
     @docstring._concatenate_inherited  # also obfuscates params
     @docstring._snippet_manager
+    @_alias_kwargs("legend")
     def legend(
         self,
         handles=None,
         labels=None,
         loc=None,
-        location=None,
         span: Optional[Union[int, Tuple[int, int]]] = None,
         row: Optional[int] = None,
         col: Optional[int] = None,
@@ -3775,7 +3688,7 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         Parameters
         ----------
         %(axes.legend_args)s
-        loc, location : int or str, default: :rc:`legend.loc`
+        loc : int or str, default: :rc:`legend.loc`
             The legend location. Valid location keys are shown in the below table.
 
             .. _legend_table:
@@ -3819,7 +3732,6 @@ class Axes(_ExternalModeMixin, maxes.Axes):
         # Translate location and possibly infer from orientation. Also optionally
         # infer align setting from keywords stored on object.
         kwargs = guides._flush_guide_kw(handles, "legend", kwargs)
-        loc = _not_none(loc=loc, location=location)
         loc = _translate_loc(loc, "legend", default=rc["legend.loc"])
         align = kwargs.pop("align", None)
         align = _translate_loc(align, "align", default="center")

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -21,6 +21,8 @@ from .. import ticker as pticker
 from ..config import rc
 from ..internals import (
     _alias_kwargs,
+    _canonicalize_kwargs,
+    _format_alias_scopes,
     _not_none,
     _pop_params,
     _pop_rc,
@@ -676,13 +678,25 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
         # To restore matplotlib behavior, which draws "child" artists on top simply
         # because the axes was created after the "parent" one, use the inset_axes
         # zorder of 4 and make the background transparent.
+        kwargs = _canonicalize_kwargs(_format_alias_scopes, kwargs)
         sy = "y" if sx == "x" else "x"
         sig = self._format_signatures[CartesianAxes]
         keys = tuple(key[1:] for key in sig.parameters if key[0] == sx)
-        kwargs = {
-            (f"{sx}spineloc" if key == "loc" else sx + key if key in keys else key): val
-            for key, val in kwargs.items()
-        }  # noqa: E501
+        normalized = {}
+        for key, value in kwargs.items():
+            if key == "loc":
+                key = f"{sx}spineloc"
+            elif key in keys:
+                key = sx + key
+            else:
+                candidate = _canonicalize_kwargs(
+                    _format_alias_scopes, {sx + key: value}
+                )
+                candidate_key = next(iter(candidate))
+                if candidate_key in sig.parameters:
+                    key = candidate_key
+            normalized[key] = value
+        kwargs = normalized
         kwargs.setdefault(f"{sy}spineloc", "neither")
         kwargs.setdefault(f"{sx}spineloc", "top" if sx == "x" else "right")
         kwargs.setdefault(f"autoscale{sy}_on", getattr(self, f"get_autoscale{sy}_on")())

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -680,13 +680,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
         sig = self._format_signatures[CartesianAxes]
         keys = tuple(key[1:] for key in sig.parameters if key[0] == sx)
         kwargs = {
-            (
-                f"{sx}spineloc"
-                if key == "loc"
-                else sx + key
-                if key in keys
-                else key
-            ): val
+            (f"{sx}spineloc" if key == "loc" else sx + key if key in keys else key): val
             for key, val in kwargs.items()
         }  # noqa: E501
         kwargs.setdefault(f"{sy}spineloc", "neither")
@@ -711,11 +705,7 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
 
         # Format parent and child axes
         self.format(
-            **{
-                f"{sx}spineloc": OPPOSITE_SIDE.get(
-                    kwargs[f"{sx}spineloc"], None
-                )
-            }
+            **{f"{sx}spineloc": OPPOSITE_SIDE.get(kwargs[f"{sx}spineloc"], None)}
         )
         setattr(ax, f"_alt{sx}_parent", self)
         getattr(ax, f"{sy}axis").set_visible(False)

--- a/ultraplot/axes/cartesian.py
+++ b/ultraplot/axes/cartesian.py
@@ -20,6 +20,7 @@ from .. import scale as pscale
 from .. import ticker as pticker
 from ..config import rc
 from ..internals import (
+    _alias_kwargs,
     _not_none,
     _pop_params,
     _pop_rc,
@@ -104,8 +105,6 @@ xwraprange, ywraprange : 2-tuple of float, optional
     example, ``xwraprange=(0, 3)`` causes the values 0 through 9 to be formatted as
     0, 1, 2, 0, 1, 2, 0, 1, 2, 0. See `~ultraplot.ticker.AutoFormatter` for details. This
     can be combined with `xtickrange` and `ytickrange` to make "stacked" line plots.
-xloc, yloc : optional
-    Shorthands for `xspineloc`, `yspineloc`.
 xspineloc, yspineloc : {'b', 't', 'l', 'r', 'bottom', 'top', 'left', 'right', \
 'both', 'neither', 'none', 'zero', 'center'} or 2-tuple, optional
     The x and y spine locations. Applied with `~matplotlib.spines.Spine.set_position`.
@@ -144,8 +143,6 @@ xgridminor, ygridminor, gridminor : bool, default: :rc:`gridminor`
 xtickminor, ytickminor, tickminor : bool, default: :rc:`tick.minor`
     Whether to draw minor ticks on the x and y axes.
     Use the keyword `tickminor` to toggle both.
-xticks, yticks : optional
-    Aliases for `xlocator`, `ylocator`.
 xlocator, ylocator : locator-spec, optional
     Used to determine the x and y axis tick mark positions. Passed
     to the `~ultraplot.constructor.Locator` constructor.  Can be float,
@@ -153,14 +150,10 @@ xlocator, ylocator : locator-spec, optional
     Use ``[]``, ``'null'``, or ``'none'`` for no ticks.
 xlocator_kw, ylocator_kw : dict-like, optional
     Keyword arguments passed to the `matplotlib.ticker.Locator` class.
-xminorticks, yminorticks : optional
-    Aliases for `xminorlocator`, `yminorlocator`.
 xminorlocator, yminorlocator : optional
     As for `xlocator`, `ylocator`, but for the minor ticks.
 xminorlocator_kw, yminorlocator_kw
     As for `xlocator_kw`, `ylocator_kw`, but for the minor locator.
-xticklabels, yticklabels : optional
-    Aliases for `xformatter`, `yformatter`.
 xformatter, yformatter : formatter-spec, optional
     Used to determine the x and y axis tick label string format.
     Passed to the `~ultraplot.constructor.Formatter` constructor.
@@ -687,12 +680,17 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
         sig = self._format_signatures[CartesianAxes]
         keys = tuple(key[1:] for key in sig.parameters if key[0] == sx)
         kwargs = {
-            (sx + key if key in keys else key): val for key, val in kwargs.items()
+            (
+                f"{sx}spineloc"
+                if key == "loc"
+                else sx + key
+                if key in keys
+                else key
+            ): val
+            for key, val in kwargs.items()
         }  # noqa: E501
-        if f"{sy}spineloc" not in kwargs:  # acccount for aliases
-            kwargs.setdefault(f"{sy}loc", "neither")
-        if f"{sx}spineloc" not in kwargs:  # account for aliases
-            kwargs.setdefault(f"{sx}loc", "top" if sx == "x" else "right")
+        kwargs.setdefault(f"{sy}spineloc", "neither")
+        kwargs.setdefault(f"{sx}spineloc", "top" if sx == "x" else "right")
         kwargs.setdefault(f"autoscale{sy}_on", getattr(self, f"get_autoscale{sy}_on")())
         kwargs.setdefault(f"share{sy}", self)
 
@@ -712,7 +710,13 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
         self._twinned_axes.join(self, ax)
 
         # Format parent and child axes
-        self.format(**{f"{sx}loc": OPPOSITE_SIDE.get(kwargs[f"{sx}loc"], None)})
+        self.format(
+            **{
+                f"{sx}spineloc": OPPOSITE_SIDE.get(
+                    kwargs[f"{sx}spineloc"], None
+                )
+            }
+        )
         setattr(ax, f"_alt{sx}_parent", self)
         getattr(ax, f"{sy}axis").set_visible(False)
         getattr(ax, "patch").set_visible(False)
@@ -1443,10 +1447,9 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
             rc.find(f"{axis}tick.direction", context=True),
         )
 
-        locator = _not_none(get("locator"), p.get(f"{axis}ticks"))
-        minorlocator = _not_none(get("minorlocator"), p.get(f"{axis}minorticks"))
-
-        formatter = _not_none(get("formatter"), p.get(f"{axis}ticklabels"))
+        locator = get("locator")
+        minorlocator = get("minorlocator")
+        formatter = get("formatter")
 
         # Tick minor default logic
         tickminor = get("tickminor")
@@ -1582,12 +1585,11 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
         return _AxisFormatConfig(**config_kwargs)
 
     @docstring._snippet_manager
+    @_alias_kwargs("cartesian.format")
     def format(
         self,
         *,
         aspect=None,
-        xloc=None,
-        yloc=None,
         xspineloc=None,
         yspineloc=None,
         xoffsetloc=None,
@@ -1612,14 +1614,8 @@ class CartesianAxes(shared._SharedAxes, plot.PlotAxes):
         yrotation=None,
         xformatter=None,
         yformatter=None,
-        xticklabels=None,
-        yticklabels=None,
-        xticks=None,
-        yticks=None,
         xlocator=None,
         ylocator=None,
-        xminorticks=None,
-        yminorticks=None,
         xminorlocator=None,
         yminorlocator=None,
         xcolor=None,

--- a/ultraplot/axes/geo.py
+++ b/ultraplot/axes/geo.py
@@ -36,6 +36,7 @@ from .. import proj as pproj
 from .. import ticker as pticker
 from ..config import rc
 from ..internals import (
+    _alias_kwargs,
     _not_none,
     _pop_params,
     _pop_props,
@@ -557,7 +558,6 @@ nsteps : int, default: :rc:`grid.nsteps`
     The number of interpolation steps used to draw gridlines.
 lonlocator, latlocator : locator-spec, optional
     Used to determine the longitude and latitude gridline locations.
-    Aliases: ``lonlines`` and ``latlines``, respectively.
     Passed to the `~ultraplot.constructor.Locator` constructor. Can be
     string, float, list of float, or `matplotlib.ticker.Locator` instance.
 
@@ -569,13 +569,10 @@ lonlocator, latlocator : locator-spec, optional
     at nice degree-minute-second intervals when the map extent is very small.
 lonlocator_kw, latlocator_kw : dict-like, optional
     Keyword arguments passed to the `matplotlib.ticker.Locator` class.
-    Aliases: ``lonlines_kw`` and ``latlines_kw``, respectively.
 lonminorlocator, latminorlocator : optional
     As with `lonlocator` and `latlocator` but for the "minor" gridlines.
-    Aliases: ``lonminorlines`` and ``latminorlines``, respectively.
 lonminorlocator_kw, latminorlocator_kw : optional
     As with `lonlocator_kw`, and `latlocator_kw` but for the "minor" gridlines.
-    Aliases: ``lonminorlines_kw`` and ``latminorlines_kw``, respectively.
 lonlabels, latlabels, labels : str, bool, or sequence, :rc:`grid.labels`
     Whether to add non-inline longitude and latitude gridline labels, and on
     which sides of the map. Use the keyword `labels` to set both at once. The
@@ -2716,33 +2713,19 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         self,
         *,
         lonlocator: Any,
-        lonlines: Any,
         latlocator: Any,
-        latlines: Any,
         lonlocator_kw: MutableMapping | None,
-        lonlines_kw: MutableMapping | None,
         latlocator_kw: MutableMapping | None,
-        latlines_kw: MutableMapping | None,
     ) -> None:
         """
         Update major longitude/latitude locators.
         """
-        lonlocator = _not_none(lonlocator=lonlocator, lonlines=lonlines)
-        latlocator = _not_none(latlocator=latlocator, latlines=latlines)
         if lonlocator is not None:
-            lonlocator_kw = _not_none(
-                lonlocator_kw=lonlocator_kw,
-                lonlines_kw=lonlines_kw,
-                default={},
-            )
+            lonlocator_kw = lonlocator_kw or {}
             locator = constructor.Locator(lonlocator, **lonlocator_kw)
             self._lonaxis.set_major_locator(locator)
         if latlocator is not None:
-            latlocator_kw = _not_none(
-                latlocator_kw=latlocator_kw,
-                latlines_kw=latlines_kw,
-                default={},
-            )
+            latlocator_kw = latlocator_kw or {}
             locator = constructor.Locator(latlocator, **latlocator_kw)
             self._lataxis.set_major_locator(locator)
 
@@ -2750,37 +2733,19 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         self,
         *,
         lonminorlocator: Any,
-        lonminorlines: Any,
         latminorlocator: Any,
-        latminorlines: Any,
         lonminorlocator_kw: MutableMapping | None,
-        lonminorlines_kw: MutableMapping | None,
         latminorlocator_kw: MutableMapping | None,
-        latminorlines_kw: MutableMapping | None,
     ) -> None:
         """
         Update minor longitude/latitude locators.
         """
-        lonminorlocator = _not_none(
-            lonminorlocator=lonminorlocator, lonminorlines=lonminorlines
-        )
-        latminorlocator = _not_none(
-            latminorlocator=latminorlocator, latminorlines=latminorlines
-        )
         if lonminorlocator is not None:
-            lonminorlocator_kw = _not_none(
-                lonminorlocator_kw=lonminorlocator_kw,
-                lonminorlines_kw=lonminorlines_kw,
-                default={},
-            )
+            lonminorlocator_kw = lonminorlocator_kw or {}
             locator = constructor.Locator(lonminorlocator, **lonminorlocator_kw)
             self._lonaxis.set_minor_locator(locator)
         if latminorlocator is not None:
-            latminorlocator_kw = _not_none(
-                latminorlocator_kw=latminorlocator_kw,
-                latminorlines_kw=latminorlines_kw,
-                default={},
-            )
+            latminorlocator_kw = latminorlocator_kw or {}
             locator = constructor.Locator(latminorlocator, **latminorlocator_kw)
             self._lataxis.set_minor_locator(locator)
 
@@ -2951,6 +2916,7 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
     # 3) apply extent, features, and gridlines
     # 4) apply tick lengths and defer to parent format
     @docstring._snippet_manager
+    @_alias_kwargs("geo.format")
     def format(
         self,
         *,
@@ -2971,21 +2937,13 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
         latmax: float | None = None,
         nsteps: int | None = None,
         lonlocator: Any = None,
-        lonlines: Any = None,
         latlocator: Any = None,
-        latlines: Any = None,
         lonminorlocator: Any = None,
-        lonminorlines: Any = None,
         latminorlocator: Any = None,
-        latminorlines: Any = None,
         lonlocator_kw: MutableMapping | None = None,
-        lonlines_kw: MutableMapping | None = None,
         latlocator_kw: MutableMapping | None = None,
-        latlines_kw: MutableMapping | None = None,
         lonminorlocator_kw: MutableMapping | None = None,
-        lonminorlines_kw: MutableMapping | None = None,
         latminorlocator_kw: MutableMapping | None = None,
-        latminorlines_kw: MutableMapping | None = None,
         lonformatter: Any = None,
         latformatter: Any = None,
         lonformatter_kw: MutableMapping | None = None,
@@ -3065,23 +3023,15 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             self._format_update_latmax(latmax)
             self._format_update_major_locators(
                 lonlocator=lonlocator,
-                lonlines=lonlines,
                 latlocator=latlocator,
-                latlines=latlines,
                 lonlocator_kw=lonlocator_kw,
-                lonlines_kw=lonlines_kw,
                 latlocator_kw=latlocator_kw,
-                latlines_kw=latlines_kw,
             )
             self._format_update_minor_locators(
                 lonminorlocator=lonminorlocator,
-                lonminorlines=lonminorlines,
                 latminorlocator=latminorlocator,
-                latminorlines=latminorlines,
                 lonminorlocator_kw=lonminorlocator_kw,
-                lonminorlines_kw=lonminorlines_kw,
                 latminorlocator_kw=latminorlocator_kw,
-                latminorlines_kw=latminorlines_kw,
             )
             (
                 loninline,
@@ -3131,22 +3081,14 @@ class GeoAxes(shared._SharedAxes, plot.PlotAxes):
             )
             self._sync_shared_tick_state(
                 "x",
-                copy_major_locator=_not_none(lonlocator=lonlocator, lonlines=lonlines)
-                is not None,
-                copy_minor_locator=_not_none(
-                    lonminorlocator=lonminorlocator, lonminorlines=lonminorlines
-                )
-                is not None,
+                copy_major_locator=lonlocator is not None,
+                copy_minor_locator=lonminorlocator is not None,
                 copy_major_formatter=lonformatter is not None,
             )
             self._sync_shared_tick_state(
                 "y",
-                copy_major_locator=_not_none(latlocator=latlocator, latlines=latlines)
-                is not None,
-                copy_minor_locator=_not_none(
-                    latminorlocator=latminorlocator, latminorlines=latminorlines
-                )
-                is not None,
+                copy_major_locator=latlocator is not None,
+                copy_minor_locator=latminorlocator is not None,
                 copy_major_formatter=latformatter is not None,
             )
         self._format_apply_ticklen(

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -36,6 +36,8 @@ from .. import colors as pcolors
 from .. import constructor, utils
 from ..config import rc
 from ..internals import (
+    _alias_kwargs,
+    _canonicalize_kwargs,
     _get_aliases,
     _not_none,
     _pop_kwargs,
@@ -519,23 +521,21 @@ inbounds : bool, default: :rc:`axes.inbounds`
     See also :rcraw:`axes.inbounds` and :rcraw:`cmap.inbounds`.
 """
 _error_means_docstring = """
-mean, means : bool, default: False
+means : bool, default: False
     Whether to plot the means of each column for 2D `{y}` coordinates. Means
     are calculated with `numpy.nanmean`. If no other arguments are specified,
     this also sets ``barstd=True`` (and ``boxstd=True`` for violin plots).
-median, medians : bool, default: False
+medians : bool, default: False
     Whether to plot the medians of each column for 2D `{y}` coordinates. Medians
     are calculated with `numpy.nanmedian`. If no other arguments arguments are
     specified, this also sets ``barstd=True`` (and ``boxstd=True`` for violin plots).
 """
 _error_bars_docstring = """
-bars : bool, default: None
-    Shorthand for `barstd`, `barstds`.
-barstd, barstds : bool, float, or 2-tuple of float, optional
+barstds : bool, float, or 2-tuple of float, optional
     Valid only if `mean` or `median` is ``True``. Standard deviation multiples for
     *thin error bars* with optional whiskers (i.e., caps). If scalar, then +/- that
     multiple is used. If ``True``, the default standard deviation range of +/-3 is used.
-barpctile, barpctiles : bool, float, or 2-tuple of float, optional
+barpctiles : bool, float, or 2-tuple of float, optional
     Valid only if `mean` or `median` is ``True``. As with `barstd`, but instead
     using percentiles for the error bars. If scalar, that percentile range is
     used (e.g., ``90`` shows the 5th to 95th percentiles). If ``True``, the default
@@ -544,9 +544,7 @@ bardata : array-like, optional
     Valid only if `mean` and `median` are ``False``. If shape is 2 x N, these
     are the lower and upper bounds for the thin error bars. If shape is N, these
     are the absolute, symmetric deviations from the central points.
-boxes : bool, default: None
-    Shorthand for `boxstd`, `boxstds`.
-boxstd, boxstds, boxpctile, boxpctiles, boxdata : optional
+boxstds, boxpctiles, boxdata : optional
     As with `barstd`, `barpctile`, and `bardata`, but for *thicker error bars*
     representing a smaller interval than the thin error bars. If `boxstds` is
     ``True``, the default standard deviation range of +/-1 is used. If `boxpctiles`
@@ -573,16 +571,12 @@ boxmc, boxmarkercolor, boxmec, boxmarkeredgecolor : color-spec, default: 'w'
     Color, face color, and edge color for the `boxmarker` marker.
 """
 _error_shading_docstring = """
-shade : bool, default: None
-    Shorthand for `shadestd`.
-shadestd, shadestds, shadepctile, shadepctiles, shadedata : optional
+shadestds, shadepctiles, shadedata : optional
     As with `barstd`, `barpctile`, and `bardata`, but using *shading* to indicate
     the error range. If `shadestds` is ``True``, the default standard deviation
     range of +/-2 is used. If `shadepctiles` is ``True``, the default
     percentile range of 10 to 90 is used.
-fade : bool, default: None
-    Shorthand for `fadestd`.
-fadestd, fadestds, fadepctile, fadepctiles, fadedata : optional
+fadestds, fadepctiles, fadedata : optional
     As with `shadestd`, `shadepctile`, and `shadedata`, but for an additional,
     more faded, *secondary* shaded region. If `fadestds` is ``True``, the default
     standard deviation range of +/-3 is used. If `fadepctiles` is ``True``,
@@ -631,7 +625,7 @@ cmap : colormap-spec, default: \
     Otherwise :rcraw:`cmap.sequential` is used.
 cmap_kw : dict-like, optional
     Passed to :class:`~ultraplot.constructor.Colormap`.
-c, color, colors : color-spec or sequence of color-spec, optional
+colors : color-spec or sequence of color-spec, optional
     The color(s) used to create a :class:`~ultraplot.colors.DiscreteColormap`.
     If not passed, `cmap` is used.
 norm : norm-spec, default: \
@@ -700,8 +694,6 @@ vmin, vmax : float, optional
     `vmin` and `vmax` are the minimum and maximum of the data values.
 """
 _manual_levels_docstring = """
-N
-    Shorthand for `levels`.
 levels : int or sequence of float, default: :rc:`cmap.levels`
     The number of level edges or a sequence of level edges. If the former, `locator`
     is used to generate this many level edges at "nice" intervals. If the latter,
@@ -782,7 +774,7 @@ labels_kw : dict-like, optional
     Ignored if `labels` is ``False``. Extra keyword args for the labels.
     For contour plots, this is passed to `~matplotlib.axes.Axes.clabel`.
     Otherwise, this is passed to `~matplotlib.axes.Axes.text`.
-formatter, fmt : formatter-spec, optional
+formatter : formatter-spec, optional
     The `~matplotlib.ticker.Formatter` used to format number labels.
     Passed to the `~ultraplot.constructor.Formatter` constructor.
 formatter_kw : dict-like, optional
@@ -911,7 +903,7 @@ Parameters
 
 Other parameters
 ----------------
-stack, stacked : bool, default: False
+stacked : bool, default: False
     Whether to "stack" lines from successive columns of {y} data
     or plot lines on top of each other.
 %(plot.cycle)s
@@ -1137,7 +1129,7 @@ width : float or array-like, default: 0.8
 absolute_width : bool, default: False
     Whether to make the `width` units *absolute*. If ``True``,
     this restores the default matplotlib behavior.
-stack, stacked : bool, default: False
+stacked : bool, default: False
     Whether to "stack" bars from successive columns of {y}
     data or plot bars side-by-side in groups.
 bar_labels : bool, default rc["bar.bar_labels"]
@@ -1253,7 +1245,7 @@ Plot individual, grouped, or overlaid shading patches.
 Parameters
 ----------
 %(plot.args_1d_multi{y})s
-stack, stacked : bool, default: False
+stacked : bool, default: False
     Whether to "stack" area patches from successive columns of {y}
     data or plot area patches on top of each other.
 %(plot.args_1d_shared)s
@@ -1304,7 +1296,7 @@ Other parameters
 ----------------
 fill : bool, default: True
     Whether to fill the box with a color.
-mean, means : bool, default: False
+means : bool, default: False
     If ``True``, this passes ``showmeans=True`` and ``meanline=True`` to
     `matplotlib.axes.Axes.boxplot`. Adds mean lines alongside the median.
 %(plot.cycle)s
@@ -1512,10 +1504,10 @@ bins : int or sequence of float, optional
 %(plot.weights)s
 histtype : {{'bar', 'barstacked', 'step', 'stepfilled'}}, optional
     The histogram type. See `matplotlib.axes.Axes.hist` for details.
-width, rwidth : float, default: 0.8 or 1
+rwidth : float, default: 0.8 or 1
     The bar width(s) for bar-type histograms relative to the bin size. Default
     is ``0.8`` for multiple columns of unstacked data and ``1`` otherwise.
-stack, stacked : bool, optional
+stacked : bool, optional
     Whether to "stack" successive columns of {y} data for bar-type histograms
     or show side-by-side in groups. Setting this to ``False`` is equivalent to
     ``histtype='bar'`` and to ``True`` is equivalent to ``histtype='barstacked'``.
@@ -1536,7 +1528,7 @@ kde_kw : dict, optional
     The remaining keys style the resulting curve and are passed to
     `matplotlib.axes.Axes.plot`, e.g. ``color``, ``linestyle``, ``linewidth``.
     By default each curve takes the color of its histogram.
-fill, filled : bool, optional
+fill : bool, optional
     Whether to "fill" step-type histograms or just plot the edges. Setting
     this to ``False`` is equivalent to ``histtype='step'`` and to ``True``
     is equivalent to ``histtype='stepfilled'``.
@@ -1627,7 +1619,7 @@ Other parameters
 %(artist.patch)s
 %(axes.edgefix)s
 %(plot.labels_1d)s
-labelpad, labeldistance : float, optional
+labeldistance : float, optional
     The distance at which labels are drawn in radial coordinates.
 
 See also
@@ -3056,13 +3048,13 @@ class PlotAxes(base.Axes):
         posobj = self._call_native(name, x, *ypos, **kwargs)
         return cbook.silent_list(type(negobj).__name__, (negobj, posobj))
 
+    @_alias_kwargs("plot.labels")
     def _add_auto_labels(
         self,
         obj,
         cobj=None,
         labels=False,
         labels_kw=None,
-        fmt=None,
         formatter=None,
         formatter_kw=None,
         precision=None,
@@ -3074,12 +3066,10 @@ class PlotAxes(base.Axes):
         # TODO: Add quiverkey to this!
         if not labels:
             return
-        labels_kw = labels_kw or {}
+        labels_kw = _canonicalize_kwargs("plot.labels", labels_kw or {})
         formatter_kw = formatter_kw or {}
         formatter = _not_none(
-            fmt_labels_kw=labels_kw.pop("fmt", None),
             formatter_labels_kw=labels_kw.pop("formatter", None),
-            fmt=fmt,
             formatter=formatter,
             default="simple",
         )
@@ -3101,15 +3091,13 @@ class PlotAxes(base.Axes):
             case _:
                 raise RuntimeError(f"Not possible to add labels to object {obj!r}.")
 
+    @_alias_kwargs("plot.text")
     def _add_quadmesh_labels(
         self,
         obj,
         fmt,
         *,
-        c=None,
         color=None,
-        colors=None,
-        size=None,
         fontsize=None,
         **kwargs,
     ):
@@ -3119,8 +3107,7 @@ class PlotAxes(base.Axes):
         """
         # Parse input args
         obj.update_scalarmappable()
-        color = _not_none(c=c, color=color, colors=colors)
-        fontsize = _not_none(size=size, fontsize=fontsize, default=rc["font.smallsize"])
+        fontsize = _not_none(fontsize, rc["font.smallsize"])
         kwargs.setdefault("ha", "center")
         kwargs.setdefault("va", "center")
 
@@ -3157,15 +3144,13 @@ class PlotAxes(base.Axes):
 
         return labs
 
+    @_alias_kwargs("plot.text")
     def _add_collection_labels(
         self,
         obj,
         fmt,
         *,
-        c=None,
         color=None,
-        colors=None,
-        size=None,
         fontsize=None,
         **kwargs,
     ):
@@ -3177,8 +3162,7 @@ class PlotAxes(base.Axes):
         # NOTE: This function also hides grid boxes filled with NaNs to avoid ugly
         # issue where edge colors surround NaNs. Should maybe move this somewhere else.
         obj.update_scalarmappable()  # update 'edgecolors' list
-        color = _not_none(c=c, color=color, colors=colors)
-        fontsize = _not_none(size=size, fontsize=fontsize, default=rc["font.smallsize"])
+        fontsize = _not_none(fontsize, rc["font.smallsize"])
         kwargs.setdefault("ha", "center")
         kwargs.setdefault("va", "center")
 
@@ -3209,16 +3193,14 @@ class PlotAxes(base.Axes):
         obj.set_edgecolors(edgecolors)
         return labs
 
+    @_alias_kwargs("plot.contour_labels")
     def _add_contour_labels(
         self,
         obj,
         cobj,
         fmt,
         *,
-        c=None,
-        color=None,
         colors=None,
-        size=None,
         fontsize=None,
         inline_spacing=None,
         **kwargs,
@@ -3231,8 +3213,7 @@ class PlotAxes(base.Axes):
         # Parse input args
         zorder = max(3, obj.get_zorder() + 1)
         kwargs.setdefault("zorder", zorder)
-        colors = _not_none(c=c, color=color, colors=colors)
-        fontsize = _not_none(size=size, fontsize=fontsize, default=rc["font.smallsize"])
+        fontsize = _not_none(fontsize, rc["font.smallsize"])
         inline_spacing = _not_none(inline_spacing, 2.5)
 
         # Separate clabel args from text Artist args
@@ -3264,6 +3245,7 @@ class PlotAxes(base.Axes):
 
         return labs
 
+    @_alias_kwargs("plot.error_bars")
     def _add_error_bars(
         self,
         x,
@@ -3275,16 +3257,10 @@ class PlotAxes(base.Axes):
         default_barpctiles=False,
         default_boxpctiles=False,
         default_marker=False,
-        bars=None,
-        boxes=None,
-        barstd=None,
         barstds=None,
-        barpctile=None,
         barpctiles=None,
         bardata=None,
-        boxstd=None,
         boxstds=None,
-        boxpctile=None,
         boxpctiles=None,
         boxdata=None,
         capsize=None,
@@ -3299,10 +3275,6 @@ class PlotAxes(base.Axes):
         # But also want default behavior where some default error indicator is shown
         # if user requests means/medians only. Result is the below kludge.
         kwargs, vert = _get_vert(**kwargs)
-        barstds = _not_none(bars=bars, barstd=barstd, barstds=barstds)
-        boxstds = _not_none(boxes=boxes, boxstd=boxstd, boxstds=boxstds)
-        barpctiles = _not_none(barpctile=barpctile, barpctiles=barpctiles)
-        boxpctiles = _not_none(boxpctile=boxpctile, boxpctiles=boxpctiles)
         if distribution is not None and not any(
             typ + mode in key
             for key in kwargs
@@ -3392,6 +3364,7 @@ class PlotAxes(base.Axes):
         kwargs["distribution"] = distribution
         return (*eobjs, kwargs)
 
+    @_alias_kwargs("plot.error_shading")
     def _add_error_shading(
         self,
         x,
@@ -3399,16 +3372,10 @@ class PlotAxes(base.Axes):
         *_,
         distribution=None,
         color_key="color",
-        shade=None,
-        shadestd=None,
         shadestds=None,
-        shadepctile=None,
         shadepctiles=None,
         shadedata=None,
-        fade=None,
-        fadestd=None,
         fadestds=None,
-        fadepctile=None,
         fadepctiles=None,
         fadedata=None,
         shadelabel=False,
@@ -3419,10 +3386,6 @@ class PlotAxes(base.Axes):
         Add up to 2 error indicators: more opaque "shading" and less opaque "fading".
         """
         kwargs, vert = _get_vert(**kwargs)
-        shadestds = _not_none(shade=shade, shadestd=shadestd, shadestds=shadestds)
-        fadestds = _not_none(fade=fade, fadestd=fadestd, fadestds=fadestds)
-        shadepctiles = _not_none(shadepctile=shadepctile, shadepctiles=shadepctiles)
-        fadepctiles = _not_none(fadepctile=fadepctile, fadepctiles=fadepctiles)
         drawshade = any(
             _ is not None and _ is not False
             for _ in (shadestds, shadepctiles, shadedata)
@@ -4190,13 +4153,12 @@ class PlotAxes(base.Axes):
             return False
         return values.shape[0] == point_count
 
+    @_alias_kwargs("plot.colormap")
     def _parse_cmap(
         self,
         *args,
         cmap=None,
         cmap_kw=None,
-        c=None,
-        color=None,
         colors=None,
         norm=None,
         norm_kw=None,
@@ -4276,7 +4238,6 @@ class PlotAxes(base.Axes):
         vmin = _not_none(vmin=vmin, norm_kw_vmin=norm_kw.pop("vmin", None))
         vmax = _not_none(vmax=vmax, norm_kw_vmax=norm_kw.pop("vmax", None))
         extend = _not_none(extend, "neither")
-        colors = _not_none(c=c, color=color, colors=colors)  # in case untranslated
         modes = {
             key: kwargs.pop(key, None)
             for key in ("sequential", "diverging", "cyclic", "qualitative")
@@ -4763,10 +4724,10 @@ class PlotAxes(base.Axes):
             levels = np.append(levels, levels[-1] + width * np.sign(levels[-1]))
         return levels, kwargs
 
+    @_alias_kwargs("plot.levels")
     def _parse_level_vals(
         self,
         *args,
-        N=None,
         levels=None,
         values=None,
         extend=None,
@@ -4789,8 +4750,6 @@ class PlotAxes(base.Axes):
         ----------
         *args
             The sample data. Passed to `_parse_level_lim`.
-        N
-            Shorthand for `levels`.
         levels : int or sequence of float, optional
             The levels list or (approximate) number of levels to create.
         values : int or sequence of float, optional
@@ -4854,7 +4813,7 @@ class PlotAxes(base.Axes):
         explicit_limits = vmin is not None or vmax is not None
         line_contours = min_levels == 1
         keep_explicit_line_limits = line_contours and explicit_limits
-        levels = _not_none(N=N, levels=levels, norm_kw_levs=norm_kw.pop("levels", None))
+        levels = _not_none(levels=levels, norm_kw_levs=norm_kw.pop("levels", None))
         if positive and negative:
             warnings._warn_ultraplot(
                 "Incompatible args positive=True and negative=True. Using former."
@@ -5614,6 +5573,7 @@ class PlotAxes(base.Axes):
         self._update_guide(obj, **guide_kw)
         return obj
 
+    @_alias_kwargs("plot.stacked")
     def _apply_lines(
         self,
         xs,
@@ -5622,7 +5582,6 @@ class PlotAxes(base.Axes):
         colors,
         *,
         vert=True,
-        stack=None,
         stacked=None,
         negpos=False,
         **kwargs,
@@ -5637,7 +5596,6 @@ class PlotAxes(base.Axes):
             kw["colors"] = colors
         kw.update(_pop_props(kw, "collection"))
         kw, extents = self._inbounds_extent(**kw)
-        stack = _not_none(stack=stack, stacked=stacked)
         xs, ys1, ys2, kw = self._parse_1d_args(xs, ys1, ys2, vert=vert, **kw)
         guide_kw = _pop_params(kw, self._update_guide)
 
@@ -5648,7 +5606,7 @@ class PlotAxes(base.Axes):
         objs, sides = [], []
         for _, n, x, y1, y2, kw in self._iter_arg_cols(xs, ys1, ys2, **kw):
             kw = self._parse_cycle(n, **kw)
-            if stack:
+            if stacked:
                 y1 = y1 + y0  # avoid in-place modification
                 y2 = y2 + y0
                 y0 = y0 + y2 - y1  # irrelevant that we added y0 to both
@@ -5833,6 +5791,7 @@ class PlotAxes(base.Axes):
         kwargs = _parse_vert(default_vert=False, **kwargs)
         return self._apply_scatter(*args, **kwargs)
 
+    @_alias_kwargs("plot.stacked")
     def _apply_fill(
         self,
         xs,
@@ -5842,7 +5801,6 @@ class PlotAxes(base.Axes):
         *,
         vert=True,
         negpos=None,
-        stack=None,
         stacked=None,
         **kwargs,
     ):
@@ -5891,7 +5849,6 @@ class PlotAxes(base.Axes):
         kw.update(_pop_props(kw, "patch"))
         kw, extents = self._inbounds_extent(**kw)
         name = "fill_between" if vert else "fill_betweenx"
-        stack = _not_none(stack=stack, stacked=stacked)
         xs, ys1, ys2, kw = self._parse_1d_args(xs, ys1, ys2, vert=vert, **kw)
         edgefix_kw = _pop_params(kw, self._fix_patch_edges)
         guide_kw = _pop_params(kw, self._update_guide)
@@ -5905,7 +5862,7 @@ class PlotAxes(base.Axes):
             kw = self._parse_cycle(n, **kw)
 
             # If stacking requested, adjust y arrays
-            if stack:
+            if stacked:
                 y1 = y1 + y0
                 y2 = y2 + y0
                 y0 = y0 + y2 - y1
@@ -6156,6 +6113,7 @@ class PlotAxes(base.Axes):
             x_step = x_step.astype("timedelta64[ns]")
         return width * x_step
 
+    @_alias_kwargs("plot.stacked")
     def _apply_bar(
         self,
         xs,
@@ -6164,7 +6122,6 @@ class PlotAxes(base.Axes):
         bs,
         *,
         absolute_width=None,
-        stack=None,
         stacked=None,
         negpos=False,
         orientation="vertical",
@@ -6179,7 +6136,6 @@ class PlotAxes(base.Axes):
         bar_labels = kw.pop("bar_labels", rc["bar.bar_labels"])
         bar_labels_kw = kw.pop("bar_labels_kw", {})
         name = "barh" if orientation == "horizontal" else "bar"
-        stack = _not_none(stack=stack, stacked=stacked)
         xs, hs, kw = self._parse_1d_args(xs, hs, orientation=orientation, **kw)
         edgefix_kw = _pop_params(kw, self._fix_patch_edges)
         if absolute_width is None:
@@ -6212,7 +6168,7 @@ class PlotAxes(base.Axes):
             )  # tolerate scalar `bottom`/`left`
             if not absolute_width:
                 w = self._convert_bar_width(x, w)
-            if stack:
+            if stacked:
                 b = b + b0
                 b0 = b0 + h
             else:  # instead "group" the bars (this is no-op if we have 1 column)
@@ -6330,12 +6286,13 @@ class PlotAxes(base.Axes):
     @inputs._preprocess_or_redirect("x", "explode")
     @docstring._concatenate_inherited
     @docstring._snippet_manager
-    def pie(self, x, explode, *, labelpad=None, labeldistance=None, **kwargs):
+    @_alias_kwargs("plot.pie")
+    def pie(self, x, explode, *, labeldistance=None, **kwargs):
         """
         %(plot.pie)s
         """
         kw = kwargs.copy()
-        pad = _not_none(labeldistance=labeldistance, labelpad=labelpad, default=1.15)
+        labeldistance = _not_none(labeldistance, 1.15)
         wedge_kw = kw.pop("wedgeprops", None) or {}
         wedge_kw.update(_pop_props(kw, "patch"))
         edgefix_kw = _pop_params(kw, self._fix_patch_edges)
@@ -6351,7 +6308,7 @@ class PlotAxes(base.Axes):
             "pie",
             x,
             explode=explode,
-            labeldistance=pad,
+            labeldistance=labeldistance,
             wedgeprops=wedge_kw,
             **kw,
         )
@@ -6413,16 +6370,15 @@ class PlotAxes(base.Axes):
             mticker.FixedFormatter([str(label) for label in label_values])
         )
 
+    @_alias_kwargs(("plot.statistics", "plot.boxplot"))
     def _apply_boxplot(
         self,
         x,
         y,
         *,
-        mean=None,
         means=None,
         vert=True,
         fill=None,
-        filled=None,
         marker=None,
         markersize=None,
         **kwargs,
@@ -6433,8 +6389,6 @@ class PlotAxes(base.Axes):
         # Global and fill properties
         kw = kwargs.copy()
         kw.update(_pop_props(kw, "patch"))
-        fill = _not_none(fill=fill, filled=filled)
-        means = _not_none(mean=mean, means=means, showmeans=kw.get("showmeans"))
         linewidth = kw.pop("linewidth", rc["patch.linewidth"])
         edgecolor = kw.pop("edgecolor", "black")
         fillcolor = kw.pop("facecolor", None)
@@ -6609,17 +6563,14 @@ class PlotAxes(base.Axes):
         kwargs = _parse_vert(default_vert=False, **kwargs)
         return self._apply_boxplot(*args, **kwargs)
 
+    @_alias_kwargs(("plot.statistics", "plot.violinplot"))
     def _apply_violinplot(
         self,
         x,
         y,
         vert=True,
-        mean=None,
         means=None,
-        median=None,
         medians=None,
-        showmeans=None,
-        showmedians=None,
         showextrema=None,
         **kwargs,
     ):
@@ -6630,8 +6581,6 @@ class PlotAxes(base.Axes):
         kw = kwargs.copy()
         kw.update(_pop_props(kw, "patch"))
         kw.setdefault("capsize", 0)  # caps are redundant for violin plots
-        means = _not_none(mean=mean, means=means, showmeans=showmeans)
-        medians = _not_none(median=median, medians=medians, showmedians=showmedians)
         if showextrema:
             kw["default_barpctiles"] = True
             if not means and not medians:
@@ -7132,17 +7081,15 @@ class PlotAxes(base.Axes):
         kwargs = _parse_vert(default_vert=False, **kwargs)
         return self._apply_ridgeline(data, **kwargs)
 
+    @_alias_kwargs("plot.hist")
     def _apply_hist(
         self,
         xs,
         bins,
         *,
-        width=None,
         rwidth=None,
-        stack=None,
         stacked=None,
         fill=None,
-        filled=None,
         histtype=None,
         orientation="vertical",
         kde=False,
@@ -7159,15 +7106,13 @@ class PlotAxes(base.Axes):
         _, xs, kw = self._parse_1d_args(
             xs, autoreverse=False, orientation=orientation, **kwargs
         )
-        fill = _not_none(fill=fill, filled=filled)
-        stack = _not_none(stack=stack, stacked=stacked)
         if fill is not None:
             histtype = _not_none(histtype, "stepfilled" if fill else "step")
-        if stack is not None:
-            histtype = _not_none(histtype, "barstacked" if stack else "bar")
+        if stacked is not None:
+            histtype = _not_none(histtype, "barstacked" if stacked else "bar")
         kw["bins"] = bins
         kw["label"] = kw.pop("labels", None)  # multiple labels are natively supported
-        kw["rwidth"] = _not_none(width=width, rwidth=rwidth)  # latter is native
+        kw["rwidth"] = rwidth
         kw["histtype"] = histtype = _not_none(histtype, "bar")
         kw.update(_pop_props(kw, "patch"))
         edgefix_kw = _pop_params(kw, self._fix_patch_edges)

--- a/ultraplot/axes/plot.py
+++ b/ultraplot/axes/plot.py
@@ -4153,7 +4153,7 @@ class PlotAxes(base.Axes):
             return False
         return values.shape[0] == point_count
 
-    @_alias_kwargs("plot.colormap")
+    @_alias_kwargs(("plot.colormap", "plot.levels"))
     def _parse_cmap(
         self,
         *args,

--- a/ultraplot/axes/polar.py
+++ b/ultraplot/axes/polar.py
@@ -19,6 +19,7 @@ from .. import constructor
 from .. import ticker as pticker
 from ..config import rc
 from ..internals import (
+    _alias_kwargs,
     _not_none,
     _pop_rc,
     docstring,
@@ -72,15 +73,11 @@ thetalocator, rlocator : locator-spec, optional
     Used to determine the azimuthal and radial gridline positions.
     Passed to the `~ultraplot.constructor.Locator` constructor. Can be
     float, list of float, string, or `matplotlib.ticker.Locator` instance.
-thetalines, rlines
-    Aliases for `thetalocator`, `rlocator`.
 thetalocator_kw, rlocator_kw : dict-like, optional
     The azimuthal and radial locator settings. Passed to
     `~ultraplot.constructor.Locator`.
 thetaminorlocator, rminorlocator : optional
     As for `thetalocator`, `rlocator`, but for the minor gridlines.
-thetaminorticks, rminorticks : optional
-    Aliases for `thetaminorlocator`, `rminorlocator`.
 thetaminorlocator_kw, rminorlocator_kw
     As for `thetalocator_kw`, `rlocator_kw`, but for the minor locator.
 rlabelpos : float, optional
@@ -92,8 +89,6 @@ thetaformatter, rformatter : formatter-spec, optional
     Passed to the `~ultraplot.constructor.Formatter` constructor.
     Can be string, list of string, or `matplotlib.ticker.Formatter`
     instance. Use ``[]``, ``'null'``, or ``'none'`` for no labels.
-thetalabels, rlabels : optional
-    Aliases for `thetaformatter`, `rformatter`.
 thetaformatter_kw, rformatter_kw : dict-like, optional
     The azimuthal and radial label formatter settings. Passed to
     `~ultraplot.constructor.Formatter`.
@@ -500,6 +495,7 @@ class PolarAxes(shared._SharedAxes, plot.PlotAxes, mpolar.PolarAxes):
         return super().get_tightbbox(renderer, *args, **kwargs)
 
     @docstring._snippet_manager
+    @_alias_kwargs("polar.format")
     def format(
         self,
         *,
@@ -523,20 +519,14 @@ class PolarAxes(shared._SharedAxes, plot.PlotAxes, mpolar.PolarAxes):
         rborder=None,
         thetalocator=None,
         rlocator=None,
-        thetalines=None,
-        rlines=None,
         thetalocator_kw=None,
         rlocator_kw=None,
         thetaminorlocator=None,
         rminorlocator=None,
-        thetaminorlines=None,
-        rminorlines=None,  # noqa: E501
         thetaminorlocator_kw=None,
         rminorlocator_kw=None,
         thetaformatter=None,
         rformatter=None,
-        thetalabels=None,
-        rlabels=None,
         thetaformatter_kw=None,
         rformatter_kw=None,
         labelpad=None,
@@ -610,20 +600,6 @@ class PolarAxes(shared._SharedAxes, plot.PlotAxes, mpolar.PolarAxes):
             rlocator_kw = rlocator_kw or {}
             rminorlocator_kw = rminorlocator_kw or {}
             rformatter_kw = rformatter_kw or {}
-
-            # Flexible input
-            thetalocator = _not_none(thetalines=thetalines, thetalocator=thetalocator)
-            thetaformatter = _not_none(
-                thetalabels=thetalabels, thetaformatter=thetaformatter
-            )  # noqa: E501
-            thetaminorlocator = _not_none(
-                thetaminorlines=thetaminorlines, thetaminorlocator=thetaminorlocator
-            )  # noqa: E501
-            rlocator = _not_none(rlines=rlines, rlocator=rlocator)
-            rformatter = _not_none(rlabels=rlabels, rformatter=rformatter)
-            rminorlocator = _not_none(
-                rminorlines=rminorlines, rminorlocator=rminorlocator
-            )  # noqa: E501
 
             # Special radius settings
             if r0 is not None:

--- a/ultraplot/axes/taylor.py
+++ b/ultraplot/axes/taylor.py
@@ -11,7 +11,7 @@ import matplotlib.transforms as mtransforms
 import numpy as np
 
 from ..config import rc
-from ..internals import _not_none, _pop_rc, docstring
+from ..internals import _alias_kwargs, _not_none, _pop_rc, docstring
 from .polar import PolarAxes
 
 __all__ = ["TaylorAxes"]
@@ -29,7 +29,7 @@ thetaunit : {'corr', 'deg', 'rad'}, default: 'corr'
 quadrant : {1, 2, 3, 4} or str, default: 1
     The quadrant used for the Taylor diagram. Quadrants follow the Cartesian
     convention: ``1`` is upper right and ``4`` is lower right.
-corrlocator, corrlines, corrticks : float or sequence of float, optional
+corrlocator : float or sequence of float, optional
     Correlation coefficients used for the angular gridlines.
 labelcolor, labelsize, labelweight : optional
     Label text properties.
@@ -492,6 +492,7 @@ class TaylorAxes(PolarAxes):
         super().draw(renderer, *args, **kwargs)
 
     @docstring._snippet_manager
+    @_alias_kwargs("taylor.format")
     def format(
         self,
         *,
@@ -501,8 +502,6 @@ class TaylorAxes(PolarAxes):
         thetaunit=None,
         quadrant=None,
         corrlocator=None,
-        corrlines=None,
-        corrticks=None,
         xlabel_kw=None,
         ylabel_kw=None,
         corrlabel_kw=None,
@@ -547,10 +546,7 @@ class TaylorAxes(PolarAxes):
                         )
                     )
                 self._taylor_thetaunit = thetaunit
-            corrs = _not_none(
-                corrlocator=corrlocator, corrlines=corrlines, corrticks=corrticks
-            )
-            self._update_taylor_ticks(corrs)
+            self._update_taylor_ticks(corrlocator)
             self._update_taylor_labels(
                 xlabel=xlabel,
                 ylabel=ylabel,

--- a/ultraplot/colorbar.py
+++ b/ultraplot/colorbar.py
@@ -57,7 +57,7 @@ class UltraColorbar:
         col: Optional[int] = None,
         rows: Optional[Union[int, Tuple[int, int]]] = None,
         cols: Optional[Union[int, Tuple[int, int]]] = None,
-        shrink: Optional[Union[float, str]] = None,
+        length: Optional[Union[float, str]] = None,
         label: Optional[str] = None,
         reverse: bool = False,
         rotation: Optional[float] = None,
@@ -102,7 +102,6 @@ class UltraColorbar:
         # TODO: Get the 'best' inset colorbar location using the legend algorithm
         # and implement inset colorbars the same as inset legends.
         grid = _not_none(drawedges, rc["colorbar.grid"])
-        length = shrink
         labelloc = labellocation
         locator = ticks
         formatter = format
@@ -174,7 +173,7 @@ class UltraColorbar:
         else:
             if inset_side:
                 kwargs.update(
-                    {"align": align, "shrink": length, "space": space, "width": width}
+                    {"align": align, "length": length, "space": space, "width": width}
                 )
                 cax, kwargs = ax._parse_colorbar_inset_side(
                     loc=loc,
@@ -186,7 +185,7 @@ class UltraColorbar:
                     {
                         "bbox_to_anchor": bbox_to_anchor,
                         "label": label,
-                        "shrink": length,
+                        "length": length,
                         "width": width,
                     }
                 )

--- a/ultraplot/colorbar.py
+++ b/ultraplot/colorbar.py
@@ -17,7 +17,7 @@ import matplotlib.text as mtext
 from packaging import version
 
 from . import constructor, colors as pcolors
-from .internals import _not_none, _pop_params, guides, warnings
+from .internals import _alias_kwargs, _not_none, _pop_params, guides, warnings
 from .config import rc, _version_mpl
 from .ultralayout import KIWI_AVAILABLE, ColorbarLayoutSolver
 from . import ticker as pticker
@@ -41,6 +41,7 @@ class UltraColorbar:
     def __init__(self, axes: maxes.Axes):
         self.axes = axes
 
+    @_alias_kwargs("colorbar")
     def add(
         self,
         mappable: Any,
@@ -51,7 +52,6 @@ class UltraColorbar:
         space: Optional[Union[float, str]] = None,
         pad: Optional[Union[float, str]] = None,
         width: Optional[Union[float, str]] = None,
-        length: Optional[Union[float, str]] = None,
         span: Optional[Union[int, Tuple[int, int]]] = None,
         row: Optional[int] = None,
         col: Optional[int] = None,
@@ -59,47 +59,35 @@ class UltraColorbar:
         cols: Optional[Union[int, Tuple[int, int]]] = None,
         shrink: Optional[Union[float, str]] = None,
         label: Optional[str] = None,
-        title: Optional[str] = None,
         reverse: bool = False,
         rotation: Optional[float] = None,
-        grid: Optional[bool] = None,
-        edges: Optional[bool] = None,
         drawedges: Optional[bool] = None,
         extend: Optional[str] = None,
         extendsize: Optional[Union[float, str]] = None,
         extendfrac: Optional[float] = None,
         ticks: Optional[Iterable[float]] = None,
-        locator: Optional[Any] = None,
         locator_kw: Optional[dict[str, Any]] = None,
         format: Optional[str] = None,
-        formatter: Optional[Any] = None,
-        ticklabels: Optional[Iterable[str]] = None,
         formatter_kw: Optional[dict[str, Any]] = None,
         minorticks: Optional[bool] = None,
-        minorlocator: Optional[Any] = None,
         minorlocator_kw: Optional[dict[str, Any]] = None,
         tickminor: Optional[bool] = None,
         ticklen: Optional[Union[float, str]] = None,
         ticklenratio: Optional[float] = None,
-        tickdir: Optional[str] = None,
         tickdirection: Optional[str] = None,
         tickwidth: Optional[Union[float, str]] = None,
         tickwidthratio: Optional[float] = None,
         ticklabelsize: Optional[float] = None,
         ticklabelweight: Optional[str] = None,
         ticklabelcolor: Optional[str] = None,
-        labelloc: Optional[str] = None,
         labellocation: Optional[str] = None,
         labelsize: Optional[float] = None,
         labelweight: Optional[str] = None,
         labelcolor: Optional[str] = None,
-        c: Optional[str] = None,
         color: Optional[str] = None,
-        lw: Optional[Union[float, str]] = None,
         linewidth: Optional[Union[float, str]] = None,
         edgefix: Optional[bool] = None,
         rasterized: Optional[bool] = None,
-        frame: Optional[bool] = None,
         frameon: Optional[bool] = None,
         outline: Union[bool, None] = None,
         labelrotation: Optional[Union[str, float]] = None,
@@ -113,19 +101,15 @@ class UltraColorbar:
         # Parse input arguments and apply defaults
         # TODO: Get the 'best' inset colorbar location using the legend algorithm
         # and implement inset colorbars the same as inset legends.
-        grid = _not_none(
-            grid=grid, edges=edges, drawedges=drawedges, default=rc["colorbar.grid"]
-        )  # noqa: E501
-        length = _not_none(length=length, shrink=shrink)
-        label = _not_none(title=title, label=label)
-        labelloc = _not_none(labelloc=labelloc, labellocation=labellocation)
-        locator = _not_none(ticks=ticks, locator=locator)
-        formatter = _not_none(ticklabels=ticklabels, formatter=formatter, format=format)
-        minorlocator = _not_none(minorticks=minorticks, minorlocator=minorlocator)
-        color = _not_none(c=c, color=color, default=rc["axes.edgecolor"])
-        linewidth = _not_none(lw=lw, linewidth=linewidth)
+        grid = _not_none(drawedges, rc["colorbar.grid"])
+        length = shrink
+        labelloc = labellocation
+        locator = ticks
+        formatter = format
+        minorlocator = minorticks
+        color = _not_none(color, rc["axes.edgecolor"])
         ticklen = units(_not_none(ticklen, rc["tick.len"]), "pt")
-        tickdir = _not_none(tickdir=tickdir, tickdirection=tickdirection)
+        tickdir = tickdirection
         tickwidth = units(_not_none(tickwidth, linewidth, rc["tick.width"]), "pt")
         linewidth = units(_not_none(linewidth, default=rc["axes.linewidth"]), "pt")
         ticklenratio = _not_none(ticklenratio, rc["tick.lenratio"])
@@ -162,7 +146,7 @@ class UltraColorbar:
         # Generate and prepare the colorbar axes
         # NOTE: The inset axes function needs 'label' to know how to pad the box
         # TODO: Use seperate keywords for frame properties vs. colorbar edge properties?
-        frame = _not_none(frame=frame, frameon=frameon)
+        frame = frameon
         bbox_to_anchor = kwargs.pop("bbox_to_anchor", None)
         inset_side = loc in ("left", "right", "top", "bottom") and getattr(
             ax, "_inset_parent", None
@@ -190,7 +174,7 @@ class UltraColorbar:
         else:
             if inset_side:
                 kwargs.update(
-                    {"align": align, "length": length, "space": space, "width": width}
+                    {"align": align, "shrink": length, "space": space, "width": width}
                 )
                 cax, kwargs = ax._parse_colorbar_inset_side(
                     loc=loc,
@@ -202,14 +186,14 @@ class UltraColorbar:
                     {
                         "bbox_to_anchor": bbox_to_anchor,
                         "label": label,
-                        "length": length,
+                        "shrink": length,
                         "width": width,
                     }
                 )
                 extendsize = _not_none(extendsize, rc["colorbar.insetextend"])
                 cax, kwargs = ax._parse_colorbar_inset(
                     loc=loc,
-                    frame=frame,
+                    frameon=frame,
                     labelloc=labelloc,
                     labelrotation=labelrotation,
                     labelsize=labelsize,

--- a/ultraplot/constructor.py
+++ b/ultraplot/constructor.py
@@ -34,6 +34,7 @@ from . import scale as pscale
 from . import ticker as pticker
 from .config import rc
 from .internals import (
+    _alias_kwargs,
     _not_none,
     _pop_props,
     _version_cartopy,
@@ -880,8 +881,6 @@ class Cycle(cycler.Cycler):
 
         If the last positional argument is numeric, it is used for the
         `samples` keyword argument.
-    N
-        Shorthand for `samples`.
     samples : float or sequence of float, optional
         For :class:`~ultraplot.colors.DiscreteColormap`\\ s, this is the number of
         colors to select. For example, ``Cycle('538', 4)`` returns the first 4
@@ -934,9 +933,9 @@ markeredgecolors, markerfacecolors
     ultraplot.utils.get_colors
     """
 
-    def __init__(self, *args, N=None, samples=None, name=None, **kwargs):
+    @_alias_kwargs("cycle")
+    def __init__(self, *args, samples=None, name=None, **kwargs):
         cycler_props = self._parse_basic_properties(kwargs)
-        samples = _not_none(samples=samples, N=N)  # trigger Colormap default
         if not args:
             self._handle_empty_args(cycler_props, kwargs)
         elif self._is_all_cyclers(args):
@@ -1495,13 +1494,12 @@ def _warn_basemap_deprecated():
     )
 
 
+@_alias_kwargs("projection")
 def Proj(
     name,
     backend=None,
     lon0=None,
-    lon_0=None,
     lat0=None,
-    lat_0=None,
     lonlim=None,
     latlim=None,
     **kwargs,
@@ -1592,8 +1590,6 @@ def Proj(
     lon0, lat0 : float, optional
         The central projection longitude and latitude. These are translated to
         `central_longitude`, `central_latitude` for cartopy projections.
-    lon_0, lat_0 : float, optional
-        Aliases for `lon0`, `lat0`.
     lonlim : 2-tuple of float, optional
         The longitude limits. Translated to `min_longitude` and `max_longitude` for
         cartopy projections and `llcrnrlon` and `urcrnrlon` for basemap projections.
@@ -1667,8 +1663,6 @@ def Proj(
     # Parse input arguments
     # NOTE: Underscores are permitted for consistency with cartopy only here.
     # In format() underscores are not allowed for constistency with reset of API.
-    lon0 = _not_none(lon0=lon0, lon_0=lon_0)
-    lat0 = _not_none(lat0=lat0, lat_0=lat_0)
     lonlim = _not_none(lonlim, default=(None, None))
     latlim = _not_none(latlim, default=(None, None))
     is_crs = Projection is not object and isinstance(name, Projection)

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -32,6 +32,7 @@ from . import legend as plegend
 from .config import rc, rc_matplotlib
 from .internals import (
     _alias_kwargs,
+    _canonicalize_kwargs,
     _not_none,
     _pop_params,
     _pop_rc,
@@ -98,15 +99,10 @@ refwidth, refheight : unit-spec, default: :rc:`subplots.refwidth`
     %(units.in)s
     Ignored if `figwidth`, `figheight`, or `figsize` was passed. If you
     specify just one, `refaspect` will be respected.
-ref, aspect, axwidth, axheight
-    Aliases for `refnum`, `refaspect`, `refwidth`, `refheight`.
-    *These may be deprecated in a future release.*
 figwidth, figheight : unit-spec, optional
     The figure width and height. Default behavior is to use `refwidth`.
     %(units.in)s
     If you specify just one, `refaspect` will be respected.
-width, height
-    Aliases for `figwidth`, `figheight`.
 figsize : 2-tuple, optional
     Tuple specifying the figure ``(width, height)``.
 sharex, sharey, share \
@@ -229,25 +225,25 @@ order : {'C', 'F'}, default: 'C'
     two options:
 
     * Pass a *list* of projection specifications, one for each subplot.
-      For example, ``uplt.subplots(ncols=2, proj=('cart', 'robin'))``.
+      For example, ``uplt.subplots(ncols=2, projection=('cart', 'robin'))``.
     * Pass a *dictionary* of projection specifications, where the
       keys are integers or tuples of integers that indicate the projection
       to use for the corresponding subplot number(s). If a key is not
       provided, the default projection ``'cartesian'`` is used. For example,
-      ``uplt.subplots(ncols=4, proj={2: 'cyl', (3, 4): 'stere'})`` creates
+      ``uplt.subplots(ncols=4, projection={2: 'cyl', (3, 4): 'stere'})`` creates
       a figure with a default Cartesian axes for the first subplot, a Mercator
       projection for the second subplot, and a Stereographic projection
       for the third and fourth subplots.
 
 %(axes.proj_kw)s
     If dictionary of properties, applies globally. If list or dictionary of
-    dictionaries, applies to specific subplots, as with `proj`. For example,
-    ``uplt.subplots(ncols=2, proj='cyl', proj_kw=({'lon_0': 0}, {'lon_0': 180})``
+    dictionaries, applies to specific subplots, as with `projection`. For example,
+    ``uplt.subplots(ncols=2, projection='cyl', projection_kw=({'lon0': 0}, {'lon0': 180})``
     centers the projection in the left subplot on the prime meridian and in the
     right subplot on the international dateline.
 %(axes.backend)s
     If string, applies to all subplots. If list or dict, applies to specific
-    subplots, as with `proj`.
+    subplots, as with `projection`.
 %(gridspec.shared)s
 %(gridspec.vector)s
 %(gridspec.tight)s
@@ -753,14 +749,7 @@ class Figure(mfigure.Figure):
 
     @docstring._obfuscate_kwargs
     @docstring._snippet_manager
-    @_alias_kwargs(
-        refnum=("ref",),
-        refaspect=("aspect",),
-        refwidth=("axwidth",),
-        refheight=("axheight",),
-        figwidth=("width",),
-        figheight=("height",),
-    )
+    @_alias_kwargs("figure.init")
     def __init__(
         self,
         *,
@@ -1050,6 +1039,7 @@ class Figure(mfigure.Figure):
         self._skip_autolayout = False
         self._includepanels = None
         self._render_context = {}
+        kwargs = _canonicalize_kwargs("figure.format", kwargs)
         rc_kw, rc_mode = _pop_rc(kwargs)
         kw_format = _pop_params(kwargs, self._format_signature)
         if figwidth is not None and figheight is not None:
@@ -3488,27 +3478,26 @@ class Figure(mfigure.Figure):
         "0.10.0", mathtext_fallback="uplt.rc.mathtext_fallback = {}"
     )
     @docstring._snippet_manager
+    @_alias_kwargs("figure.format")
+    @_alias_kwargs("axes.format")
+    @_alias_kwargs("cartesian.format")
+    @_alias_kwargs("geo.format")
+    @_alias_kwargs("polar.format")
+    @_alias_kwargs("taylor.format")
     def format(
         self,
         axs=None,
         *,
-        figtitle=None,
         suptitle=None,
         suptitle_kw=None,
-        llabels=None,
         leftlabels=None,
         leftlabels_kw=None,
-        rlabels=None,
         rightlabels=None,
         rightlabels_kw=None,
-        blabels=None,
         bottomlabels=None,
         bottomlabels_kw=None,
-        tlabels=None,
         toplabels=None,
         toplabels_kw=None,
-        rowlabels=None,
-        collabels=None,  # aliases
         includepanels=None,
         **kwargs,
     ):
@@ -3568,23 +3557,16 @@ class Figure(mfigure.Figure):
         explicit_format_keys.update(generic_axis_kwargs)
         rc_kw, rc_mode = _pop_rc(kwargs)
         figure_layout_requested = _any_not_none(
-            figtitle,
             suptitle,
             suptitle_kw,
-            llabels,
             leftlabels,
             leftlabels_kw,
-            rlabels,
             rightlabels,
             rightlabels_kw,
-            blabels,
             bottomlabels,
             bottomlabels_kw,
-            tlabels,
             toplabels,
             toplabels_kw,
-            rowlabels,
-            collabels,
             includepanels,
         )
         if (
@@ -3620,30 +3602,11 @@ class Figure(mfigure.Figure):
             rightlabels_kw = rightlabels_kw or {}
             bottomlabels_kw = bottomlabels_kw or {}
             toplabels_kw = toplabels_kw or {}
-            self._update_super_title(
-                _not_none(figtitle=figtitle, suptitle=suptitle),
-                **suptitle_kw,
-            )
-            self._update_super_labels(
-                "left",
-                _not_none(rowlabels=rowlabels, leftlabels=leftlabels, llabels=llabels),
-                **leftlabels_kw,
-            )
-            self._update_super_labels(
-                "right",
-                _not_none(rightlabels=rightlabels, rlabels=rlabels),
-                **rightlabels_kw,
-            )
-            self._update_super_labels(
-                "bottom",
-                _not_none(bottomlabels=bottomlabels, blabels=blabels),
-                **bottomlabels_kw,
-            )
-            self._update_super_labels(
-                "top",
-                _not_none(collabels=collabels, toplabels=toplabels, tlabels=tlabels),
-                **toplabels_kw,
-            )
+            self._update_super_title(suptitle, **suptitle_kw)
+            self._update_super_labels("left", leftlabels, **leftlabels_kw)
+            self._update_super_labels("right", rightlabels, **rightlabels_kw)
+            self._update_super_labels("bottom", bottomlabels, **bottomlabels_kw)
+            self._update_super_labels("top", toplabels, **toplabels_kw)
 
         # Update the main axes
         if skip_axes:  # avoid recursion
@@ -3717,12 +3680,12 @@ class Figure(mfigure.Figure):
 
     @docstring._concatenate_inherited
     @docstring._snippet_manager
+    @_alias_kwargs("colorbar")
     def colorbar(
         self,
         mappable,
         values=None,
         loc: Optional[str] = None,
-        location: Optional[str] = None,
         row: Optional[int] = None,
         col: Optional[int] = None,
         rows: Optional[Union[int, Tuple[int, int]]] = None,
@@ -3739,17 +3702,14 @@ class Figure(mfigure.Figure):
         Parameters
         ----------
         %(axes.colorbar_args)s
-        length : float, default: :rc:`colorbar.length`
+        shrink : float, default: :rc:`colorbar.length`
             The colorbar length. Units are relative to the span of the rows and
             columns of subplots.
-        shrink : float, optional
-            Alias for `length`. This is included for consistency with
-            `matplotlib.figure.Figure.colorbar`.
         width : unit-spec, default: :rc:`colorbar.width`
             The colorbar width.
             %(units.in)s
         %(figure.colorbar_space)s
-            Has no visible effect if `length` is ``1``.
+            Has no visible effect if `shrink` is ``1``.
 
         Other parameters
         ----------------
@@ -3913,7 +3873,7 @@ class Figure(mfigure.Figure):
             )
         # Figure panel colorbar
         else:
-            loc = _not_none(loc=loc, location=location, default="r")
+            loc = _not_none(loc, "r")
             ax = self._add_figure_panel(
                 loc,
                 row=row,
@@ -3930,12 +3890,12 @@ class Figure(mfigure.Figure):
 
     @docstring._concatenate_inherited
     @docstring._snippet_manager
+    @_alias_kwargs("legend")
     def legend(
         self,
         handles=None,
         labels=None,
         loc=None,
-        location=None,
         row=None,
         col=None,
         rows=None,
@@ -4128,7 +4088,7 @@ class Figure(mfigure.Figure):
             )
         # Figure panel legend
         else:
-            loc = _not_none(loc=loc, location=location, default="r")
+            loc = _not_none(loc, "r")
             ax = self._add_figure_panel(
                 loc,
                 row=row,

--- a/ultraplot/figure.py
+++ b/ultraplot/figure.py
@@ -3702,14 +3702,14 @@ class Figure(mfigure.Figure):
         Parameters
         ----------
         %(axes.colorbar_args)s
-        shrink : float, default: :rc:`colorbar.length`
-            The colorbar length. Units are relative to the span of the rows and
-            columns of subplots.
+        length : float, default: :rc:`colorbar.length`
+            The colorbar length (also accepted as ``shrink``). Units are relative
+            to the span of the rows and columns of subplots.
         width : unit-spec, default: :rc:`colorbar.width`
             The colorbar width.
             %(units.in)s
         %(figure.colorbar_space)s
-            Has no visible effect if `shrink` is ``1``.
+            Has no visible effect if `length` is ``1``.
 
         Other parameters
         ----------------
@@ -3740,6 +3740,9 @@ class Figure(mfigure.Figure):
             )
         # Fill this axes
         if cax is not None:
+            # Matplotlib uses its native spelling when given explicit axes.
+            if "length" in kwargs:
+                kwargs["shrink"] = kwargs.pop("length")
             with context._state_context(cax, _internal_call=True):  # do not wrap pcolor
                 cb = super().colorbar(mappable, cax=cax, **kwargs)
         # Axes panel colorbar

--- a/ultraplot/gridspec.py
+++ b/ultraplot/gridspec.py
@@ -20,6 +20,7 @@ from . import axes as paxes
 from .axes._formatting import pop_axis_format_kwargs
 from .config import rc
 from .internals import (
+    _alias_kwargs,
     _not_none,
     _pop_rc,
     docstring,
@@ -71,13 +72,10 @@ wspace, hspace, space : unit-spec or sequence, default: None
     layout algorithm. For example, ``subplots(ncols=3, tight=True, wspace=(2, None))``
     fixes the space between columns 1 and 2 but lets the tight layout algorithm
     determine the space between columns 2 and 3.
-wratios, hratios : float or sequence, optional
-    Passed to :class:`~ultraplot.gridspec.GridSpec`, denotes the width and height
-    ratios for the subplot grid. Length of `wratios` must match the number
-    of columns, and length of `hratios` must match the number of rows.
-width_ratios, height_ratios
-    Aliases for `wratios`, `hratios`. Included for
-    consistency with `matplotlib.gridspec.GridSpec`.
+width_ratios, height_ratios : float or sequence, optional
+    Passed to :class:`~ultraplot.gridspec.GridSpec`, and denote the width and
+    height ratios for the subplot grid. Length of `width_ratios` must match the
+    number of columns, and length of `height_ratios` must match the number of rows.
 wpad, hpad, pad : unit-spec or sequence, optional
     The tight layout padding between columns, rows, and both, respectively.
     Unlike ``space``, these control the padding between subplot content
@@ -529,8 +527,8 @@ class GridSpec(mgridspec.GridSpec):
                 right=right,
                 top=top,
                 bottom=bottom,
-                wratios=self._wratios_total,
-                hratios=self._hratios_total,
+                width_ratios=self._wratios_total,
+                height_ratios=self._hratios_total,
                 wpanels=[bool(val) for val in self._wpanels],
                 hpanels=[bool(val) for val in self._hpanels],
             )
@@ -1377,6 +1375,7 @@ class GridSpec(mgridspec.GridSpec):
         else:
             warnings._warn_ultraplot(f"Auto resize failed. Invalid figsize {figsize}.")
 
+    @_alias_kwargs("gridspec")
     def _update_params(
         self,
         *,
@@ -1400,8 +1399,6 @@ class GridSpec(mgridspec.GridSpec):
         outerpad=None,
         innerpad=None,
         panelpad=None,
-        hratios=None,
-        wratios=None,
         width_ratios=None,
         height_ratios=None,
     ):
@@ -1484,8 +1481,8 @@ class GridSpec(mgridspec.GridSpec):
         wspace = _not_none(wspace, space)
         hspace = units(hspace, "em", "in")
         wspace = units(wspace, "em", "in")
-        hratios = _not_none(hratios=hratios, height_ratios=height_ratios)
-        wratios = _not_none(wratios=wratios, width_ratios=width_ratios)
+        hratios = height_ratios
+        wratios = width_ratios
         _assign_vector("hpad", hpad, space=True)
         _assign_vector("wpad", wpad, space=True)
         _assign_vector("hspace", hspace, space=True)

--- a/ultraplot/internals/__init__.py
+++ b/ultraplot/internals/__init__.py
@@ -22,6 +22,11 @@ from . import warnings
 from .kwargs import (  # noqa: F401
     _alias_kwargs,
     _alias_maps,
+    _alias_registry,
+    _canonicalize_kwargs,
+    _format_alias_reference,
+    _figure_format_alias_scopes,
+    _format_alias_scopes,
     _get_aliases,
     _get_signature,
     _kwargs_to_args,

--- a/ultraplot/internals/docstring.py
+++ b/ultraplot/internals/docstring.py
@@ -180,71 +180,62 @@ _snippet_manager["units.in"] = _units_docstring.format(units="inches")
 _snippet_manager["units.em"] = _units_docstring.format(units="em-widths")
 
 
-# Style docstrings
-# NOTE: These are needed in a few different places
-def _aliases_note(*names):
-    """
-    Render a compact ``Aliases: ...`` note for a style parameter. The canonical
-    name leads the numpydoc field; the common documented synonyms go here so the
-    parameter reads cleanly instead of opening with a pile of alias names.
-    """
-    return "Aliases: " + ", ".join(f"``{name}``" for name in names) + "."
-
-
-_line_docstring = f"""
+# Style docstrings. Compatibility spellings are intentionally kept out of these
+# primary parameter docs; the registry-generated alias reference is authoritative.
+_line_docstring = """
 linewidth : unit-spec, default: :rc:`lines.linewidth`
-    The width of the line(s). {_aliases_note("lw", "linewidths")}
+    The width of the line(s).
     %(units.pt)s
 linestyle : str, default: :rc:`lines.linestyle`
-    The style of the line(s). {_aliases_note("ls", "linestyles")}
+    The style of the line(s).
 color : color-spec, optional
-    The color of the line(s). The property `cycle` is used by default. {_aliases_note("c", "colors")}
+    The color of the line(s). The property `cycle` is used by default.
 alpha : float, optional
-    The opacity of the line(s). Inferred from `color` by default. {_aliases_note("a", "alphas")}
+    The opacity of the line(s). Inferred from `color` by default.
 """
-_patch_docstring = f"""
+_patch_docstring = """
 linewidth : unit-spec, default: :rc:`patch.linewidth`
-    The edge width of the patch(es). {_aliases_note("lw", "linewidths")}
+    The edge width of the patch(es).
     %(units.pt)s
 linestyle : str, default: '-'
-    The edge style of the patch(es). {_aliases_note("ls", "linestyles")}
-edgecolor : color-spec, default: '{{edgecolor}}'
-    The edge color of the patch(es). {_aliases_note("ec", "edgecolors")}
+    The edge style of the patch(es).
+edgecolor : color-spec, default: '{edgecolor}'
+    The edge color of the patch(es).
 facecolor : color-spec, optional
-    The face color of the patch(es). The property `cycle` is used by default. {_aliases_note("fc", "facecolors", "fillcolor", "fillcolors")}
+    The face color of the patch(es). The property `cycle` is used by default.
 alpha : float, optional
-    The opacity of the patch(es). Inferred from `facecolor` and `edgecolor` by default. {_aliases_note("a", "alphas")}
+    The opacity of the patch(es). Inferred from `facecolor` and `edgecolor` by default.
 """
-_pcolor_collection_docstring = f"""
+_pcolor_collection_docstring = """
 linewidths : unit-spec, default: 0.3
-    The width of lines between grid boxes. {_aliases_note("lw", "linewidth")}
+    The width of lines between grid boxes.
     %(units.pt)s
 linestyles : str, default: '-'
-    The style of lines between grid boxes. {_aliases_note("ls", "linestyle")}
+    The style of lines between grid boxes.
 edgecolors : color-spec, default: 'k'
-    The color of lines between grid boxes. {_aliases_note("ec", "edgecolor")}
+    The color of lines between grid boxes.
 alpha : float, optional
-    The opacity of the grid boxes. Inferred from `cmap` by default. {_aliases_note("a", "alphas")}
+    The opacity of the grid boxes. Inferred from `cmap` by default.
 """
-_contour_collection_docstring = f"""
+_contour_collection_docstring = """
 linewidths : unit-spec, default: 0.3 or :rc:`lines.linewidth`
     The width of the line contours. Default is ``0.3`` when adding to filled contours
-    or :rc:`lines.linewidth` otherwise. {_aliases_note("lw", "linewidth")} %(units.pt)s
+    or :rc:`lines.linewidth` otherwise. %(units.pt)s
 linestyles : str, default: '-' or :rc:`contour.negative_linestyle`
     The style of the line contours. Default is ``'-'`` for positive contours and
-    :rcraw:`contour.negative_linestyle` for negative contours. {_aliases_note("ls", "linestyle")}
+    :rcraw:`contour.negative_linestyle` for negative contours.
 edgecolors : color-spec, default: 'k' or inferred
     The color of the line contours. Default is ``'k'`` when adding to filled contours
-    or inferred from `color` or `cmap` otherwise. {_aliases_note("ec", "edgecolor")}
+    or inferred from `color` or `cmap` otherwise.
 alpha : float, optional
-    The opacity of the contours. Inferred from `edgecolors` by default. {_aliases_note("a", "alphas")}
+    The opacity of the contours. Inferred from `edgecolors` by default.
 """
-_text_docstring = f"""
+_text_docstring = """
 fontfamily : str, optional
     The font typeface name (e.g., ``'Fira Math'``) or font family name (e.g.,
-    ``'serif'``). Matplotlib falls back to the system default if not found. {_aliases_note("family", "name", "fontname")}
+    ``'serif'``). Matplotlib falls back to the system default if not found.
 fontsize : unit-spec or str, optional
-    The font size. {_aliases_note("size")} %(units.pt)s
+    The font size. %(units.pt)s
     This can also be a string indicating some scaling relative to
     :rcraw:`font.size`. The sizes and scalings are shown below. The
     scalings ``'med'``, ``'med-small'``, and ``'med-large'`` are

--- a/ultraplot/internals/guides.py
+++ b/ultraplot/internals/guides.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from . import ic  # noqa: F401
 from . import warnings
+from .kwargs import _alias_registry
 
 # Global constants
 REMOVE_AFTER_FLUSH = (
@@ -22,10 +23,10 @@ REMOVE_AFTER_FLUSH = (
     "align",
     "queue",
 )
-GUIDE_ALIASES = (
-    ("title", "label"),
-    ("locator", "ticks"),
-    ("format", "formatter", "ticklabels"),
+GUIDE_ALIASES = tuple(
+    (canonical, *aliases)
+    for scope in ("colorbar", "legend")
+    for canonical, aliases in _alias_registry[scope].items()
 )
 
 

--- a/ultraplot/internals/inputs.py
+++ b/ultraplot/internals/inputs.py
@@ -11,6 +11,7 @@ import numpy.ma as ma
 
 from . import ic  # noqa: F401
 from . import _not_none, warnings
+from .kwargs import _alias_kwargs
 
 try:
     from cartopy.crs import PlateCarree
@@ -549,14 +550,13 @@ def _dist_clean(distribution):
         raise ValueError("Input must be a numpy array or a list of lists")
 
 
-def _dist_reduce(data, *, mean=None, means=None, median=None, medians=None, **kwargs):
+@_alias_kwargs("plot.statistics")
+def _dist_reduce(data, *, means=None, medians=None, **kwargs):
     """
     Reduce statistical distributions to means and medians. Tack on a
     distribution keyword argument for processing down the line.
     """
     # TODO: Permit 3D array with error dimension coming first
-    means = _not_none(mean=mean, means=means)
-    medians = _not_none(median=median, medians=medians)
     if means and medians:
         warnings._warn_ultraplot(
             "Cannot have both means=True and medians=True. Using former."

--- a/ultraplot/internals/kwargs.py
+++ b/ultraplot/internals/kwargs.py
@@ -16,6 +16,11 @@ from . import warnings
 __all__ = [
     "_not_none",
     "_alias_kwargs",
+    "_alias_registry",
+    "_canonicalize_kwargs",
+    "_format_alias_reference",
+    "_figure_format_alias_scopes",
+    "_format_alias_scopes",
     "_alias_maps",
     "_get_aliases",
     "_kwargs_to_args",
@@ -23,6 +28,331 @@ __all__ = [
     "_pop_params",
     "_pop_props",
 ]
+
+
+# Compatibility aliases are deliberately kept outside function signatures. The
+# first-level keys describe the API context because the same shorthand can map to
+# different canonical Matplotlib names (for example ``lw`` for a Line2D versus a
+# Collection). This is data, rather than decorator arguments scattered throughout
+# the package, so it can also drive the migration reference and error messages.
+_alias_registry = {
+    "figure.init": {
+        "refnum": ("ref",),
+        "refaspect": ("aspect",),
+        "refwidth": ("axwidth",),
+        "refheight": ("axheight",),
+        "figwidth": ("width",),
+        "figheight": ("height",),
+    },
+    "axes.format": {
+        "lefttitle": ("ltitle",),
+        "centertitle": ("ctitle",),
+        "righttitle": ("rtitle",),
+        "upperlefttitle": ("ultitle",),
+        "uppercentertitle": ("uctitle",),
+        "upperrighttitle": ("urtitle",),
+        "lowerlefttitle": ("lltitle",),
+        "lowercentertitle": ("lctitle",),
+        "lowerrighttitle": ("lrtitle",),
+    },
+    "cartesian.format": {
+        "xspineloc": ("xloc",),
+        "yspineloc": ("yloc",),
+        "xformatter": ("xticklabels",),
+        "yformatter": ("yticklabels",),
+        "xlocator": ("xticks",),
+        "ylocator": ("yticks",),
+        "xminorlocator": ("xminorticks",),
+        "yminorlocator": ("yminorticks",),
+    },
+    "geo.format": {
+        "lonlocator": ("lonlines",),
+        "latlocator": ("latlines",),
+        "lonminorlocator": ("lonminorlines",),
+        "latminorlocator": ("latminorlines",),
+        "lonlocator_kw": ("lonlines_kw",),
+        "latlocator_kw": ("latlines_kw",),
+        "lonminorlocator_kw": ("lonminorlines_kw",),
+        "latminorlocator_kw": ("latminorlines_kw",),
+    },
+    "polar.format": {
+        "thetalocator": ("thetalines",),
+        "rlocator": ("rlines",),
+        "thetaminorlocator": ("thetaminorlines",),
+        "rminorlocator": ("rminorlines",),
+        "thetaformatter": ("thetalabels",),
+        "rformatter": ("rlabels",),
+    },
+    "taylor.format": {
+        "corrlocator": ("corrlines", "corrticks"),
+    },
+    "figure.format": {
+        "suptitle": ("figtitle",),
+        "leftlabels": ("llabels", "rowlabels"),
+        "rightlabels": ("rlabels",),
+        "bottomlabels": ("blabels",),
+        "toplabels": ("tlabels", "collabels"),
+    },
+    "colorbar": {
+        "loc": ("location",),
+        "drawedges": ("grid", "edges"),
+        "shrink": ("length",),
+        "label": ("title",),
+        "labellocation": ("labelloc",),
+        "ticks": ("locator",),
+        "format": ("formatter", "ticklabels"),
+        "minorticks": ("minorlocator",),
+        "color": ("c",),
+        "linewidth": ("lw",),
+        "tickdirection": ("tickdir",),
+        "frameon": ("frame",),
+    },
+    "legend": {
+        "loc": ("location",),
+        "ncols": ("ncol",),
+        "frameon": ("frame",),
+    },
+    "gridspec": {
+        "width_ratios": ("wratios",),
+        "height_ratios": ("hratios",),
+    },
+    "subplot": {
+        "projection": ("proj",),
+        "projection_kw": ("proj_kw",),
+    },
+    "inset": {
+        "projection": ("proj",),
+    },
+    "cycle": {
+        "samples": ("N",),
+    },
+    "projection": {
+        "lon0": ("lon_0",),
+        "lat0": ("lat_0",),
+    },
+    "scale.log": {
+        "base": ("basex", "basey"),
+        "nonpos": ("nonposx", "nonposy"),
+        "subs": ("subsx", "subsy"),
+    },
+    "scale.symlog": {
+        "base": ("basex", "basey"),
+        "linthresh": ("linthreshx", "linthreshy"),
+        "linscale": ("linscalex", "linscaley"),
+        "subs": ("subsx", "subsy"),
+    },
+    "plot.labels": {
+        "formatter": ("fmt",),
+    },
+    "plot.text": {
+        "color": ("c", "colors"),
+        "fontsize": ("size",),
+    },
+    "plot.contour_labels": {
+        "colors": ("c", "color"),
+        "fontsize": ("size",),
+    },
+    "plot.error_bars": {
+        "barstds": ("bars", "barstd"),
+        "barpctiles": ("barpctile",),
+        "boxstds": ("boxes", "boxstd"),
+        "boxpctiles": ("boxpctile",),
+    },
+    "plot.error_shading": {
+        "shadestds": ("shade", "shadestd"),
+        "shadepctiles": ("shadepctile",),
+        "fadestds": ("fade", "fadestd"),
+        "fadepctiles": ("fadepctile",),
+    },
+    "plot.colormap": {
+        "colors": ("c", "color"),
+    },
+    "plot.levels": {
+        "levels": ("N",),
+    },
+    "plot.stacked": {
+        "stacked": ("stack",),
+    },
+    "plot.statistics": {
+        "means": ("mean",),
+        "medians": ("median",),
+    },
+    "plot.boxplot": {
+        "means": ("showmeans",),
+        "fill": ("filled",),
+    },
+    "plot.violinplot": {
+        "means": ("showmeans",),
+        "medians": ("showmedians",),
+    },
+    "plot.hist": {
+        "rwidth": ("width",),
+        "stacked": ("stack",),
+        "fill": ("filled",),
+    },
+    "plot.pie": {
+        "labeldistance": ("labelpad",),
+    },
+}
+
+_format_alias_scopes = (
+    "axes.format",
+    "cartesian.format",
+    "geo.format",
+    "polar.format",
+    "taylor.format",
+)
+_figure_format_alias_scopes = ("figure.format", *_format_alias_scopes)
+
+
+def _get_alias_groups(scope=None, aliases=None):
+    """Return validated canonical-to-legacy alias groups."""
+    if scope is not None and aliases:
+        raise TypeError("Pass an alias registry scope or inline aliases, not both.")
+    if scope is None:
+        groups = aliases or {}
+    else:
+        try:
+            groups = _alias_registry[scope]
+        except KeyError:
+            raise KeyError(f"Unknown alias registry scope {scope!r}.") from None
+    return {
+        canonical: (legacy,) if isinstance(legacy, str) else tuple(legacy)
+        for canonical, legacy in groups.items()
+    }
+
+
+def _canonicalize_kwargs(
+    scope, kwargs, *, aliases=None, provided=(), warn=False
+):
+    """
+    Return a copy of *kwargs* with legacy names translated to canonical names.
+
+    Only explicitly registered spellings are translated. Supplying two spellings
+    for one parameter raises ``TypeError``, matching Matplotlib's alias handling.
+    The input mapping is never mutated. Translation is intentionally silent during
+    the compatibility stage; a later deprecation can opt into warnings with
+    ``warn=True`` without changing call signatures or registry data.
+    """
+    if isinstance(scope, (tuple, list)):
+        if aliases:
+            raise TypeError("Inline aliases cannot be combined with multiple scopes.")
+        output = dict(kwargs)
+        for item in scope:
+            output = _canonicalize_kwargs(
+                item, output, provided=provided, warn=warn
+            )
+        return output
+    groups = _get_alias_groups(scope, aliases)
+    lookup = {
+        legacy: canonical
+        for canonical, legacy_names in groups.items()
+        for legacy in legacy_names
+    }
+    output = dict(kwargs)
+    explicit = output.get("_explicit_format_keys")
+    if explicit is not None:
+        output["_explicit_format_keys"] = {
+            lookup.get(name, name) for name in explicit
+        }
+    seen = {
+        canonical: canonical
+        for canonical in groups
+        if output.get(canonical) is not None
+    }
+    seen.update(
+        {
+            canonical: canonical
+            for canonical in provided
+            if canonical in groups and provided[canonical] is not None
+        }
+    )
+    # Validate the entire call before translating anything so invalid calls do
+    # not emit a partial sequence of migration warnings.
+    for legacy, value in output.items():
+        canonical = lookup.get(legacy)
+        if canonical is None or value is None:
+            continue
+        if canonical in seen:
+            raise TypeError(
+                f"Got both {seen[canonical]!r} and {legacy!r}, which are aliases "
+                f"for {canonical!r}."
+            )
+        seen[canonical] = legacy
+    for legacy in tuple(output):
+        canonical = lookup.get(legacy)
+        if canonical is None:
+            continue
+        value = output.pop(legacy)
+        # ``None`` is how pyplot and UltraPlot wrappers forward unspecified
+        # options. Treat it as absent so it neither warns nor shadows defaults.
+        if value is None:
+            continue
+        output[canonical] = value
+        if warn:
+            warnings._warn_ultraplot(
+                f"Keyword {legacy!r} is deprecated; use {canonical!r} instead."
+            )
+    return output
+
+
+def _format_alias_table(rows):
+    """Format alias rows as a simple RST table."""
+    rows = [("Context", "Accepted spelling", "Canonical spelling"), *rows]
+    widths = [max(len(row[idx]) for row in rows) for idx in range(3)]
+    rule = " ".join("=" * width for width in widths)
+    lines = [rule]
+    for idx, row in enumerate(rows):
+        lines.append(
+            " ".join(value.ljust(widths[col]) for col, value in enumerate(row)).rstrip()
+        )
+        if idx == 0:
+            lines.append(rule)
+    lines.append(rule)
+    return "\n".join(lines)
+
+
+def _format_alias_reference():
+    """Return the registered compatibility aliases as grouped RST tables."""
+    function_rows = []
+    style_rows = []
+    for scope, groups in _alias_registry.items():
+        target = style_rows if scope.startswith("style.") else function_rows
+        for canonical, aliases in groups.items():
+            target.extend((scope, legacy, canonical) for legacy in aliases)
+
+    # Dotted rc names cannot be Python identifiers, so UltraPlot historically
+    # accepted dotless spellings in ``format()`` kwargs. Generate these mappings
+    # from the rc registry instead of copying hundreds of entries by hand.
+    from . import rcsetup
+
+    rc_rows = [
+        ("rc (dotless)", legacy, canonical)
+        for legacy, canonical in sorted(rcsetup._rc_nodots.items())
+        if legacy != canonical
+    ]
+    sections = (
+        (
+            "Function keyword aliases",
+            "These mappings apply only in the listed call context.",
+            function_rows,
+        ),
+        (
+            "Artist property aliases",
+            "These are Matplotlib-style shorthand properties accepted while styling artists.",
+            style_rows,
+        ),
+        (
+            "Dotless rc aliases",
+            "Use the dotted canonical spelling through ``rc_kw`` when avoiding the accepted shorthand.",
+            rc_rows,
+        ),
+    )
+    rendered = [
+        f"{title}\n{'-' * len(title)}\n\n{description}\n\n{_format_alias_table(rows)}"
+        for title, description, rows in sections
+    ]
+    return "\n\n".join(rendered)
 
 
 def _not_none(*args, default=None, **kwargs):
@@ -52,45 +382,49 @@ def _not_none(*args, default=None, **kwargs):
     return first
 
 
-def _alias_kwargs(**aliases):
+def _alias_kwargs(scope=None, **aliases):
     """
     Fold keyword-argument aliases into their canonical names before a call.
 
-    Each keyword maps a canonical parameter name to a tuple of accepted synonyms,
-    e.g. ``@_alias_kwargs(figwidth=("width",), refnum=("ref",))``. A synonym passed
-    by the caller is renamed to its canonical name. Passing a canonical together
-    with a synonym (or two synonyms) warns and keeps the canonical / first value,
-    matching the precedence and warning of `_not_none`. This replaces the repetitive
-    ``x = _not_none(x=x, y=y)`` boilerplate at the top of aliased functions.
+    Pass a registry scope, e.g. ``@_alias_kwargs("figure.init")``. Inline mappings
+    remain available for small private helpers, but public compatibility aliases
+    should live in `_alias_registry` so they can be documented and audited.
 
-    This handles keyword aliases only: a canonical argument passed *positionally*
-    is not deduplicated against its synonyms, and a synonym must not shadow a
+    This handles keyword aliases only. Canonical arguments passed positionally
+    are included in duplicate detection, and a synonym must not shadow a
     different real parameter of the wrapped function.
     """
-    # Map each synonym to its canonical name; synonyms are tried in declared order
-    # so the first non-``None`` one wins, exactly like `_not_none`.
-    lookup = {syn: canon for canon, syns in aliases.items() for syn in syns}
+    if isinstance(scope, (tuple, list)):
+        if aliases:
+            raise TypeError("Inline aliases cannot be combined with multiple scopes.")
+        groups = {}
+        for item in scope:
+            groups.update(_get_alias_groups(item))
+    else:
+        groups = _get_alias_groups(scope, aliases)
 
     def decorator(func):
+        signature = inspect.signature(func)
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            for syn, canon in lookup.items():
-                if syn not in kwargs:
-                    continue
-                value = kwargs.pop(syn)
-                if value is None:
-                    continue
-                if kwargs.get(canon) is None:
-                    kwargs[canon] = value
-                else:
-                    # ``canon`` already holds an earlier value (from the canonical
-                    # keyword or a prior synonym); keep it and drop this synonym.
-                    warnings._warn_ultraplot(
-                        f"Got conflicting or duplicate values for {canon!r} "
-                        f"(ignoring alias {syn!r}). Using the first value."
-                    )
+            # Bind positional arguments separately so ``func(value, alias=value)``
+            # is diagnosed before the translated call reaches Python's binder.
+            provided = signature.bind_partial(*args).arguments
+            kwargs = _canonicalize_kwargs(
+                scope,
+                kwargs,
+                aliases=groups if scope is None else None,
+                provided=provided,
+            )
             return func(*args, **kwargs)
 
+        wrapper._ultraplot_alias_scopes = (
+            tuple(scope)
+            if isinstance(scope, (tuple, list))
+            else (scope,) if scope is not None else ()
+        )
+        wrapper._ultraplot_aliases = dict(groups)
         return wrapper
 
     return decorator
@@ -199,6 +533,14 @@ _alias_maps = {
         "zorder": ("z", "zorders"),
     },
 }
+
+# Style aliases are consumed by ``_pop_props`` rather than decorators, but they
+# belong to the same context-aware compatibility registry. Keeping the legacy
+# ``_alias_maps`` name as a view avoids a broad internal migration while making
+# the complete public mapping discoverable and documentable in one place.
+_alias_registry.update(
+    {f"style.{category}": groups for category, groups in _alias_maps.items()}
+)
 
 
 _INTERNAL_POP_PARAMS = frozenset(

--- a/ultraplot/internals/kwargs.py
+++ b/ultraplot/internals/kwargs.py
@@ -222,9 +222,7 @@ def _get_alias_groups(scope=None, aliases=None):
     }
 
 
-def _canonicalize_kwargs(
-    scope, kwargs, *, aliases=None, provided=(), warn=False
-):
+def _canonicalize_kwargs(scope, kwargs, *, aliases=None, provided=(), warn=False):
     """
     Return a copy of *kwargs* with legacy names translated to canonical names.
 
@@ -239,9 +237,7 @@ def _canonicalize_kwargs(
             raise TypeError("Inline aliases cannot be combined with multiple scopes.")
         output = dict(kwargs)
         for item in scope:
-            output = _canonicalize_kwargs(
-                item, output, provided=provided, warn=warn
-            )
+            output = _canonicalize_kwargs(item, output, provided=provided, warn=warn)
         return output
     groups = _get_alias_groups(scope, aliases)
     lookup = {
@@ -252,9 +248,7 @@ def _canonicalize_kwargs(
     output = dict(kwargs)
     explicit = output.get("_explicit_format_keys")
     if explicit is not None:
-        output["_explicit_format_keys"] = {
-            lookup.get(name, name) for name in explicit
-        }
+        output["_explicit_format_keys"] = {lookup.get(name, name) for name in explicit}
     seen = {
         canonical: canonical
         for canonical in groups

--- a/ultraplot/internals/kwargs.py
+++ b/ultraplot/internals/kwargs.py
@@ -96,7 +96,7 @@ _alias_registry = {
     "colorbar": {
         "loc": ("location",),
         "drawedges": ("grid", "edges"),
-        "shrink": ("length",),
+        "length": ("shrink",),
         "label": ("title",),
         "labellocation": ("labelloc",),
         "ticks": ("locator",),

--- a/ultraplot/legend.py
+++ b/ultraplot/legend.py
@@ -16,7 +16,15 @@ from matplotlib import legend_handler as mhandler
 from matplotlib.markers import MarkerStyle
 
 from .config import rc
-from .internals import _not_none, _pop_props, docstring, guides, inputs, rcsetup
+from .internals import (
+    _alias_kwargs,
+    _not_none,
+    _pop_props,
+    docstring,
+    guides,
+    inputs,
+    rcsetup,
+)
 from .utils import _fontsize_to_pt, units
 
 try:
@@ -2247,6 +2255,7 @@ class UltraLegend:
         """
         return ALIGN_OPTS
 
+    @_alias_kwargs("legend")
     def _resolve_inputs(
         self,
         handles=None,
@@ -2257,9 +2266,7 @@ class UltraLegend:
         width=None,
         pad=None,
         space=None,
-        frame=None,
         frameon=None,
-        ncol=None,
         ncols=None,
         alphabetize=False,
         center=None,
@@ -2284,9 +2291,9 @@ class UltraLegend:
         """
         Normalize inputs, apply rc defaults, and convert units.
         """
-        ncol = _not_none(ncols=ncols, ncol=ncol)
+        ncol = ncols
         order = _not_none(order, "C")
-        frameon = _not_none(frame=frame, frameon=frameon, default=rc["legend.frameon"])
+        frameon = _not_none(frameon, default=rc["legend.frameon"])
         fontsize = _not_none(fontsize, rc["legend.fontsize"])
         titlefontsize = _not_none(
             title_fontsize=kwargs.pop("title_fontsize", None),
@@ -2468,6 +2475,7 @@ class UltraLegend:
         ax._register_guide("legend", obj, (loc, align))
         return obj
 
+    @_alias_kwargs("legend")
     def add(
         self,
         handles=None,
@@ -2478,9 +2486,7 @@ class UltraLegend:
         width=None,
         pad=None,
         space=None,
-        frame=None,
         frameon=None,
-        ncol=None,
         ncols=None,
         alphabetize=False,
         center=None,
@@ -2513,9 +2519,7 @@ class UltraLegend:
             width=width,
             pad=pad,
             space=space,
-            frame=frame,
             frameon=frameon,
-            ncol=ncol,
             ncols=ncols,
             alphabetize=alphabetize,
             center=center,

--- a/ultraplot/scale.py
+++ b/ultraplot/scale.py
@@ -13,6 +13,7 @@ import numpy.ma as ma
 
 from . import ticker as pticker
 from .internals import (
+    _canonicalize_kwargs,
     _not_none,
     _version_mpl,
     ic,  # noqa: F401
@@ -43,15 +44,11 @@ def _parse_logscale_args(*keys, **kwargs):
     # NOTE: Scale classes ignore unused arguments with warnings, but matplotlib 3.3
     # version changes the keyword args. Since we can't do a try except clause, only
     # way to avoid warnings with 3.3 upgrade is to test version string.
+    scope = "scale.symlog" if "linthresh" in keys else "scale.log"
+    kwargs = _canonicalize_kwargs(scope, kwargs)
     kwsuffix = "" if _version_mpl >= "3.3" else "x"
     for key in keys:
-        # Remove duplicates
-        opts = {
-            key: kwargs.pop(key, None),
-            key + "x": kwargs.pop(key + "x", None),
-            key + "y": kwargs.pop(key + "y", None),
-        }
-        value = _not_none(**opts)  # issues warning if multiple values passed
+        value = kwargs.pop(key, None)
 
         # Apply defaults and adjust
         # NOTE: If linthresh is *exactly* on a power of the base, can end
@@ -207,10 +204,6 @@ class LogScale(_Scale, mscale.LogScale):
             Default *minor* tick locations are on these multiples of each power
             of the base. For example, ``subs=(1, 2, 5)`` draws ticks on 1, 2,
             5, 10, 20, 50, 100, 200, 500, etc.
-        basex, basey, nonposx, nonposy, subsx, subsy
-            Aliases for the above keywords. These used to be conditional
-            on the *name* of the axis.
-
         See also
         --------
         ultraplot.constructor.Scale
@@ -252,10 +245,6 @@ class SymmetricalLogScale(_Scale, mscale.SymmetricalLogScale):
             Default *minor* tick locations are on these multiples of each power
             of the base. For example, ``subs=(1, 2, 5)`` draws ticks on 1, 2,
             5, 10, 20, 50, 100, 200, 500, etc.
-        basex, basey, linthreshx, linthreshy, linscalex, linscaley, subsx, subsy
-            Aliases for the above keywords. These keywords used to be
-            conditional on the name of the axis.
-
         See also
         --------
         ultraplot.constructor.Scale

--- a/ultraplot/tests/test_alias_signatures.py
+++ b/ultraplot/tests/test_alias_signatures.py
@@ -146,3 +146,10 @@ def test_level_alias_is_consumed_before_native_plot_call() -> None:
     _, ax = uplt.subplots()
     mesh = ax.heatmap(np.arange(4).reshape(2, 2), N=5)
     assert mesh is not None
+
+
+def test_format_alias_is_consumed_before_twin_axes_init() -> None:
+    """A twin's legacy spine location must override its canonical default."""
+    _, ax = uplt.subplots()
+    twin = ax.twiny(xloc="bottom", ticks=2.5)
+    assert twin is not None

--- a/ultraplot/tests/test_alias_signatures.py
+++ b/ultraplot/tests/test_alias_signatures.py
@@ -2,6 +2,9 @@
 
 import inspect
 
+import numpy as np
+
+import ultraplot as uplt
 from ultraplot.axes.base import Axes
 from ultraplot.axes.cartesian import CartesianAxes
 from ultraplot.axes.geo import GeoAxes
@@ -136,3 +139,10 @@ def test_plotting_helper_signatures_contain_only_canonical_names() -> None:
     for function, legacy_names in cases:
         names = _parameter_names(inspect.signature(function))
         assert names.isdisjoint(legacy_names)
+
+
+def test_level_alias_is_consumed_before_native_plot_call() -> None:
+    """The legacy ``N`` spelling must not leak into Matplotlib artist kwargs."""
+    _, ax = uplt.subplots()
+    mesh = ax.heatmap(np.arange(4).reshape(2, 2), N=5)
+    assert mesh is not None

--- a/ultraplot/tests/test_alias_signatures.py
+++ b/ultraplot/tests/test_alias_signatures.py
@@ -26,8 +26,7 @@ def _parameter_names(signature):
         name
         for name, parameter in signature.parameters.items()
         if name != "self"
-        and parameter.kind
-        not in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD)
+        and parameter.kind not in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD)
     }
 
 

--- a/ultraplot/tests/test_alias_signatures.py
+++ b/ultraplot/tests/test_alias_signatures.py
@@ -51,10 +51,11 @@ def test_format_signatures_contain_only_canonical_names() -> None:
 
 def test_largest_migrated_signature_has_thirteen_fewer_parameters() -> None:
     names = _parameter_names(inspect.signature(UltraColorbar.add))
+    assert "length" in names
     assert len(names) == 47
     assert names.isdisjoint(
         {
-            "length",
+            "shrink",
             "title",
             "grid",
             "edges",
@@ -96,9 +97,10 @@ def test_layout_and_projection_signatures_contain_only_canonical_names() -> None
 
 def test_guide_signatures_contain_only_canonical_names() -> None:
     cases = (
-        (Axes.colorbar, {"location"}),
+        (Axes.colorbar, {"location", "shrink"}),
+        (Axes._add_colorbar, {"shrink"}),
         (Axes.legend, {"location"}),
-        (Figure.colorbar, {"location"}),
+        (Figure.colorbar, {"location", "shrink"}),
         (Figure.legend, {"location"}),
         (Axes._add_legend, {"ncol", "frame"}),
         (UltraLegend.add, {"location", "ncol", "frame"}),

--- a/ultraplot/tests/test_alias_signatures.py
+++ b/ultraplot/tests/test_alias_signatures.py
@@ -1,0 +1,139 @@
+"""Regression tests for canonical public call signatures."""
+
+import inspect
+
+from ultraplot.axes.base import Axes
+from ultraplot.axes.cartesian import CartesianAxes
+from ultraplot.axes.geo import GeoAxes
+from ultraplot.axes.plot import PlotAxes
+from ultraplot.axes.polar import PolarAxes
+from ultraplot.axes.taylor import TaylorAxes
+from ultraplot._subplots import SubplotManager
+from ultraplot.colorbar import UltraColorbar
+from ultraplot.constructor import Cycle, Proj
+from ultraplot.figure import Figure
+from ultraplot.gridspec import GridSpec
+from ultraplot.legend import UltraLegend
+from ultraplot.ultralayout import (
+    UltraLayoutSolver,
+    compute_ultra_positions,
+    get_grid_positions_ultra,
+)
+
+
+def _parameter_names(signature):
+    return {
+        name
+        for name, parameter in signature.parameters.items()
+        if name != "self"
+        and parameter.kind
+        not in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD)
+    }
+
+
+def test_format_signatures_contain_only_canonical_names() -> None:
+    aliases = {
+        Axes: {"ltitle", "ctitle", "rtitle"},
+        CartesianAxes: {"xloc", "xticks", "xticklabels", "xminorticks"},
+        GeoAxes: {"lonlines", "latlines", "lonlines_kw", "latlines_kw"},
+        PolarAxes: {"thetalines", "rlines", "thetalabels", "rlabels"},
+        TaylorAxes: {"corrlines", "corrticks"},
+    }
+    for cls, legacy_names in aliases.items():
+        names = _parameter_names(Axes._format_signatures[cls])
+        assert names.isdisjoint(legacy_names)
+
+    names = _parameter_names(Figure._format_signature)
+    assert names.isdisjoint({"figtitle", "llabels", "rowlabels", "collabels"})
+
+
+def test_largest_migrated_signature_has_thirteen_fewer_parameters() -> None:
+    names = _parameter_names(inspect.signature(UltraColorbar.add))
+    assert len(names) == 47
+    assert names.isdisjoint(
+        {
+            "length",
+            "title",
+            "grid",
+            "edges",
+            "locator",
+            "formatter",
+            "ticklabels",
+            "minorlocator",
+            "tickdir",
+            "labelloc",
+            "c",
+            "lw",
+            "frame",
+        }
+    )
+
+
+def test_figure_init_signature_contains_only_canonical_names() -> None:
+    names = _parameter_names(inspect.signature(inspect.unwrap(Figure.__init__)))
+    assert len(names) == 36
+    assert names.isdisjoint({"ref", "aspect", "axwidth", "axheight", "width", "height"})
+
+
+def test_layout_and_projection_signatures_contain_only_canonical_names() -> None:
+    cases = (
+        (SubplotManager.parse_proj, {"proj", "proj_kw"}),
+        (SubplotManager.add_subplots, {"proj", "proj_kw"}),
+        (GridSpec._update_params, {"wratios", "hratios"}),
+        (UltraLayoutSolver.__init__, {"wratios", "hratios"}),
+        (compute_ultra_positions, {"wratios", "hratios"}),
+        (get_grid_positions_ultra, {"wratios", "hratios"}),
+        (Cycle.__init__, {"N"}),
+        (Proj, {"lon_0", "lat_0"}),
+        (Axes._add_inset_axes, {"proj"}),
+    )
+    for function, legacy_names in cases:
+        names = _parameter_names(inspect.signature(function))
+        assert names.isdisjoint(legacy_names)
+
+
+def test_guide_signatures_contain_only_canonical_names() -> None:
+    cases = (
+        (Axes.colorbar, {"location"}),
+        (Axes.legend, {"location"}),
+        (Figure.colorbar, {"location"}),
+        (Figure.legend, {"location"}),
+        (Axes._add_legend, {"ncol", "frame"}),
+        (UltraLegend.add, {"location", "ncol", "frame"}),
+        (UltraLegend._resolve_inputs, {"ncol", "frame"}),
+    )
+    for function, legacy_names in cases:
+        signature = inspect.signature(inspect.unwrap(function))
+        assert _parameter_names(signature).isdisjoint(legacy_names)
+
+
+def test_plotting_helper_signatures_contain_only_canonical_names() -> None:
+    cases = (
+        (PlotAxes._add_auto_labels, {"fmt"}),
+        (PlotAxes._add_quadmesh_labels, {"c", "colors", "size"}),
+        (PlotAxes._add_collection_labels, {"c", "colors", "size"}),
+        (PlotAxes._add_contour_labels, {"c", "color", "size"}),
+        (
+            PlotAxes._add_error_bars,
+            {"bars", "barstd", "barpctile", "boxes", "boxstd", "boxpctile"},
+        ),
+        (
+            PlotAxes._add_error_shading,
+            {"shade", "shadestd", "shadepctile", "fade", "fadestd", "fadepctile"},
+        ),
+        (PlotAxes._parse_cmap, {"c", "color"}),
+        (PlotAxes._parse_level_vals, {"N"}),
+        (PlotAxes._apply_lines, {"stack"}),
+        (PlotAxes._apply_fill, {"stack"}),
+        (PlotAxes._apply_bar, {"stack"}),
+        (PlotAxes._apply_boxplot, {"mean", "showmeans", "filled"}),
+        (
+            PlotAxes._apply_violinplot,
+            {"mean", "median", "showmeans", "showmedians"},
+        ),
+        (PlotAxes._apply_hist, {"width", "stack", "filled"}),
+        (inspect.unwrap(PlotAxes.pie), {"labelpad"}),
+    )
+    for function, legacy_names in cases:
+        names = _parameter_names(inspect.signature(function))
+        assert names.isdisjoint(legacy_names)

--- a/ultraplot/tests/test_colorbar.py
+++ b/ultraplot/tests/test_colorbar.py
@@ -10,6 +10,40 @@ from matplotlib.transforms import Bbox
 import ultraplot as uplt
 
 
+@pytest.mark.parametrize("placement", ["outer", "inset", "inset_side", "figure"])
+def test_colorbar_shrink_alias_matches_length(placement):
+    bounds = []
+    for keyword in ("length", "shrink"):
+        fig, ax = uplt.subplots()
+        if placement == "inset_side":
+            ax = ax.inset_axes([0.2, 0.2, 0.5, 0.5])
+        target = fig if placement == "figure" else ax
+        loc = "upper right" if placement == "inset" else "right"
+        length = "4em" if placement == "inset" else 0.4
+        cb = target.colorbar("magma", loc=loc, **{keyword: length})
+        fig.canvas.draw()
+        bounds.append(cb.ax.get_position().bounds)
+    np.testing.assert_allclose(bounds[0], bounds[1])
+
+
+@pytest.mark.parametrize("keyword", ["length", "shrink"])
+def test_colorbar_length_with_explicit_cax(keyword):
+    fig, ax = uplt.subplots()
+    mappable = ax.imshow(np.arange(4).reshape(2, 2))
+    cax = fig.add_axes([0.85, 0.2, 0.05, 0.6])
+    cb = fig.colorbar(mappable, cax=cax, **{keyword: 0.4})
+    assert cb.ax is cax
+    fig.canvas.draw()
+
+
+@pytest.mark.parametrize("target", ["axes", "figure"])
+def test_colorbar_length_and_shrink_conflict(target):
+    fig, ax = uplt.subplots()
+    target = fig if target == "figure" else ax
+    with pytest.raises(TypeError, match="aliases.*length"):
+        target.colorbar("magma", length=0.4, shrink=0.5)
+
+
 def test_colorbar_defers_external_mode():
     """
     External mode should defer on-the-fly colorbar creation until explicitly requested.

--- a/ultraplot/tests/test_docstring_helpers.py
+++ b/ultraplot/tests/test_docstring_helpers.py
@@ -5,33 +5,29 @@ from ultraplot.internals import docstring
 
 
 def test_style_snippets_lead_with_canonical_name() -> None:
-    # The shared style fields should lead with the canonical parameter name and
-    # relegate synonyms to a trailing "Aliases:" note, rather than opening the
-    # numpydoc field with a pile of alias names.
+    # Shared style fields only show canonical names. Compatibility spellings are
+    # documented centrally in docs/aliases.rst.
     line = docstring._snippet_manager["artist.line"]
     assert line.lstrip().startswith("linewidth : unit-spec")
-    assert "Aliases: ``lw``, ``linewidths``." in line
     assert "The color of the line(s)" in line
-    assert "Aliases: ``c``, ``colors``." in line
+    assert "Aliases:" not in line
     # The old alias-pile header must be gone.
     assert "lw, linewidth, linewidths :" not in line
 
 
-def test_collection_snippets_lead_with_registry_canonical_names() -> None:
+def test_collection_snippets_use_only_registry_canonical_names() -> None:
     for name in ("artist.collection_pcolor", "artist.collection_contour"):
         snippet = docstring._snippet_manager[name]
         assert snippet.lstrip().startswith("linewidths : unit-spec")
         assert "\nlinestyles : str" in snippet
         assert "\nedgecolors : color-spec" in snippet
-        assert "Aliases: ``lw``, ``linewidth``." in snippet
-        assert "Aliases: ``ls``, ``linestyle``." in snippet
-        assert "Aliases: ``ec``, ``edgecolor``." in snippet
+        assert "Aliases:" not in snippet
 
 
 def test_contour_alpha_alias_typo_fixed() -> None:
     # Previously the contour snippet listed ``a, alpha, alpha`` (duplicate typo).
     contour = docstring._snippet_manager["artist.collection_contour"]
-    assert "``a``, ``alphas``." in contour
+    assert "Aliases:" not in contour
     assert "a, alpha, alpha" not in contour
 
 
@@ -47,17 +43,15 @@ def test_method_docstring_fully_substituted() -> None:
     # leftover unfilled snippet markers.
     doc = uplt.axes.PlotAxes.line.__doc__ or ""
     assert "linewidth : unit-spec" in doc
-    assert "Aliases: ``lw``" in doc
+    assert "Aliases:" not in doc
     assert "%(artist" not in doc
 
 
-def test_geo_format_folds_alias_entries() -> None:
-    # The geo format docstring folded its standalone "Aliases for ..." blocks
-    # into trailing notes on the canonical locator entries.
+def test_geo_format_uses_only_canonical_entries() -> None:
+    # Compatibility spellings live in the generated alias reference instead of
+    # competing with canonical parameters in each function's primary docs.
     geo = docstring._snippet_manager["geo.format"]
     assert "Aliases for" not in geo
     assert "lonlocator, latlocator : locator-spec" in geo
-    assert "Aliases: ``lonlines`` and ``latlines``, respectively." in geo
-    assert (
-        "Aliases: ``lonminorlines_kw`` and ``latminorlines_kw``, respectively." in geo
-    )
+    assert "lonlines" not in geo
+    assert "latlines" not in geo

--- a/ultraplot/tests/test_figure.py
+++ b/ultraplot/tests/test_figure.py
@@ -943,13 +943,9 @@ def test_figure_keyword_aliases() -> None:
     uplt.close("all")
 
 
-def test_figure_alias_conflict_warns() -> None:
-    with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
-        fig = uplt.figure(refnum=1, ref=5)
-    assert fig._refnum == 1  # canonical wins
-    assert any("conflicting" in str(w.message).lower() for w in record)
-    uplt.close(fig)
+def test_figure_alias_conflict_raises() -> None:
+    with pytest.raises(TypeError, match="aliases"):
+        uplt.figure(refnum=1, ref=5)
 
 
 def test_clear_drops_subplot_state():

--- a/ultraplot/tests/test_kwargs_helpers.py
+++ b/ultraplot/tests/test_kwargs_helpers.py
@@ -2,7 +2,10 @@
 
 import warnings
 
+import pytest
+
 from ultraplot import internals
+from ultraplot.internals import guides
 from ultraplot.internals import kwargs as ikwargs
 
 
@@ -12,6 +15,11 @@ def test_kwargs_helpers_reexported_from_package() -> None:
     for name in (
         "_not_none",
         "_alias_kwargs",
+        "_alias_registry",
+        "_canonicalize_kwargs",
+        "_format_alias_reference",
+        "_figure_format_alias_scopes",
+        "_format_alias_scopes",
         "_alias_maps",
         "_get_aliases",
         "_kwargs_to_args",
@@ -56,25 +64,82 @@ def test_alias_kwargs_none_synonym_defers_to_default() -> None:
     assert func(width=None) == 42
 
 
-def test_alias_kwargs_conflict_keeps_canonical_and_warns() -> None:
+def test_alias_kwargs_conflict_raises() -> None:
     @ikwargs._alias_kwargs(figwidth=("width",))
     def func(*, figwidth=None):
         return figwidth
 
-    with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
-        value = func(figwidth=1, width=2)
-    assert value == 1  # canonical wins, matching _not_none precedence
-    assert any("conflicting" in str(w.message).lower() for w in record)
+    with pytest.raises(TypeError, match="aliases"):
+        func(figwidth=1, width=2)
 
 
-def test_alias_kwargs_multiple_synonyms_first_wins() -> None:
+def test_alias_kwargs_multiple_synonyms_raise() -> None:
     @ikwargs._alias_kwargs(saturation=("s", "c", "chroma"))
     def func(*, saturation=None):
         return saturation
 
     assert func(chroma=0.5) == 0.5
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter("always")
-        # Two synonyms: the first one encountered in declaration order wins.
-        assert func(s=0.1, chroma=0.9) == 0.1
+    with pytest.raises(TypeError, match="aliases"):
+        func(s=0.1, chroma=0.9)
+
+
+def test_registry_scope_translates_without_mutating_input() -> None:
+    kwargs = {"xticks": [1, 2], "color": "red"}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = ikwargs._canonicalize_kwargs("cartesian.format", kwargs)
+    assert kwargs == {"xticks": [1, 2], "color": "red"}
+    assert result == {"xlocator": [1, 2], "color": "red"}
+
+
+def test_registry_translates_explicit_format_keys() -> None:
+    kwargs = {"xticks": [1, 2], "_explicit_format_keys": {"xticks"}}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = ikwargs._canonicalize_kwargs("cartesian.format", kwargs)
+    assert result["_explicit_format_keys"] == {"xlocator"}
+
+
+def test_ambiguous_alias_uses_call_context() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        axes = ikwargs._canonicalize_kwargs(ikwargs._format_alias_scopes, {"rlabels": 5})
+        figure = ikwargs._canonicalize_kwargs(
+            ikwargs._figure_format_alias_scopes, {"rlabels": ["right"]}
+        )
+    assert axes == {"rformatter": 5}
+    assert figure == {"rightlabels": ["right"]}
+
+
+def test_alias_kwargs_combines_registered_scopes() -> None:
+    @ikwargs._alias_kwargs(("plot.statistics", "plot.boxplot"))
+    def func(*, means=None, medians=None, fill=None):
+        return means, medians, fill
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert func(showmeans=True) == (True, None, None)
+        assert func(filled=True) == (None, None, True)
+    assert func._ultraplot_alias_scopes == ("plot.statistics", "plot.boxplot")
+    assert func._ultraplot_aliases["fill"] == ("filled",)
+
+
+def test_alias_kwargs_rejects_inline_aliases_with_registered_scopes() -> None:
+    with pytest.raises(TypeError, match="Inline aliases"):
+        ikwargs._alias_kwargs(("plot.statistics", "plot.boxplot"), old="new")
+
+
+def test_alias_reference_is_generated_from_registry() -> None:
+    reference = ikwargs._format_alias_reference()
+    assert "Function keyword aliases" in reference
+    assert "Artist property aliases" in reference
+    assert "Dotless rc aliases" in reference
+    assert "cartesian.format" in reference
+    assert "xticks" in reference
+    assert "xlocator" in reference
+
+
+def test_guide_defaults_do_not_duplicate_accepted_aliases() -> None:
+    kwargs = {"length": 0.5, "minorlocator": "minor"}
+    guides._update_kw(kwargs, overwrite=False, shrink=1.0, minorticks=True)
+    assert kwargs == {"length": 0.5, "minorlocator": "minor"}

--- a/ultraplot/tests/test_kwargs_helpers.py
+++ b/ultraplot/tests/test_kwargs_helpers.py
@@ -103,7 +103,9 @@ def test_registry_translates_explicit_format_keys() -> None:
 def test_ambiguous_alias_uses_call_context() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        axes = ikwargs._canonicalize_kwargs(ikwargs._format_alias_scopes, {"rlabels": 5})
+        axes = ikwargs._canonicalize_kwargs(
+            ikwargs._format_alias_scopes, {"rlabels": 5}
+        )
         figure = ikwargs._canonicalize_kwargs(
             ikwargs._figure_format_alias_scopes, {"rlabels": ["right"]}
         )

--- a/ultraplot/tests/test_subplot_manager.py
+++ b/ultraplot/tests/test_subplot_manager.py
@@ -397,18 +397,13 @@ def test_ui_introspects_manager_not_figure_delegator():
     silently routes ``proj`` to the figure, which then raises from ``Figure.set()``.
     """
     proj_params = set(inspect.signature(SubplotManager.parse_proj).parameters)
-    assert {
-        "proj",
-        "projection",
-        "proj_kw",
-        "projection_kw",
-        "backend",
-        "basemap",
-    } <= proj_params
+    assert {"projection", "projection_kw", "backend", "basemap"} <= proj_params
+    assert {"proj", "proj_kw"}.isdisjoint(proj_params)
 
     subplots_params = set(inspect.signature(SubplotManager.add_subplots).parameters)
     assert {"array", "nrows", "ncols", "order"} <= subplots_params
-    assert {"proj", "projection", "proj_kw", "projection_kw"} <= subplots_params
+    assert {"projection", "projection_kw"} <= subplots_params
+    assert {"proj", "proj_kw"}.isdisjoint(subplots_params)
 
 
 def test_figure_delegator_signature_is_not_load_bearing():

--- a/ultraplot/ui.py
+++ b/ultraplot/ui.py
@@ -10,6 +10,9 @@ from . import figure as pfigure
 from . import gridspec as pgridspec
 from ._subplots import SubplotManager
 from .internals import (
+    _canonicalize_kwargs,
+    _figure_format_alias_scopes,
+    _format_alias_scopes,
     _not_none,
     _pop_params,
     _pop_props,
@@ -181,6 +184,9 @@ def subplot(**kwargs):
     matplotlib.figure.Figure
     """
     _parse_figsize(kwargs)
+    kwargs = _canonicalize_kwargs("subplot", kwargs)
+    kwargs = _canonicalize_kwargs("gridspec", kwargs)
+    kwargs = _canonicalize_kwargs(_format_alias_scopes, kwargs)
     rc_kw, rc_mode = _pop_rc(kwargs)
     kwsub = _pop_props(kwargs, "patch")  # e.g. 'color'
     # NOTE: Introspect the manager, which owns these parameters, rather than the
@@ -229,6 +235,9 @@ def subplots(*args, **kwargs):
     matplotlib.figure.Figure
     """
     _parse_figsize(kwargs)
+    kwargs = _canonicalize_kwargs("subplot", kwargs)
+    kwargs = _canonicalize_kwargs("gridspec", kwargs)
+    kwargs = _canonicalize_kwargs(_figure_format_alias_scopes, kwargs)
     rc_kw, rc_mode = _pop_rc(kwargs)
     kwsubs = _pop_props(kwargs, "patch")  # e.g. 'color'
     kwsubs.update(_pop_params(kwargs, SubplotManager.add_subplots))

--- a/ultraplot/ultralayout.py
+++ b/ultraplot/ultralayout.py
@@ -11,6 +11,8 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
+from .internals import _alias_kwargs
+
 try:
     from kiwisolver import Solver, Variable
 
@@ -147,6 +149,7 @@ class UltraLayoutSolver:
     a superior layout experience for complex subplot arrangements.
     """
 
+    @_alias_kwargs("gridspec")
     def __init__(
         self,
         array: np.ndarray,
@@ -158,8 +161,8 @@ class UltraLayoutSolver:
         right: float = 0.125,
         top: float = 0.125,
         bottom: float = 0.125,
-        wratios: Optional[List[float]] = None,
-        hratios: Optional[List[float]] = None,
+        width_ratios: Optional[List[float]] = None,
+        height_ratios: Optional[List[float]] = None,
         wpanels: Optional[List[bool]] = None,
         hpanels: Optional[List[bool]] = None,
     ):
@@ -176,7 +179,7 @@ class UltraLayoutSolver:
             Spacing between columns and rows in inches
         left, right, top, bottom : float
             Margins in inches
-        wratios, hratios : list of float, optional
+        width_ratios, height_ratios : list of float, optional
             Width and height ratios for columns and rows
         wpanels, hpanels : list of bool, optional
             Flags indicating panel columns or rows with fixed widths/heights.
@@ -211,15 +214,15 @@ class UltraLayoutSolver:
             self.hspace = list(hspace)
 
         # Set up ratios
-        if wratios is None:
+        if width_ratios is None:
             self.wratios = [1.0] * self.ncols
         else:
-            self.wratios = list(wratios)
+            self.wratios = list(width_ratios)
 
-        if hratios is None:
+        if height_ratios is None:
             self.hratios = [1.0] * self.nrows
         else:
-            self.hratios = list(hratios)
+            self.hratios = list(height_ratios)
 
         # Set up panel flags (True for fixed-width panel slots).
         if wpanels is None:
@@ -511,6 +514,7 @@ class ColorbarLayoutSolver:
         }
 
 
+@_alias_kwargs("gridspec")
 def compute_ultra_positions(
     array: np.ndarray,
     figwidth: float = 10.0,
@@ -521,8 +525,8 @@ def compute_ultra_positions(
     right: float = 0.125,
     top: float = 0.125,
     bottom: float = 0.125,
-    wratios: Optional[List[float]] = None,
-    hratios: Optional[List[float]] = None,
+    width_ratios: Optional[List[float]] = None,
+    height_ratios: Optional[List[float]] = None,
     wpanels: Optional[List[bool]] = None,
     hpanels: Optional[List[bool]] = None,
 ) -> Dict[int, Tuple[float, float, float, float]]:
@@ -539,7 +543,7 @@ def compute_ultra_positions(
         Spacing between columns and rows in inches
     left, right, top, bottom : float
         Margins in inches
-    wratios, hratios : list of float, optional
+    width_ratios, height_ratios : list of float, optional
         Width and height ratios for columns and rows
     wpanels, hpanels : list of bool, optional
         Flags indicating panel columns or rows with fixed widths/heights.
@@ -567,14 +571,15 @@ def compute_ultra_positions(
         right,
         top,
         bottom,
-        wratios,
-        hratios,
+        width_ratios,
+        height_ratios,
         wpanels,
         hpanels,
     )
     return solver.solve()
 
 
+@_alias_kwargs("gridspec")
 def get_grid_positions_ultra(
     array: np.ndarray,
     figwidth: float,
@@ -585,8 +590,8 @@ def get_grid_positions_ultra(
     right: float = 0.125,
     top: float = 0.125,
     bottom: float = 0.125,
-    wratios: Optional[List[float]] = None,
-    hratios: Optional[List[float]] = None,
+    width_ratios: Optional[List[float]] = None,
+    height_ratios: Optional[List[float]] = None,
     wpanels: Optional[List[bool]] = None,
     hpanels: Optional[List[bool]] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -606,7 +611,7 @@ def get_grid_positions_ultra(
         Spacing between columns and rows in inches
     left, right, top, bottom : float
         Margins in inches
-    wratios, hratios : list of float, optional
+    width_ratios, height_ratios : list of float, optional
         Width and height ratios for columns and rows
     wpanels, hpanels : list of bool, optional
         Flags indicating panel columns or rows with fixed widths/heights.
@@ -626,8 +631,8 @@ def get_grid_positions_ultra(
         right,
         top,
         bottom,
-        wratios,
-        hratios,
+        width_ratios,
+        height_ratios,
         wpanels,
         hpanels,
     )


### PR DESCRIPTION
Continuation of our discussion in #808 

UltraPlot has many (many many) aliases. Some love them, some hate them. This PR proposes to move them away from function signatures, to remain with a smaller set, and pushing the rest into a specific decorator. This allows for a smaller function description in stuff like pylance. 

I added a small applet in the docs that shows all the aliases, and shows where they can be added etc. Open for feedback!