### PR TITLE
Fix:Reduce bloat

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -10,13 +10,13 @@ with ``pip`` or ``conda`` as follows:
    pip install ultraplot
    conda install -c conda-forge ultraplot
 
-The default install includes optional features (for example, pyCirclize-based plots).
-For a minimal install, use ``--no-deps`` and install the core requirements:
+pyCirclize-based plots require the optional ``circos`` extra:
 
 .. code-block:: bash
 
-   pip install ultraplot --no-deps
-   pip install -r requirements-minimal.txt
+   pip install 'ultraplot[circos]'
+
+The ``docs`` extra also includes pyCirclize for building the documentation.
 
 Likewise, an existing installation of ultraplot can be upgraded to the latest version with:
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -18,6 +18,12 @@ pyCirclize-based plots require the optional ``circos`` extra:
 
 The ``docs`` extra also includes pyCirclize for building the documentation.
 
+To install all optional dependency groups (``circos``, ``docs``, and ``stats``):
+
+.. code-block:: bash
+
+   pip install 'ultraplot[all]'
+
 Likewise, an existing installation of ultraplot can be upgraded to the latest version with:
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -104,13 +104,13 @@ UltraPlot is published on `PyPi <https://pypi.org/project/ultraplot/>`__ and
    pip install ultraplot
    conda install -c conda-forge ultraplot
 
-The default install includes optional features (for example, pyCirclize-based plots).
-For a minimal install, use ``--no-deps`` and install the core requirements:
+pyCirclize-based plots require the optional ``circos`` extra:
 
 .. code-block:: bash
 
-   pip install ultraplot --no-deps
-   pip install -r requirements-minimal.txt
+   pip install 'ultraplot[circos]'
+
+The ``docs`` extra also includes pyCirclize for building the documentation.
 
 Likewise, an existing installation of UltraPlot can be upgraded
 to the latest version with:

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,12 @@ pyCirclize-based plots require the optional ``circos`` extra:
 
 The ``docs`` extra also includes pyCirclize for building the documentation.
 
+To install all optional dependency groups (``circos``, ``docs``, and ``stats``):
+
+.. code-block:: bash
+
+   pip install 'ultraplot[all]'
+
 Likewise, an existing installation of UltraPlot can be upgraded
 to the latest version with:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 dependencies= [
     "numpy>=1.26.0",
     "matplotlib>=3.9,<3.11",
-    "pycirclize>=1.10.1",
     "typing-extensions; python_version < '3.12'",
 ]
 dynamic = ["version"]
@@ -71,12 +70,16 @@ filterwarnings = [
 ]
 mpl-default-style = { axes.prop_cycle = "cycler('color', ['#4c72b0ff', '#55a868ff', '#c44e52ff', '#8172b2ff', '#ccb974ff', '#64b5cdff'])" }
 [project.optional-dependencies]
+circos = [
+    "pycirclize>=1.10.1",
+]
 docs = [
     "jupyter",
     "jupytext",
     "lxml-html-clean",
     "markdown",
     "mpltern",
+    "pycirclize>=1.10.1",
     # Floors below are the versions that work with Sphinx 9, which removed
     # sphinx.ext.autosummary.get_documenter. Without them pip is free to pair a
     # current Sphinx with an extension that cannot import it, and the build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ filterwarnings = [
 ]
 mpl-default-style = { axes.prop_cycle = "cycler('color', ['#4c72b0ff', '#55a868ff', '#c44e52ff', '#8172b2ff', '#ccb974ff', '#64b5cdff'])" }
 [project.optional-dependencies]
+all = [
+    "ultraplot[circos,docs,stats]",
+]
 circos = [
     "pycirclize>=1.10.1",
 ]

--- a/ultraplot/axes/plot_types/circlize.py
+++ b/ultraplot/axes/plot_types/circlize.py
@@ -14,6 +14,7 @@ from matplotlib.projections.polar import PolarAxes as MplPolarAxes
 
 from ... import constructor
 from ...config import rc
+from ...internals import warnings
 
 #: Settings ``pycirclize.config`` writes into the global rcParams the moment it
 #: is imported. Importing a library must not change how unrelated figures are
@@ -36,6 +37,9 @@ def _import_pycirclize():
     restore = {key: mpl.rcParams[key] for key in _PYCIRCLIZE_RC_LEAKS}
     try:
         return _import_pycirclize_unguarded()
+    except ImportError as exc:
+        warnings._warn_ultraplot(str(exc))
+        raise
     finally:
         for key, value in restore.items():
             if mpl.rcParams[key] != value:

--- a/ultraplot/tests/test_circlize_integration.py
+++ b/ultraplot/tests/test_circlize_integration.py
@@ -178,7 +178,9 @@ def test_import_pycirclize_error_message(monkeypatch):
     monkeypatch.setattr(Path, "is_dir", lambda self: False)
     sys.modules.pop("pycirclize", None)
     with pytest.warns(UserWarning, match=r"pip install 'ultraplot\[circos\]'"):
-        with pytest.raises(ImportError, match="pycirclize is required for circos plots"):
+        with pytest.raises(
+            ImportError, match="pycirclize is required for circos plots"
+        ):
             circlize_mod._import_pycirclize()
 
 

--- a/ultraplot/tests/test_circlize_integration.py
+++ b/ultraplot/tests/test_circlize_integration.py
@@ -177,8 +177,9 @@ def test_import_pycirclize_error_message(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     monkeypatch.setattr(Path, "is_dir", lambda self: False)
     sys.modules.pop("pycirclize", None)
-    with pytest.raises(ImportError, match="pycirclize is required for circos plots"):
-        circlize_mod._import_pycirclize()
+    with pytest.warns(UserWarning, match=r"pip install 'ultraplot\[circos\]'"):
+        with pytest.raises(ImportError, match="pycirclize is required for circos plots"):
+            circlize_mod._import_pycirclize()
 
 
 def test_resolve_defaults_with_existing_objects(fake_pycirclize):


### PR DESCRIPTION
This makes pycirclize optional for users that don't need it. It add the relevant options to pyproject for installing it if the user wants the full experience with all deps.