### PR TITLE
Modernize pyproject.toml configuration and formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=64",
-    "setuptools_scm[toml]>=8",
-    "wheel",
+    "setuptools>=80",
+    "setuptools-scm>=8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -19,9 +18,8 @@ maintainers = [
 description = "A succinct matplotlib wrapper for making beautiful, publication-quality graphics."
 readme = "README.rst"
 requires-python = ">=3.10,<3.15"
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
@@ -50,16 +48,18 @@ packages = {find = {exclude=["docs*", "baseline*", "logo*"]}}
 include-package-data = true
 
 [tool.setuptools_scm]
-write_to = "ultraplot/_version.py"
-write_to_template = "__version__ = '{version}'\n"
+version_file = "ultraplot/_version.py"
+version_file_template = "__version__ = '{version}'\n"
 
 [tool.ultraplot.core_versions]
 python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 matplotlib = ["3.9", "3.10"]
 
 
-[tool.ruff]
-ignore = ["I001", "I002", "I003", "I004"]
+[tool.ruff.lint]
+ignore = [
+    "I",  # isort (import order)
+]
 
 [tool.basedpyright]
 exclude = ["**/*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,33 @@
-[build-system]
-requires = [
-    "setuptools>=80",
-    "setuptools-scm>=8",
-]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "ultraplot"
-authors = [
-    {name = "Casper van Elteren", email = "caspervanelteren@gmail.com"},
-    {name = "Luke Davis", email = "lukelbd@gmail.com"},
-]
-maintainers = [
-    {name = "Casper van Elteren", email = "caspervanelteren@gmail.com"},
-    {name = "Matthew R. Becker", email = "becker.mr@gmail.com"},
-]
 description = "A succinct matplotlib wrapper for making beautiful, publication-quality graphics."
 readme = "README.rst"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
-classifiers = [
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Framework :: Matplotlib",
+authors = [
+  { name = "Casper van Elteren", email = "caspervanelteren@gmail.com" },
+  { name = "Luke Davis", email = "lukelbd@gmail.com" },
 ]
-dependencies= [
-    "numpy>=1.26.0",
-    "matplotlib>=3.9,<3.11",
-    "pycirclize>=1.10.1",
-    "typing-extensions; python_version < '3.12'",
+maintainers = [
+  { name = "Casper van Elteren", email = "caspervanelteren@gmail.com" },
+  { name = "Matthew R. Becker", email = "becker.mr@gmail.com" },
+]
+classifiers = [
+  "Framework :: Matplotlib",
+  "Intended Audience :: Science/Research",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = [
+  "matplotlib>=3.9,<3.11",
+  "numpy>=1.26.0",
+  "pycirclize>=1.10.1",
+  "typing-extensions; python_version < '3.12'",
 ]
 dynamic = ["version"]
 
@@ -43,8 +36,56 @@ dynamic = ["version"]
 "Issue Tracker" = "https://github.com/ultraplot/ultraplot/issues"
 "Source Code" = "https://github.com/ultraplot/ultraplot"
 
+[project.optional-dependencies]
+docs = [
+  "jupyter",
+  "jupytext",
+  "lxml-html-clean",
+  "markdown",
+  "mpltern",
+  # Floors below are the versions that work with Sphinx 9, which removed
+  # sphinx.ext.autosummary.get_documenter. Without them pip is free to pair a
+  # current Sphinx with an extension that cannot import it, and the build
+  # dies with "Extension error (sphinx_automodapi.automodsumm)".
+  "nbsphinx>=0.9.8",  # 0.9.7 declares sphinx<8.2
+  "sphinx",
+  "sphinx-autoapi",
+  "sphinx-automodapi>=0.22",  # 0.19 imports the removed get_documenter
+  "sphinx-copybutton",
+  "sphinx-design>=0.7",  # 0.6.1 declares sphinx<9
+  "sphinx-gallery",
+  "shibuya",
+  "sphinx-sitemap",
+  "typing-extensions"
+]
+stats = [
+  "scipy",
+]
+
+[build-system]
+requires = [
+  "setuptools>=80",
+  "setuptools-scm>=8",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.basedpyright]
+exclude = ["**/*.ipynb"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+  "ignore:'parseString' deprecated - use 'parse_string':DeprecationWarning:matplotlib._fontconfig_pattern",
+  "ignore:'resetCache' deprecated - use 'reset_cache':DeprecationWarning:matplotlib._fontconfig_pattern",
+]
+mpl-default-style = { axes.prop_cycle = "cycler('color', ['#4c72b0ff', '#55a868ff', '#c44e52ff', '#8172b2ff', '#ccb974ff', '#64b5cdff'])" }
+
+[tool.ruff.lint]
+ignore = [
+  "I",  # isort (import order)
+]
+
 [tool.setuptools]
-packages = {find = {exclude=["docs*", "baseline*", "logo*"]}}
+packages = { find = { exclude = ["docs*", "baseline*", "logo*"] } }
 include-package-data = true
 
 [tool.setuptools_scm]
@@ -54,44 +95,3 @@ version_file_template = "__version__ = '{version}'\n"
 [tool.ultraplot.core_versions]
 python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 matplotlib = ["3.9", "3.10"]
-
-
-[tool.ruff.lint]
-ignore = [
-    "I",  # isort (import order)
-]
-
-[tool.basedpyright]
-exclude = ["**/*.ipynb"]
-
-[tool.pytest.ini_options]
-filterwarnings = [
-    "ignore:'parseString' deprecated - use 'parse_string':DeprecationWarning:matplotlib._fontconfig_pattern",
-    "ignore:'resetCache' deprecated - use 'reset_cache':DeprecationWarning:matplotlib._fontconfig_pattern",
-]
-mpl-default-style = { axes.prop_cycle = "cycler('color', ['#4c72b0ff', '#55a868ff', '#c44e52ff', '#8172b2ff', '#ccb974ff', '#64b5cdff'])" }
-[project.optional-dependencies]
-docs = [
-    "jupyter",
-    "jupytext",
-    "lxml-html-clean",
-    "markdown",
-    "mpltern",
-    # Floors below are the versions that work with Sphinx 9, which removed
-    # sphinx.ext.autosummary.get_documenter. Without them pip is free to pair a
-    # current Sphinx with an extension that cannot import it, and the build
-    # dies with "Extension error (sphinx_automodapi.automodsumm)".
-    "nbsphinx>=0.9.8",          # 0.9.7 declares sphinx<8.2
-    "sphinx",
-    "sphinx-autoapi",
-    "sphinx-automodapi>=0.22",  # 0.19 imports the removed get_documenter
-    "sphinx-copybutton",
-    "sphinx-design>=0.7",       # 0.6.1 declares sphinx<9
-    "sphinx-gallery",
-    "shibuya",
-    "sphinx-sitemap",
-    "typing-extensions"
-]
-stats = [
-    "scipy",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 dependencies = [
   "matplotlib>=3.9,<3.11",
   "numpy>=1.26.0",
-  "pycirclize>=1.10.1",
   "typing-extensions; python_version < '3.12'",
 ]
 dynamic = ["version"]
@@ -38,6 +37,9 @@ dynamic = ["version"]
 "Source Code" = "https://github.com/ultraplot/ultraplot"
 
 [project.optional-dependencies]
+circos = [
+  "pycirclize>=1.10.1",
+]
 docs = [
   "jupyter",
   "jupytext",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ description = "A succinct matplotlib wrapper for making beautiful, publication-q
 readme = "README.rst"
 requires-python = ">=3.10,<3.15"
 license = "MIT"
+license-files = ["LICENSE"]
 authors = [
   { name = "Casper van Elteren", email = "caspervanelteren@gmail.com" },
   { name = "Luke Davis", email = "lukelbd@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dynamic = ["version"]
 "Source Code" = "https://github.com/ultraplot/ultraplot"
 
 [project.optional-dependencies]
+all = [
+    "ultraplot[circos,docs,stats]",
+]
 circos = [
   "pycirclize>=1.10.1",
 ]


### PR DESCRIPTION
Update deprecated lint and packaging configuration in `pyproject.toml`.

- Move Ruff settings to `[tool.ruff.lint]` and ignore the isort group with `"I"`.
- Replace setuptools_scm's `write_to` and `write_to_template` with `version_file` and `version_file_template`, preserving the generated version format.
- Use the SPDX license expression `"MIT"` and remove the deprecated license classifier.
- Require `setuptools>=80` and remove the redundant `[toml]` extra and `wheel` build dependency.
- Format `pyproject.toml` using [Tombi](https://github.com/tombi-toml/tombi), a TOML formatter.

Validation:
- Built an sdist and a wheel from that sdist.
- Passed `twine check --strict` for both artifacts.
- Verified wheel version and license metadata.
- Verified Ruff configuration loading and `git diff --check`.
