### PR TITLE
Add tombi formatting hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,6 @@ repos:
     rev: v1.5.2
     hooks:
       - id: tombi-format
+        args: ["--offline"]
+      - id: tombi-lint
+        args: ["--offline"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
     rev: 26.5.1
     hooks:
       - id: black
+
+  - repo: https://github.com/tombi-toml/tombi-pre-commit
+    rev: v1.5.2
+    hooks:
+      - id: tombi-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 all = [
-    "ultraplot[circos,docs,stats]",
+  "ultraplot[circos,docs,stats]",
 ]
 circos = [
   "pycirclize>=1.10.1",


### PR DESCRIPTION
Add the `tombi-format` pre-commit hook, pinned to v1.5.2, to format TOML files automatically. Align the indentation of the `all` optional dependency in `pyproject.toml` with the surrounding entries.

Validation: `pre-commit validate-config .pre-commit-config.yaml` and `git diff --check origin/main...HEAD` passed.
